### PR TITLE
fix(parity): correct P0 API endpoint and behavior bugs

### DIFF
--- a/src/services/CubeService.ts
+++ b/src/services/CubeService.ts
@@ -212,26 +212,28 @@ export class CubeService extends ObjectService {
     }
 
     public async getStorageDimensionOrder(cubeName: string): Promise<string[]> {
-        /** Get storage dimension order for a cube
+        /** Get the storage dimension order of a cube
          *
          * :param cube_name: name of the cube
-         * :return: ordered list of dimension names
+         * :return: List of dimension names in storage order
          */
-        const url = formatUrl("/Cubes('{}')/Dimensions?$select=Name", cubeName);
+        const url = formatUrl("/Cubes('{}')/tm1.DimensionsStorageOrder()?$select=Name", cubeName);
         const response = await this.rest.get(url);
         return response.data.value.map((dim: any) => dim.Name);
     }
 
-    public async updateStorageDimensionOrder(cubeName: string, dimensionNames: string[]): Promise<AxiosResponse> {
-        /** Update storage dimension order for a cube
+    public async updateStorageDimensionOrder(cubeName: string, dimensionNames: string[]): Promise<number> {
+        /** Update the storage dimension order of a cube
          *
          * :param cube_name: name of the cube
          * :param dimension_names: ordered list of dimension names
-         * :return: response
+         * :return: Float - percent change in memory usage
          */
-        const url = formatUrl("/Cubes('{}')/tm1.UpdateStorageOrder", cubeName);
-        const body = { Dimensions: dimensionNames };
-        return await this.rest.post(url, body);
+        const url = formatUrl("/Cubes('{}')/tm1.ReorderDimensions", cubeName);
+        const payload: any = {};
+        payload['Dimensions@odata.bind'] = dimensionNames.map(d => formatUrl("Dimensions('{}')", d));
+        const response = await this.rest.post(url, JSON.stringify(payload));
+        return response.data.value;
     }
 
     public async getRandomIntersection(cubeName: string, uniqueNames: boolean = false): Promise<string[]> {

--- a/src/services/FileService.ts
+++ b/src/services/FileService.ts
@@ -51,6 +51,20 @@ export class FileService extends ObjectService {
             await this.ensureFolderHierarchy(segments.slice(0, -1));
         }
 
+        // Create document metadata entry before uploading content
+        const documentName = segments[segments.length - 1];
+        const contentsUrl = this.constructContentUrl(
+            segments.length > 1 ? segments.slice(0, -1) : [],
+            false,
+            'Contents'
+        );
+        const metadataBody = {
+            '@odata.type': '#ibm.tm1.api.v1.Document',
+            'ID': documentName,
+            'Name': documentName
+        };
+        await this.rest.post(contentsUrl, JSON.stringify(metadataBody));
+
         return await this.uploadFileContent(
             segments,
             this.toBuffer(content),

--- a/src/services/HierarchyService.ts
+++ b/src/services/HierarchyService.ts
@@ -27,14 +27,15 @@ export class HierarchyService extends ObjectService {
     }
 
     public async update(hierarchy: Hierarchy, keepExistingAttributes: boolean = false): Promise<void> {
-        // Update elements first
-        await this.updateElements(hierarchy);
-        
-        // Update element attributes
+        /** Update a hierarchy. Two step process:
+         * 1. PATCH Hierarchy (elements, edges, structure)
+         * 2. Update Element Attributes
+         */
+        const url = this.formatUrl("/Dimensions('{}')/Hierarchies('{}')", hierarchy.dimensionName, hierarchy.name);
+        const hierarchyBody = hierarchy.bodyAsDict;
+        await this.rest.patch(url, JSON.stringify(hierarchyBody));
+
         await this.updateElementAttributes(hierarchy, keepExistingAttributes);
-        
-        // Update edges
-        await this.updateEdges(hierarchy);
     }
 
     public async delete(dimensionName: string, hierarchyName: string): Promise<AxiosResponse> {
@@ -64,37 +65,6 @@ export class HierarchyService extends ObjectService {
         const url = this.formatUrl("/Dimensions('{}')/Hierarchies?$expand=*", dimensionName);
         const response = await this.rest.get(url);
         return response.data.value.map((h: any) => Hierarchy.fromDict(h, dimensionName));
-    }
-
-    public async updateElements(hierarchy: Hierarchy): Promise<void> {
-        // Remove all existing elements first
-        await this.removeAllElements(hierarchy.dimensionName, hierarchy.name);
-        
-        // Add all elements from hierarchy
-        for (const element of hierarchy.elements) {
-            const url = this.formatUrl("/Dimensions('{}')/Hierarchies('{}')/Elements", 
-                hierarchy.dimensionName, hierarchy.name);
-            await this.rest.post(url, element.body);
-        }
-    }
-
-    public async updateEdges(hierarchy: Hierarchy): Promise<void> {
-        // Remove all existing edges
-        await this.removeAllEdges(hierarchy.dimensionName, hierarchy.name);
-        
-        // Add all edges from hierarchy
-        for (const [key, weight] of hierarchy.edges) {
-            const [parentName, componentName] = key.split(':');
-            const edgeBody = {
-                ParentName: parentName,
-                ComponentName: componentName,
-                Weight: weight
-            };
-            
-            const url = this.formatUrl("/Dimensions('{}')/Hierarchies('{}')/Edges", 
-                hierarchy.dimensionName, hierarchy.name);
-            await this.rest.post(url, JSON.stringify(edgeBody));
-        }
     }
 
     public async updateElementAttributes(hierarchy: Hierarchy, keepExisting: boolean = false): Promise<void> {

--- a/src/services/ProcessService.ts
+++ b/src/services/ProcessService.ts
@@ -859,7 +859,12 @@ export class ProcessService extends ObjectService {
         const url = '/ExecuteProcessWithReturn?$expand=*';
         const payload = {
             Process: {
+                Name: '',
                 PrologProcedure: prologProcedure,
+                MetadataProcedure: '',
+                DataProcedure: '',
+                EpilogProcedure: '',
+                HasSecurityAccess: false,
                 Parameters: []
             }
         };

--- a/src/services/ProcessService.ts
+++ b/src/services/ProcessService.ts
@@ -847,78 +847,32 @@ export class ProcessService extends ObjectService {
     }
 
     /**
-     * Evaluate a boolean TI expression
+     * Evaluate a boolean TI expression using the ProcessQuit approach
+     *
+     * Uses ProcessQuit to determine boolean result: if expression is false,
+     * ProcessQuit is called (status=QuitCalled), otherwise completes successfully.
      */
     public async evaluateBooleanTiExpression(expression: string): Promise<boolean> {
-        /** Evaluate a boolean TI expression and return the result
-         *
-         * :param expression: TI expression to evaluate
-         * :return: boolean result of the expression
-         */
-        const tiCode = `
-            # Evaluate boolean expression
-            nResult = ${expression};
-            CellPutN(nResult, 'TempCube', 'Result');
-        `;
+        const formula = expression.replace(/;$/, '');
+        const prologProcedure = `if (~${formula});\n  ProcessQuit;\nendif;`;
 
-        // Create temporary cube for result
-        const cubeName = `TempEvalCube_${Date.now()}`;
-        const dimensionName = `TempEvalDim_${Date.now()}`;
-        
-        try {
-            // Create temporary dimension
-            const dimBody = {
-                Name: dimensionName,
-                Hierarchies: [{
-                    Name: dimensionName,
-                    Elements: [{
-                        Name: 'Result',
-                        Type: 'Numeric'
-                    }]
-                }]
-            };
-            await this.rest.post('/Dimensions', dimBody);
-
-            // Create temporary cube
-            const cubeBody = {
-                Name: cubeName,
-                Dimensions: [dimensionName]
-            };
-            await this.rest.post('/Cubes', cubeBody);
-
-            // Execute TI code
-            const processBody = {
-                Name: `EvalProcess_${Date.now()}`,
-                PrologProcedure: tiCode,
-                HasSecurityAccess: false
-            };
-
-            await this.rest.post('/Processes', processBody);
-            
-            const executeUrl = `/Processes('${processBody.Name}')/tm1.ExecuteProcess`;
-            await this.rest.post(executeUrl, {});
-
-            // Get result
-            const cellUrl = `/Cubes('${cubeName}')/Views/~Native/tm1.Execute?$select=Value&$filter=Members('${dimensionName}','Result')`;
-            const response = await this.rest.get(cellUrl);
-            const result = response.data.Cells?.[0]?.Value || 0;
-
-            // Clean up
-            await this.rest.delete(`/Processes('${processBody.Name}')`);
-            await this.rest.delete(`/Cubes('${cubeName}')`);
-            await this.rest.delete(`/Dimensions('${dimensionName}')`);
-
-            return Boolean(result);
-
-        } catch (error) {
-            // Clean up on error
-            try {
-                await this.rest.delete(`/Cubes('${cubeName}')`);
-                await this.rest.delete(`/Dimensions('${dimensionName}')`);
-            } catch (cleanupError) {
-                // Ignore cleanup errors
+        const url = '/ExecuteProcessWithReturn?$expand=*';
+        const payload = {
+            Process: {
+                PrologProcedure: prologProcedure,
+                Parameters: []
             }
-            throw error;
+        };
+
+        const response = await this.rest.post(url, JSON.stringify(payload));
+        const status = response.data.ProcessExecuteStatusCode;
+
+        if (status === 'QuitCalled') {
+            return false;
+        } else if (status === 'CompletedSuccessfully') {
+            return true;
+        } else {
+            throw new TM1Exception(`Unexpected TI return status: '${status}' for expression: '${expression}'`);
         }
     }
 

--- a/src/services/ProcessService.ts
+++ b/src/services/ProcessService.ts
@@ -597,7 +597,7 @@ export class ProcessService extends ObjectService {
          * :return: list of filenames
          */
         let url = formatUrl(
-            "/ErrorLogFiles?$select=Filename&$filter=contains(tolower(Filename), tolower('{}'))",
+            "/ErrorLogFiles?select=Filename&$filter=contains(tolower(Filename), tolower('{}'))",
             searchString
         );
 
@@ -853,7 +853,7 @@ export class ProcessService extends ObjectService {
      * ProcessQuit is called (status=QuitCalled), otherwise completes successfully.
      */
     public async evaluateBooleanTiExpression(expression: string): Promise<boolean> {
-        const formula = expression.replace(/;$/, '');
+        const formula = expression.replace(/^;+|;+$/g, '');
         const prologProcedure = `if (~${formula});\n  ProcessQuit;\nendif;`;
 
         const url = '/ExecuteProcessWithReturn?$expand=*';

--- a/src/services/ProcessService.ts
+++ b/src/services/ProcessService.ts
@@ -574,30 +574,66 @@ export class ProcessService extends ObjectService {
     }
 
     public async getErrorLogFileContent(fileName: string): Promise<string> {
-        /** Get the content of a process error log file
+        /** Get content of error log file
          *
-         * :param file_name: name of the error log file
-         * :return: file content as string
+         * :param file_name: name of the error log file in the TM1 log directory
+         * :return: String, content of the file
          */
-        const url = formatUrl("/Contents('Logs/{}')", fileName);
+        const url = formatUrl("/ErrorLogFiles('{}')/Content", fileName);
         const response = await this.rest.get(url);
         return response.data;
     }
 
-    public async getErrorLogFilenames(top?: number): Promise<string[]> {
-        /** Get list of error log file names
+    public async searchErrorLogFilenames(
+        searchString: string,
+        top: number = 0,
+        descending: boolean = false
+    ): Promise<string[]> {
+        /** Search error log filenames for given search string
          *
-         * :param top: optional limit on number of files to return
-         * :return: list of error log file names
+         * :param searchString: substring to contain in file names
+         * :param top: top n filenames
+         * :param descending: sort descending (most recent first)
+         * :return: list of filenames
          */
-        let url = "/Contents('Logs')?$select=Name&$filter=endswith(Name,'.log')";
-        
-        if (top) {
+        let url = formatUrl(
+            "/ErrorLogFiles?$select=Filename&$filter=contains(tolower(Filename), tolower('{}'))",
+            searchString
+        );
+
+        if (top > 0) {
             url += `&$top=${top}`;
         }
 
+        if (descending) {
+            url += '&$orderby=Filename desc';
+        }
+
         const response = await this.rest.get(url);
-        return response.data.value.map((file: any) => file.Name);
+        return response.data.value.map((log: any) => log.Filename);
+    }
+
+    public async getErrorLogFilenames(
+        processName?: string,
+        top: number = 0,
+        descending: boolean = false
+    ): Promise<string[]> {
+        /** Get error log filenames for specified TI process
+         *
+         * :param processName: valid TI name, leave blank to return all error log filenames
+         * :param top: top n filenames
+         * :param descending: sort descending (most recent first)
+         * :return: list of filenames
+         */
+        let searchString = '';
+        if (processName) {
+            if (!(await this.exists(processName))) {
+                throw new Error(`'${processName}' is not a valid process`);
+            }
+            searchString = processName;
+        }
+
+        return this.searchErrorLogFilenames(searchString, top, descending);
     }
 
     public async deleteErrorLogFile(fileName: string): Promise<AxiosResponse> {
@@ -606,8 +642,35 @@ export class ProcessService extends ObjectService {
          * :param file_name: name of the error log file to delete
          * :return: response
          */
-        const url = formatUrl("/Contents('Logs/{}')", fileName);
+        const url = formatUrl("/ErrorLogFiles('{}')", fileName);
         return await this.rest.delete(url);
+    }
+
+    public async getProcessErrorLogs(processName: string): Promise<any[]> {
+        /** Get all ProcessErrorLog entries for a process
+         *
+         * :param processName: name of the process
+         * :return: list - Collection of ProcessErrorLogs
+         */
+        const url = formatUrl("/Processes('{}')/ErrorLogs", processName);
+        const response = await this.rest.get(url);
+        return response.data.value;
+    }
+
+    public async getLastMessageFromProcessErrorLog(processName: string): Promise<string | undefined> {
+        /** Get the latest ProcessErrorLog from a process entity
+         *
+         * :param processName: name of the process
+         * :return: String - the error log content, or undefined if no logs exist
+         */
+        const logs = await this.getProcessErrorLogs(processName);
+        if (logs.length > 0) {
+            const timestamp = logs[logs.length - 1].Timestamp;
+            const url = formatUrl("/Processes('{}')/ErrorLogs('{}')/Content", processName, timestamp);
+            const response = await this.rest.get(url);
+            return response.data;
+        }
+        return undefined;
     }
 
     public async searchStringInName(

--- a/src/services/ProcessService.ts
+++ b/src/services/ProcessService.ts
@@ -363,43 +363,157 @@ export class ProcessService extends ObjectService {
         return '';
     }
 
-    public async getProcessDebugBreakpoints(processName: string): Promise<ProcessDebugBreakpoint[]> {
-        /** Get debug breakpoints for a process
+    public async getProcessDebugBreakpoints(debugId: string): Promise<ProcessDebugBreakpoint[]> {
+        /** Get debug breakpoints for a debug context
          *
-         * :param process_name: name of the process
+         * :param debugId: debug session ID
          * :return: list of ProcessDebugBreakpoint objects
          */
-        const url = formatUrl("/Processes('{}')/Breakpoints", processName);
+        const url = formatUrl("/ProcessDebugContexts('{}')/Breakpoints", debugId);
         const response = await this.rest.get(url);
         return response.data.value.map((bp: any) => ProcessDebugBreakpoint.fromDict(bp));
     }
 
     public async createProcessDebugBreakpoint(
-        processName: string,
+        debugId: string,
         breakpoint: ProcessDebugBreakpoint
     ): Promise<AxiosResponse> {
-        /** Create a debug breakpoint for a process
+        /** Create a debug breakpoint in a debug context
          *
-         * :param process_name: name of the process
+         * :param debugId: debug session ID
          * :param breakpoint: ProcessDebugBreakpoint object
          * :return: response
          */
-        const url = formatUrl("/Processes('{}')/Breakpoints", processName);
+        const url = formatUrl("/ProcessDebugContexts('{}')/Breakpoints", debugId);
         return await this.rest.post(url, breakpoint.body);
     }
 
     public async deleteProcessDebugBreakpoint(
-        processName: string,
-        lineNumber: number
+        debugId: string,
+        breakpointId: number
     ): Promise<AxiosResponse> {
-        /** Delete a debug breakpoint from a process
+        /** Delete a debug breakpoint from a debug context
          *
-         * :param process_name: name of the process
-         * :param line_number: line number of the breakpoint
+         * :param debugId: debug session ID
+         * :param breakpointId: ID of the breakpoint
          * :return: response
          */
-        const url = formatUrl("/Processes('{}')/Breakpoints({})", processName, lineNumber.toString());
+        const url = formatUrl("/ProcessDebugContexts('{}')/Breakpoints('{}')", debugId, breakpointId.toString());
         return await this.rest.delete(url);
+    }
+
+    /**
+     * Add multiple breakpoints to a debug context
+     */
+    public async debugAddBreakpoints(
+        debugId: string,
+        breakpoints: ProcessDebugBreakpoint[]
+    ): Promise<AxiosResponse> {
+        const url = formatUrl("/ProcessDebugContexts('{}')/Breakpoints", debugId);
+        const body = JSON.stringify(breakpoints.map(bp => bp.bodyAsDict));
+        return await this.rest.post(url, body);
+    }
+
+    /**
+     * Update an existing breakpoint in a debug context
+     */
+    public async debugUpdateBreakpoint(
+        debugId: string,
+        breakpoint: ProcessDebugBreakpoint
+    ): Promise<AxiosResponse> {
+        const url = formatUrl(
+            "/ProcessDebugContexts('{}')/Breakpoints('{}')",
+            debugId,
+            breakpoint.breakpointId.toString()
+        );
+        return await this.rest.patch(url, breakpoint.body);
+    }
+
+    /**
+     * Get all variable values from the current debug call stack
+     */
+    public async debugGetVariableValues(debugId: string): Promise<Record<string, string>> {
+        const url = formatUrl(
+            "/ProcessDebugContexts('{}')?$expand=CallStack($expand=Variables)",
+            debugId
+        );
+        const response = await this.rest.get(url);
+        const result = response.data;
+        const callStack = result.CallStack && result.CallStack.length > 0
+            ? result.CallStack[0].Variables
+            : [];
+
+        const variables: Record<string, string> = {};
+        for (const entry of callStack) {
+            variables[entry.Name] = entry.Value;
+        }
+        return variables;
+    }
+
+    /**
+     * Get a single variable value from the current debug call stack
+     */
+    public async debugGetSingleVariableValue(debugId: string, variableName: string): Promise<string> {
+        const url = formatUrl(
+            "/ProcessDebugContexts('{}')?$expand=" +
+            "CallStack($expand=Variables($filter=tolower(Name) eq '{}';$select=Value))",
+            debugId,
+            variableName.toLowerCase()
+        );
+        const response = await this.rest.get(url);
+        try {
+            return response.data.CallStack[0].Variables[0].Value;
+        } catch {
+            throw new Error(`'${variableName}' not found in collection`);
+        }
+    }
+
+    /**
+     * Get the current procedure name from the debug call stack
+     */
+    public async debugGetProcessProcedure(debugId: string): Promise<string> {
+        const url = formatUrl(
+            "/ProcessDebugContexts('{}')?$expand=CallStack($select=Procedure)",
+            debugId
+        );
+        const response = await this.rest.get(url);
+        return response.data.CallStack[0].Procedure;
+    }
+
+    /**
+     * Get the current line number from the debug call stack
+     */
+    public async debugGetProcessLineNumber(debugId: string): Promise<number> {
+        const url = formatUrl(
+            "/ProcessDebugContexts('{}')?$expand=CallStack($select=LineNumber)",
+            debugId
+        );
+        const response = await this.rest.get(url);
+        return response.data.CallStack[0].LineNumber;
+    }
+
+    /**
+     * Get the current record number from the debug call stack
+     */
+    public async debugGetRecordNumber(debugId: string): Promise<number> {
+        const url = formatUrl(
+            "/ProcessDebugContexts('{}')?$expand=CallStack($select=RecordNumber)",
+            debugId
+        );
+        const response = await this.rest.get(url);
+        return response.data.CallStack[0].RecordNumber;
+    }
+
+    /**
+     * Get the current breakpoint from the debug context
+     */
+    public async debugGetCurrentBreakpoint(debugId: string): Promise<ProcessDebugBreakpoint> {
+        const url = formatUrl(
+            "/ProcessDebugContexts('{}')?$expand=CurrentBreakpoint",
+            debugId
+        );
+        const response = await this.rest.get(url);
+        return ProcessDebugBreakpoint.fromDict(response.data.CurrentBreakpoint);
     }
 
     public async executeTiCode(
@@ -558,58 +672,115 @@ export class ProcessService extends ObjectService {
         return await this.create(sourceProcess);
     }
 
-    // ===== NEW DEBUGGING FUNCTIONS FOR 100% TM1PY PARITY =====
+    // ===== DEBUG FUNCTIONS =====
 
     /**
-     * Step over in process debugging
+     * Start debug session for specified process; debug session id is returned in response
      */
-    public async debugStepOver(processName: string): Promise<void> {
-        /** Step over the current line during process debugging
-         *
-         * :param process_name: name of the process being debugged
-         * :return: void
-         */
-        const url = formatUrl("/Processes('{}')/tm1.DebugStepOver", processName);
-        await this.rest.post(url, {});
+    public async debugProcess(
+        processName: string,
+        timeout?: number,
+        parameters?: Record<string, any>
+    ): Promise<any> {
+        const url = formatUrl(
+            "/Processes('{}')/tm1.Debug?$expand=Breakpoints," +
+            "Thread,CallStack($expand=Variables,Process($select=Name))",
+            processName
+        );
+
+        const body: any = {};
+        if (parameters && Object.keys(parameters).length > 0) {
+            body.Parameters = Object.entries(parameters).map(([name, value]) => ({
+                Name: name,
+                Value: value
+            }));
+        }
+
+        const config: any = {};
+        if (timeout) {
+            config.timeout = timeout * 1000;
+        }
+
+        const response = await this.rest.post(url, JSON.stringify(body), config);
+        return response.data;
     }
 
     /**
-     * Step into in process debugging
+     * Runs a single statement in the process.
+     * If ExecuteProcess is next function, will NOT debug child process.
      */
-    public async debugStepIn(processName: string): Promise<void> {
-        /** Step into the current line during process debugging
-         *
-         * :param process_name: name of the process being debugged
-         * :return: void
-         */
-        const url = formatUrl("/Processes('{}')/tm1.DebugStepIn", processName);
-        await this.rest.post(url, {});
+    public async debugStepOver(debugId: string): Promise<any> {
+        const url = formatUrl("/ProcessDebugContexts('{}')/tm1.StepOver", debugId);
+        await this.rest.post(url, '{}');
+
+        // digest time necessary for TM1 <= 11.8
+        await new Promise(resolve => setTimeout(resolve, 100));
+
+        const getUrl = formatUrl(
+            "/ProcessDebugContexts('{}')?$expand=Breakpoints," +
+            "Thread,CallStack($expand=Variables,Process($select=Name))",
+            debugId
+        );
+        const response = await this.rest.get(getUrl);
+        return response.data;
     }
 
     /**
-     * Step out in process debugging
+     * Runs a single statement in the process.
+     * If ExecuteProcess is next function, will pause at first statement inside child process.
      */
-    public async debugStepOut(processName: string): Promise<void> {
-        /** Step out of the current procedure during process debugging
-         *
-         * :param process_name: name of the process being debugged
-         * :return: void
-         */
-        const url = formatUrl("/Processes('{}')/tm1.DebugStepOut", processName);
-        await this.rest.post(url, {});
+    public async debugStepIn(debugId: string): Promise<any> {
+        const url = formatUrl("/ProcessDebugContexts('{}')/tm1.StepIn", debugId);
+        await this.rest.post(url, '{}');
+
+        // digest time necessary for TM1 <= 11.8
+        await new Promise(resolve => setTimeout(resolve, 100));
+
+        const getUrl = formatUrl(
+            "/ProcessDebugContexts('{}')?$expand=Breakpoints," +
+            "Thread,CallStack($expand=Variables,Process($select=Name))",
+            debugId
+        );
+        const response = await this.rest.get(getUrl);
+        return response.data;
     }
 
     /**
-     * Continue execution in process debugging
+     * Resumes execution and runs until current process has finished.
      */
-    public async debugContinue(processName: string): Promise<void> {
-        /** Continue execution during process debugging
-         *
-         * :param process_name: name of the process being debugged
-         * :return: void
-         */
-        const url = formatUrl("/Processes('{}')/tm1.DebugContinue", processName);
-        await this.rest.post(url, {});
+    public async debugStepOut(debugId: string): Promise<any> {
+        const url = formatUrl("/ProcessDebugContexts('{}')/tm1.StepOut", debugId);
+        await this.rest.post(url, '{}');
+
+        // digest time necessary for TM1 <= 11.8
+        await new Promise(resolve => setTimeout(resolve, 100));
+
+        const getUrl = formatUrl(
+            "/ProcessDebugContexts('{}')?$expand=Breakpoints," +
+            "Thread,CallStack($expand=Variables,Process($select=Name))",
+            debugId
+        );
+        const response = await this.rest.get(getUrl);
+        return response.data;
+    }
+
+    /**
+     * Resumes execution until next breakpoint
+     */
+    public async debugContinue(debugId: string): Promise<any> {
+        const url = formatUrl("/ProcessDebugContexts('{}')/tm1.Continue", debugId);
+        await this.rest.post(url, '{}');
+
+        // digest time necessary for TM1 <= 11.8
+        await new Promise(resolve => setTimeout(resolve, 100));
+
+        const getUrl = formatUrl(
+            "/ProcessDebugContexts('{}')?$expand=Breakpoints," +
+            "Thread,CallStack($expand=Variables,Process($select=Name))",
+            debugId
+        );
+        const response = await this.rest.get(getUrl);
+        return response.data;
     }
 
     /**

--- a/src/tests/enhancedCubeService.test.ts
+++ b/src/tests/enhancedCubeService.test.ts
@@ -87,7 +87,7 @@ describe('Enhanced CubeService Tests', () => {
 
             expect(result).toEqual(['Year', 'Region', 'Product']);
             expect(mockRestService.get).toHaveBeenCalledWith(
-                "/Cubes('TestCube')/Dimensions?$select=Name"
+                "/Cubes('TestCube')/tm1.DimensionsStorageOrder()?$select=Name"
             );
             
             console.log('✅ getStorageDimensionOrder test passed');
@@ -96,15 +96,22 @@ describe('Enhanced CubeService Tests', () => {
         test('updateStorageDimensionOrder should reorder dimensions', async () => {
             const newOrder = ['Product', 'Region', 'Year'];
 
-            mockRestService.post.mockResolvedValue(createMockResponse({}));
+            mockRestService.post.mockResolvedValue(createMockResponse({ value: -23.07 }));
 
-            await cubeService.updateStorageDimensionOrder('TestCube', newOrder);
+            const result = await cubeService.updateStorageDimensionOrder('TestCube', newOrder);
 
             expect(mockRestService.post).toHaveBeenCalledWith(
-                "/Cubes('TestCube')/tm1.UpdateStorageOrder",
-                { Dimensions: newOrder }
+                "/Cubes('TestCube')/tm1.ReorderDimensions",
+                JSON.stringify({
+                    'Dimensions@odata.bind': [
+                        "Dimensions('Product')",
+                        "Dimensions('Region')",
+                        "Dimensions('Year')"
+                    ]
+                })
             );
-            
+            expect(result).toBe(-23.07);
+
             console.log('✅ updateStorageDimensionOrder test passed');
         });
 

--- a/src/tests/processService.comprehensive.test.ts
+++ b/src/tests/processService.comprehensive.test.ts
@@ -635,7 +635,7 @@ describe('ProcessService - Comprehensive Tests', () => {
 
             expect(result).toEqual(['Process1_20250115.log', 'Process2_20250114.log', 'Process3_20250113.log']);
             expect(mockRestService.get).toHaveBeenCalledWith(
-                "/ErrorLogFiles?$select=Filename&$filter=contains(tolower(Filename), tolower(''))"
+                "/ErrorLogFiles?select=Filename&$filter=contains(tolower(Filename), tolower(''))"
             );
         });
 
@@ -652,7 +652,7 @@ describe('ProcessService - Comprehensive Tests', () => {
 
             expect(result).toEqual(['Process1_20250115.log', 'Process2_20250114.log']);
             expect(mockRestService.get).toHaveBeenCalledWith(
-                "/ErrorLogFiles?$select=Filename&$filter=contains(tolower(Filename), tolower(''))&$top=2"
+                "/ErrorLogFiles?select=Filename&$filter=contains(tolower(Filename), tolower(''))&$top=2"
             );
         });
 
@@ -1151,7 +1151,7 @@ describe('ProcessService - Comprehensive Tests', () => {
             const result = await processService.searchErrorLogFilenames('TestProcess');
 
             expect(mockRestService.get).toHaveBeenCalledWith(
-                "/ErrorLogFiles?$select=Filename&$filter=contains(tolower(Filename), tolower('TestProcess'))"
+                "/ErrorLogFiles?select=Filename&$filter=contains(tolower(Filename), tolower('TestProcess'))"
             );
             expect(result).toEqual([
                 'TM1ProcessError_TestProcess_20250115.log',

--- a/src/tests/processService.comprehensive.test.ts
+++ b/src/tests/processService.comprehensive.test.ts
@@ -522,24 +522,24 @@ describe('ProcessService - Comprehensive Tests', () => {
             };
             mockRestService.get.mockResolvedValue(mockResponse(breakpointsData));
 
-            const result = await processService.getProcessDebugBreakpoints('TestProcess');
-            
+            const result = await processService.getProcessDebugBreakpoints('debug-123');
+
             expect(result).toHaveLength(2);
             expect(ProcessDebugBreakpoint.fromDict).toHaveBeenCalledTimes(2);
-            expect(mockRestService.get).toHaveBeenCalledWith("/Processes('TestProcess')/Breakpoints");
+            expect(mockRestService.get).toHaveBeenCalledWith("/ProcessDebugContexts('debug-123')/Breakpoints");
         });
 
         test('should create process debug breakpoint', async () => {
             mockRestService.post.mockResolvedValue(mockResponse({}));
 
             const result = await processService.createProcessDebugBreakpoint(
-                'TestProcess',
+                'debug-123',
                 mockProcessDebugBreakpoint
             );
-            
+
             expect(result).toBeDefined();
             expect(mockRestService.post).toHaveBeenCalledWith(
-                "/Processes('TestProcess')/Breakpoints",
+                "/ProcessDebugContexts('debug-123')/Breakpoints",
                 mockProcessDebugBreakpoint.body
             );
         });
@@ -547,54 +547,66 @@ describe('ProcessService - Comprehensive Tests', () => {
         test('should delete process debug breakpoint', async () => {
             mockRestService.delete.mockResolvedValue(mockResponse({}));
 
-            const result = await processService.deleteProcessDebugBreakpoint('TestProcess', 5);
-            
+            const result = await processService.deleteProcessDebugBreakpoint('debug-123', 5);
+
             expect(result).toBeDefined();
-            expect(mockRestService.delete).toHaveBeenCalledWith("/Processes('TestProcess')/Breakpoints(5)");
+            expect(mockRestService.delete).toHaveBeenCalledWith("/ProcessDebugContexts('debug-123')/Breakpoints('5')");
         });
 
         test('should debug step over', async () => {
+            const debugData = { ID: 'debug-123', CallStack: [] };
             mockRestService.post.mockResolvedValue(mockResponse({}));
+            mockRestService.get.mockResolvedValue(mockResponse(debugData));
 
-            await processService.debugStepOver('TestProcess');
-            
+            const result = await processService.debugStepOver('debug-123');
+
             expect(mockRestService.post).toHaveBeenCalledWith(
-                "/Processes('TestProcess')/tm1.DebugStepOver",
-                {}
+                "/ProcessDebugContexts('debug-123')/tm1.StepOver",
+                '{}'
             );
+            expect(result).toEqual(debugData);
         });
 
         test('should debug step in', async () => {
+            const debugData = { ID: 'debug-123', CallStack: [] };
             mockRestService.post.mockResolvedValue(mockResponse({}));
+            mockRestService.get.mockResolvedValue(mockResponse(debugData));
 
-            await processService.debugStepIn('TestProcess');
-            
+            const result = await processService.debugStepIn('debug-123');
+
             expect(mockRestService.post).toHaveBeenCalledWith(
-                "/Processes('TestProcess')/tm1.DebugStepIn",
-                {}
+                "/ProcessDebugContexts('debug-123')/tm1.StepIn",
+                '{}'
             );
+            expect(result).toEqual(debugData);
         });
 
         test('should debug step out', async () => {
+            const debugData = { ID: 'debug-123', CallStack: [] };
             mockRestService.post.mockResolvedValue(mockResponse({}));
+            mockRestService.get.mockResolvedValue(mockResponse(debugData));
 
-            await processService.debugStepOut('TestProcess');
-            
+            const result = await processService.debugStepOut('debug-123');
+
             expect(mockRestService.post).toHaveBeenCalledWith(
-                "/Processes('TestProcess')/tm1.DebugStepOut",
-                {}
+                "/ProcessDebugContexts('debug-123')/tm1.StepOut",
+                '{}'
             );
+            expect(result).toEqual(debugData);
         });
 
         test('should debug continue', async () => {
+            const debugData = { ID: 'debug-123', CallStack: [] };
             mockRestService.post.mockResolvedValue(mockResponse({}));
+            mockRestService.get.mockResolvedValue(mockResponse(debugData));
 
-            await processService.debugContinue('TestProcess');
-            
+            const result = await processService.debugContinue('debug-123');
+
             expect(mockRestService.post).toHaveBeenCalledWith(
-                "/Processes('TestProcess')/tm1.DebugContinue",
-                {}
+                "/ProcessDebugContexts('debug-123')/tm1.Continue",
+                '{}'
             );
+            expect(result).toEqual(debugData);
         });
     });
 
@@ -606,41 +618,41 @@ describe('ProcessService - Comprehensive Tests', () => {
             const result = await processService.getErrorLogFileContent('TestProcess_20250115.log');
             
             expect(result).toBe(logContent);
-            expect(mockRestService.get).toHaveBeenCalledWith("/Contents('Logs/TestProcess_20250115.log')");
+            expect(mockRestService.get).toHaveBeenCalledWith("/ErrorLogFiles('TestProcess_20250115.log')/Content");
         });
 
         test('should get error log filenames', async () => {
             const filesData = {
                 value: [
-                    { Name: 'Process1_20250115.log' },
-                    { Name: 'Process2_20250114.log' },
-                    { Name: 'Process3_20250113.log' }
+                    { Filename: 'Process1_20250115.log' },
+                    { Filename: 'Process2_20250114.log' },
+                    { Filename: 'Process3_20250113.log' }
                 ]
             };
             mockRestService.get.mockResolvedValue(mockResponse(filesData));
 
             const result = await processService.getErrorLogFilenames();
-            
+
             expect(result).toEqual(['Process1_20250115.log', 'Process2_20250114.log', 'Process3_20250113.log']);
             expect(mockRestService.get).toHaveBeenCalledWith(
-                "/Contents('Logs')?$select=Name&$filter=endswith(Name,'.log')"
+                "/ErrorLogFiles?$select=Filename&$filter=contains(tolower(Filename), tolower(''))"
             );
         });
 
         test('should get error log filenames with top limit', async () => {
             const filesData = {
                 value: [
-                    { Name: 'Process1_20250115.log' },
-                    { Name: 'Process2_20250114.log' }
+                    { Filename: 'Process1_20250115.log' },
+                    { Filename: 'Process2_20250114.log' }
                 ]
             };
             mockRestService.get.mockResolvedValue(mockResponse(filesData));
 
-            const result = await processService.getErrorLogFilenames(2);
-            
+            const result = await processService.getErrorLogFilenames(undefined, 2);
+
             expect(result).toEqual(['Process1_20250115.log', 'Process2_20250114.log']);
             expect(mockRestService.get).toHaveBeenCalledWith(
-                "/Contents('Logs')?$select=Name&$filter=endswith(Name,'.log')&$top=2"
+                "/ErrorLogFiles?$select=Filename&$filter=contains(tolower(Filename), tolower(''))&$top=2"
             );
         });
 
@@ -648,9 +660,9 @@ describe('ProcessService - Comprehensive Tests', () => {
             mockRestService.delete.mockResolvedValue(mockResponse({}));
 
             const result = await processService.deleteErrorLogFile('TestProcess_20250115.log');
-            
+
             expect(result).toBeDefined();
-            expect(mockRestService.delete).toHaveBeenCalledWith("/Contents('Logs/TestProcess_20250115.log')");
+            expect(mockRestService.delete).toHaveBeenCalledWith("/ErrorLogFiles('TestProcess_20250115.log')");
         });
 
         test('should get last message from message log', async () => {
@@ -715,66 +727,37 @@ describe('ProcessService - Comprehensive Tests', () => {
 
     describe('Boolean TI Expression Evaluation', () => {
         test('should evaluate boolean TI expression - true result', async () => {
-            // Mock the series of REST calls for evaluation
-            mockRestService.post
-                .mockResolvedValueOnce(mockResponse({})) // Create dimension
-                .mockResolvedValueOnce(mockResponse({})) // Create cube
-                .mockResolvedValueOnce(mockResponse({})) // Create process
-                .mockResolvedValueOnce(mockResponse({})); // Execute process
-
-            mockRestService.get.mockResolvedValue(mockResponse({
-                Cells: [{ Value: 1 }]
-            }));
-
-            mockRestService.delete
-                .mockResolvedValueOnce(mockResponse({})) // Delete process
-                .mockResolvedValueOnce(mockResponse({})) // Delete cube
-                .mockResolvedValueOnce(mockResponse({})); // Delete dimension
+            mockRestService.post.mockResolvedValue(
+                mockResponse({ ProcessExecuteStatusCode: 'CompletedSuccessfully' })
+            );
 
             const result = await processService.evaluateBooleanTiExpression('1 = 1');
-            
+
             expect(result).toBe(true);
-            expect(mockRestService.post).toHaveBeenCalledTimes(4);
-            expect(mockRestService.delete).toHaveBeenCalledTimes(3);
+            expect(mockRestService.post).toHaveBeenCalledTimes(1);
+            expect(mockRestService.post).toHaveBeenCalledWith(
+                '/ExecuteProcessWithReturn?$expand=*',
+                expect.stringContaining('ProcessQuit')
+            );
         });
 
         test('should evaluate boolean TI expression - false result', async () => {
-            // Mock the series of REST calls for evaluation
-            mockRestService.post
-                .mockResolvedValueOnce(mockResponse({})) // Create dimension
-                .mockResolvedValueOnce(mockResponse({})) // Create cube
-                .mockResolvedValueOnce(mockResponse({})) // Create process
-                .mockResolvedValueOnce(mockResponse({})); // Execute process
-
-            mockRestService.get.mockResolvedValue(mockResponse({
-                Cells: [{ Value: 0 }]
-            }));
-
-            mockRestService.delete
-                .mockResolvedValueOnce(mockResponse({})) // Delete process
-                .mockResolvedValueOnce(mockResponse({})) // Delete cube
-                .mockResolvedValueOnce(mockResponse({})); // Delete dimension
+            mockRestService.post.mockResolvedValue(
+                mockResponse({ ProcessExecuteStatusCode: 'QuitCalled' })
+            );
 
             const result = await processService.evaluateBooleanTiExpression('1 = 0');
-            
+
             expect(result).toBe(false);
         });
 
-        test('should handle evaluation errors and cleanup', async () => {
-            mockRestService.post
-                .mockResolvedValueOnce(mockResponse({})) // Create dimension
-                .mockResolvedValueOnce(mockResponse({})) // Create cube
-                .mockRejectedValueOnce(new Error('Process creation failed')); // Fail process creation
-
-            mockRestService.delete
-                .mockResolvedValueOnce(mockResponse({})) // Delete cube
-                .mockResolvedValueOnce(mockResponse({})); // Delete dimension
+        test('should handle unexpected status from evaluation', async () => {
+            mockRestService.post.mockResolvedValue(
+                mockResponse({ ProcessExecuteStatusCode: 'Aborted' })
+            );
 
             await expect(processService.evaluateBooleanTiExpression('invalid expression'))
-                .rejects.toThrow('Process creation failed');
-
-            // Verify cleanup was attempted
-            expect(mockRestService.delete).toHaveBeenCalledTimes(2);
+                .rejects.toThrow("Unexpected TI return status: 'Aborted'");
         });
     });
 
@@ -902,15 +885,16 @@ describe('ProcessService - Comprehensive Tests', () => {
         });
 
         test('should support debug workflow management', async () => {
+            const debugData = { ID: 'debug-123', CallStack: [] };
             mockRestService.post.mockResolvedValue(mockResponse({}));
-            mockRestService.get.mockResolvedValue(mockResponse({ value: [] }));
+            mockRestService.get.mockResolvedValue(mockResponse(debugData));
             mockRestService.delete.mockResolvedValue(mockResponse({}));
 
             // Debug workflow: set breakpoint, run debug commands, remove breakpoint
-            await processService.createProcessDebugBreakpoint('TestProcess', mockProcessDebugBreakpoint);
-            await processService.debugStepOver('TestProcess');
-            await processService.debugContinue('TestProcess');
-            await processService.deleteProcessDebugBreakpoint('TestProcess', 5);
+            await processService.createProcessDebugBreakpoint('debug-123', mockProcessDebugBreakpoint);
+            await processService.debugStepOver('debug-123');
+            await processService.debugContinue('debug-123');
+            await processService.deleteProcessDebugBreakpoint('debug-123', 5);
 
             expect(mockRestService.post).toHaveBeenCalledTimes(3);
             expect(mockRestService.delete).toHaveBeenCalledTimes(1);

--- a/src/tests/processService.comprehensive.test.ts
+++ b/src/tests/processService.comprehensive.test.ts
@@ -741,6 +741,27 @@ describe('ProcessService - Comprehensive Tests', () => {
             );
         });
 
+        test('should send enriched Process payload matching tm1py parity', async () => {
+            mockRestService.post.mockResolvedValue(
+                mockResponse({ ProcessExecuteStatusCode: 'CompletedSuccessfully' })
+            );
+
+            await processService.evaluateBooleanTiExpression('1 = 1');
+
+            const callPayload = JSON.parse(mockRestService.post.mock.calls[0][1]);
+            expect(callPayload.Process).toEqual(
+                expect.objectContaining({
+                    Name: '',
+                    MetadataProcedure: '',
+                    DataProcedure: '',
+                    EpilogProcedure: '',
+                    HasSecurityAccess: false,
+                    Parameters: []
+                })
+            );
+            expect(callPayload.Process.PrologProcedure).toContain('ProcessQuit');
+        });
+
         test('should evaluate boolean TI expression - false result', async () => {
             mockRestService.post.mockResolvedValue(
                 mockResponse({ ProcessExecuteStatusCode: 'QuitCalled' })
@@ -863,6 +884,309 @@ describe('ProcessService - Comprehensive Tests', () => {
             const result = await processService.searchStringInCode('WriteToMessageLog');
             
             expect(result).toHaveLength(1000);
+        });
+    });
+
+    describe('Debug Session Methods', () => {
+        test('debugProcess should POST to tm1.Debug with expand and return data', async () => {
+            const debugResponse = {
+                ID: 'ctx-001',
+                Breakpoints: [],
+                Thread: { ID: 'thread-1' },
+                CallStack: [{ Variables: [], Process: { Name: 'TestProcess' } }]
+            };
+            mockRestService.post.mockResolvedValue(mockResponse(debugResponse));
+
+            const result = await processService.debugProcess('TestProcess');
+
+            expect(mockRestService.post).toHaveBeenCalledWith(
+                "/Processes('TestProcess')/tm1.Debug?$expand=Breakpoints," +
+                "Thread,CallStack($expand=Variables,Process($select=Name))",
+                '{}',
+                {}
+            );
+            expect(result).toEqual(debugResponse);
+        });
+
+        test('debugProcess should include parameters when provided', async () => {
+            const debugResponse = { ID: 'ctx-002', Breakpoints: [], CallStack: [] };
+            mockRestService.post.mockResolvedValue(mockResponse(debugResponse));
+
+            const params = { pRegion: 'US', pYear: 2025 };
+            await processService.debugProcess('TestProcess', undefined, params);
+
+            const callBody = JSON.parse(mockRestService.post.mock.calls[0][1]);
+            expect(callBody.Parameters).toEqual([
+                { Name: 'pRegion', Value: 'US' },
+                { Name: 'pYear', Value: 2025 }
+            ]);
+        });
+
+        test('debugProcess should pass timeout config when provided', async () => {
+            const debugResponse = { ID: 'ctx-003', Breakpoints: [], CallStack: [] };
+            mockRestService.post.mockResolvedValue(mockResponse(debugResponse));
+
+            await processService.debugProcess('TestProcess', 60);
+
+            expect(mockRestService.post).toHaveBeenCalledWith(
+                expect.any(String),
+                expect.any(String),
+                { timeout: 60000 }
+            );
+        });
+
+        test('debugAddBreakpoints should POST breakpoints array to Breakpoints endpoint', async () => {
+            mockRestService.post.mockResolvedValue(mockResponse({}));
+
+            const bp1 = { bodyAsDict: { LineNumber: 1, Procedure: 'Prolog' } } as any;
+            const bp2 = { bodyAsDict: { LineNumber: 10, Procedure: 'Epilog' } } as any;
+
+            await processService.debugAddBreakpoints('ctx-001', [bp1, bp2]);
+
+            expect(mockRestService.post).toHaveBeenCalledWith(
+                "/ProcessDebugContexts('ctx-001')/Breakpoints",
+                JSON.stringify([
+                    { LineNumber: 1, Procedure: 'Prolog' },
+                    { LineNumber: 10, Procedure: 'Epilog' }
+                ])
+            );
+        });
+
+        test('debugUpdateBreakpoint should PATCH to Breakpoints(id)', async () => {
+            mockRestService.patch.mockResolvedValue(mockResponse({}));
+
+            const bp = {
+                breakpointId: 7,
+                body: JSON.stringify({ ID: 7, Enabled: false })
+            } as any;
+
+            await processService.debugUpdateBreakpoint('ctx-001', bp);
+
+            expect(mockRestService.patch).toHaveBeenCalledWith(
+                "/ProcessDebugContexts('ctx-001')/Breakpoints('7')",
+                bp.body
+            );
+        });
+    });
+
+    describe('Debug Inspection Methods', () => {
+        test('debugGetVariableValues should return variables as key-value map', async () => {
+            const contextData = {
+                CallStack: [{
+                    Variables: [
+                        { Name: 'sRegion', Value: 'US' },
+                        { Name: 'nAmount', Value: '100' }
+                    ]
+                }]
+            };
+            mockRestService.get.mockResolvedValue(mockResponse(contextData));
+
+            const result = await processService.debugGetVariableValues('ctx-001');
+
+            expect(mockRestService.get).toHaveBeenCalledWith(
+                "/ProcessDebugContexts('ctx-001')?$expand=CallStack($expand=Variables)"
+            );
+            expect(result).toEqual({ sRegion: 'US', nAmount: '100' });
+        });
+
+        test('debugGetVariableValues should return empty object when call stack is empty', async () => {
+            mockRestService.get.mockResolvedValue(mockResponse({ CallStack: [] }));
+
+            const result = await processService.debugGetVariableValues('ctx-001');
+
+            expect(result).toEqual({});
+        });
+
+        test('debugGetSingleVariableValue should return value for given variable', async () => {
+            const contextData = {
+                CallStack: [{
+                    Variables: [{ Value: 'Europe' }]
+                }]
+            };
+            mockRestService.get.mockResolvedValue(mockResponse(contextData));
+
+            const result = await processService.debugGetSingleVariableValue('ctx-001', 'sRegion');
+
+            expect(mockRestService.get).toHaveBeenCalledWith(
+                "/ProcessDebugContexts('ctx-001')?$expand=" +
+                "CallStack($expand=Variables($filter=tolower(Name) eq 'sregion';$select=Value))"
+            );
+            expect(result).toBe('Europe');
+        });
+
+        test('debugGetSingleVariableValue should throw when variable not found', async () => {
+            mockRestService.get.mockResolvedValue(mockResponse({ CallStack: [] }));
+
+            await expect(
+                processService.debugGetSingleVariableValue('ctx-001', 'nMissing')
+            ).rejects.toThrow("'nMissing' not found in collection");
+        });
+
+        test('debugGetProcessProcedure should return current procedure name', async () => {
+            const contextData = { CallStack: [{ Procedure: 'Prolog' }] };
+            mockRestService.get.mockResolvedValue(mockResponse(contextData));
+
+            const result = await processService.debugGetProcessProcedure('ctx-001');
+
+            expect(mockRestService.get).toHaveBeenCalledWith(
+                "/ProcessDebugContexts('ctx-001')?$expand=CallStack($select=Procedure)"
+            );
+            expect(result).toBe('Prolog');
+        });
+
+        test('debugGetProcessLineNumber should return current line number', async () => {
+            const contextData = { CallStack: [{ LineNumber: 42 }] };
+            mockRestService.get.mockResolvedValue(mockResponse(contextData));
+
+            const result = await processService.debugGetProcessLineNumber('ctx-001');
+
+            expect(mockRestService.get).toHaveBeenCalledWith(
+                "/ProcessDebugContexts('ctx-001')?$expand=CallStack($select=LineNumber)"
+            );
+            expect(result).toBe(42);
+        });
+
+        test('debugGetRecordNumber should return current record number', async () => {
+            const contextData = { CallStack: [{ RecordNumber: 15 }] };
+            mockRestService.get.mockResolvedValue(mockResponse(contextData));
+
+            const result = await processService.debugGetRecordNumber('ctx-001');
+
+            expect(mockRestService.get).toHaveBeenCalledWith(
+                "/ProcessDebugContexts('ctx-001')?$expand=CallStack($select=RecordNumber)"
+            );
+            expect(result).toBe(15);
+        });
+
+        test('debugGetCurrentBreakpoint should return breakpoint from context', async () => {
+            const bpData = {
+                '@odata.type': '#ibm.tm1.api.v1.ProcessDebugContextLineBreakpoint',
+                ID: 3,
+                Enabled: true,
+                HitMode: 'BreakAlways',
+                Expression: '',
+                LineNumber: 5,
+                Procedure: 'Prolog',
+                ProcessName: 'TestProcess',
+                HitCount: 0
+            };
+            mockRestService.get.mockResolvedValue(mockResponse({ CurrentBreakpoint: bpData }));
+
+            const result = await processService.debugGetCurrentBreakpoint('ctx-001');
+
+            expect(mockRestService.get).toHaveBeenCalledWith(
+                "/ProcessDebugContexts('ctx-001')?$expand=CurrentBreakpoint"
+            );
+            expect(ProcessDebugBreakpoint.fromDict).toHaveBeenCalledWith(bpData);
+            expect(result).toEqual(mockProcessDebugBreakpoint);
+        });
+    });
+
+    describe('Process Error Log Methods', () => {
+        test('getProcessErrorLogs should GET ErrorLogs from process and return value array', async () => {
+            const logsData = {
+                value: [
+                    { Timestamp: '2025-01-15T10:00:00Z', Message: 'Error at line 5' },
+                    { Timestamp: '2025-01-15T11:00:00Z', Message: 'Error at line 12' }
+                ]
+            };
+            mockRestService.get.mockResolvedValue(mockResponse(logsData));
+
+            const result = await processService.getProcessErrorLogs('TestProcess');
+
+            expect(mockRestService.get).toHaveBeenCalledWith("/Processes('TestProcess')/ErrorLogs");
+            expect(result).toEqual(logsData.value);
+            expect(result).toHaveLength(2);
+        });
+
+        test('getProcessErrorLogs should return empty array when no logs', async () => {
+            mockRestService.get.mockResolvedValue(mockResponse({ value: [] }));
+
+            const result = await processService.getProcessErrorLogs('CleanProcess');
+
+            expect(result).toEqual([]);
+        });
+
+        test('getLastMessageFromProcessErrorLog should return content of latest log', async () => {
+            const logsData = {
+                value: [
+                    { Timestamp: '2025-01-15T10:00:00Z' },
+                    { Timestamp: '2025-01-15T11:00:00Z' }
+                ]
+            };
+            const logContent = 'Error: Variable not defined at line 5';
+
+            // First call: getProcessErrorLogs -> GET ErrorLogs
+            // Second call: GET Content of latest log
+            mockRestService.get
+                .mockResolvedValueOnce(mockResponse(logsData))
+                .mockResolvedValueOnce(mockResponse(logContent));
+
+            const result = await processService.getLastMessageFromProcessErrorLog('TestProcess');
+
+            expect(mockRestService.get).toHaveBeenCalledWith("/Processes('TestProcess')/ErrorLogs");
+            expect(mockRestService.get).toHaveBeenCalledWith(
+                "/Processes('TestProcess')/ErrorLogs('2025-01-15T11%3A00%3A00Z')/Content"
+            );
+            expect(result).toBe(logContent);
+        });
+
+        test('getLastMessageFromProcessErrorLog should return undefined when no logs exist', async () => {
+            mockRestService.get.mockResolvedValue(mockResponse({ value: [] }));
+
+            const result = await processService.getLastMessageFromProcessErrorLog('CleanProcess');
+
+            expect(result).toBeUndefined();
+        });
+
+        test('searchErrorLogFilenames should GET filenames with filter', async () => {
+            const filesData = {
+                value: [
+                    { Filename: 'TM1ProcessError_TestProcess_20250115.log' },
+                    { Filename: 'TM1ProcessError_TestProcess_20250116.log' }
+                ]
+            };
+            mockRestService.get.mockResolvedValue(mockResponse(filesData));
+
+            const result = await processService.searchErrorLogFilenames('TestProcess');
+
+            expect(mockRestService.get).toHaveBeenCalledWith(
+                "/ErrorLogFiles?$select=Filename&$filter=contains(tolower(Filename), tolower('TestProcess'))"
+            );
+            expect(result).toEqual([
+                'TM1ProcessError_TestProcess_20250115.log',
+                'TM1ProcessError_TestProcess_20250116.log'
+            ]);
+        });
+
+        test('searchErrorLogFilenames should append $top when top > 0', async () => {
+            mockRestService.get.mockResolvedValue(mockResponse({ value: [{ Filename: 'file.log' }] }));
+
+            await processService.searchErrorLogFilenames('Test', 5);
+
+            expect(mockRestService.get).toHaveBeenCalledWith(
+                expect.stringContaining('&$top=5')
+            );
+        });
+
+        test('searchErrorLogFilenames should append $orderby desc when descending', async () => {
+            mockRestService.get.mockResolvedValue(mockResponse({ value: [] }));
+
+            await processService.searchErrorLogFilenames('Test', 0, true);
+
+            expect(mockRestService.get).toHaveBeenCalledWith(
+                expect.stringContaining('&$orderby=Filename desc')
+            );
+        });
+
+        test('searchErrorLogFilenames should combine top and descending', async () => {
+            mockRestService.get.mockResolvedValue(mockResponse({ value: [] }));
+
+            await processService.searchErrorLogFilenames('Test', 3, true);
+
+            const url = mockRestService.get.mock.calls[0][0];
+            expect(url).toContain('&$top=3');
+            expect(url).toContain('&$orderby=Filename desc');
         });
     });
 

--- a/src/tests/simpleCoverage.test.ts
+++ b/src/tests/simpleCoverage.test.ts
@@ -152,43 +152,39 @@ describe('Simple Coverage Tests', () => {
         });
 
         test('ProcessService debug operations should work', async () => {
+            const debugData = { ID: 'debug-123', CallStack: [] };
             const mockRest = {
-                post: jest.fn().mockResolvedValue(mockResponse)
+                post: jest.fn().mockResolvedValue(mockResponse),
+                get: jest.fn().mockResolvedValue({ data: debugData, status: 200, statusText: 'OK', headers: {}, config: {} })
             } as any;
 
             const processService = new ProcessService(mockRest);
-            
-            await processService.debugStepOver('TestProcess');
-            await processService.debugStepIn('TestProcess');
-            await processService.debugStepOut('TestProcess');
-            await processService.debugContinue('TestProcess');
-            
+
+            await processService.debugStepOver('debug-123');
+            await processService.debugStepIn('debug-123');
+            await processService.debugStepOut('debug-123');
+            await processService.debugContinue('debug-123');
+
             expect(mockRest.post).toHaveBeenCalledTimes(4);
+            expect(mockRest.get).toHaveBeenCalledTimes(4);
         });
 
         test('ProcessService boolean expression evaluation should work', async () => {
             const mockRest = {
                 post: jest.fn().mockResolvedValue({
-                    data: { value: true },
+                    data: { ProcessExecuteStatusCode: 'CompletedSuccessfully' },
                     status: 200,
                     statusText: 'OK',
                     headers: {},
                     config: {}
-                }),
-                get: jest.fn().mockResolvedValue({
-                    data: { Cells: [{ Value: true }] },
-                    status: 200,
-                    statusText: 'OK',
-                    headers: {},
-                    config: {}
-                }),
-                delete: jest.fn().mockResolvedValue(mockResponse)
+                })
             } as any;
 
             const processService = new ProcessService(mockRest);
-            
+
             const result = await processService.evaluateBooleanTiExpression('1=1');
             expect(result).toBe(true);
+            expect(mockRest.post).toHaveBeenCalledTimes(1);
         });
     });
 


### PR DESCRIPTION
## Summary

Fixes 6 critical parity bugs where tm1npm used incorrect TM1 REST API endpoints or wrong behavioral patterns compared to the tm1py reference implementation.

### Bugs Fixed

| # | Service | Issue | Fix |
|---|---------|-------|-----|
| 1 | ProcessService | Debug methods used `/Processes('{name}')` | Changed to `/ProcessDebugContexts('{debugId}')` with proper Step/Continue actions |
| 2 | ProcessService | Error log methods used `/Contents('Logs/...')` | Changed to `/ErrorLogFiles(...)` API |
| 3 | ProcessService | `evaluateBooleanTiExpression` created temp cubes/dims | Replaced with ProcessQuit-based approach via `/ExecuteProcessWithReturn` |
| 4 | HierarchyService | `update()` deleted all elements then rebuilt | Changed to single PATCH request matching tm1py |
| 5 | CubeService | `getStorageDimensionOrder` used `/Dimensions?$select=Name` | Changed to `/tm1.DimensionsStorageOrder()` and `/tm1.ReorderDimensions` |
| 6 | FileService | `create` skipped document metadata POST | Added `#ibm.tm1.api.v1.Document` POST before content upload |

### Files Changed
- `src/services/ProcessService.ts` — debug endpoints, error log endpoints, boolean TI expression
- `src/services/HierarchyService.ts` — PATCH-based update
- `src/services/CubeService.ts` — storage dimension order endpoints
- `src/services/FileService.ts` — document metadata creation step
- `src/tests/processService.comprehensive.test.ts` — 20+ new tests
- `src/tests/enhancedCubeService.test.ts` — updated URL expectations
- `src/tests/simpleCoverage.test.ts` — updated mocks

## Test plan
- [x] All existing tests pass with updated expectations
- [x] 20+ new unit tests added for debug methods, error log methods, and boolean TI expression
- [ ] Integration test against live TM1 server (manual)

## Breaking Changes
- `debugProcess` / `debugStep` / `debugContinue` parameter changed from `processName` to `debugId`
- `evaluateBooleanTiExpression` no longer creates temporary cubes/dimensions
- `update()` in HierarchyService now sends PATCH instead of destructive rebuild
- `getStorageDimensionOrder` / `updateStorageDimensionOrder` use different API endpoints