### PR TITLE
fix(objects): NativeView fromDict stubbed, Hierarchy edge keys wrong, MDXView missing dynamicProperties (#35)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -218,3 +218,4 @@ build/Release
 
 .claude/
 CLAUDE.md
+IMPLEMENTATION_PLAN.md

--- a/src/objects/Axis.ts
+++ b/src/objects/Axis.ts
@@ -1,6 +1,6 @@
 import { TM1Object } from './TM1Object';
 import { Subset, AnonymousSubset } from './Subset';
-import { formatUrl } from '../utils/Utils';
+import { formatUrl, parseODataBindUrl } from '../utils/Utils';
 
 export class ViewAxisSelection extends TM1Object {
     /** Describes what is selected in a dimension on an axis. Can be a Registered Subset or an Anonymous Subset
@@ -42,9 +42,19 @@ export class ViewAxisSelection extends TM1Object {
         return this.constructBody();
     }
 
-    public static fromDict(_data: Record<string, any>): ViewAxisSelection {
-        // Basic implementation - would need actual data structure
-        return new ViewAxisSelection('', new AnonymousSubset('', ''));
+    public static fromDict(data: Record<string, any>): ViewAxisSelection {
+        if ('Subset' in data) {
+            const subset = AnonymousSubset.fromDict(data['Subset']);
+            return new ViewAxisSelection(subset.dimensionName, subset);
+        } else if ('Subset@odata.bind' in data) {
+            const parts = parseODataBindUrl(data['Subset@odata.bind']);
+            const dimName = parts[0] || '';
+            const hierName = parts[1] || '';
+            const subsetName = parts[2] || '';
+            const subset = new Subset(subsetName, dimName, hierName);
+            return new ViewAxisSelection(dimName, subset);
+        }
+        throw new Error("ViewAxisSelection dict must contain 'Subset' or 'Subset@odata.bind'");
     }
 
     private constructBody(): Record<string, any> {
@@ -53,7 +63,7 @@ export class ViewAxisSelection extends TM1Object {
          * :return: dictionary
          */
         const bodyAsDict: Record<string, any> = {};
-        
+
         if (this._subset instanceof AnonymousSubset) {
             bodyAsDict['Subset'] = JSON.parse(this._subset.body);
         } else if (this._subset instanceof Subset) {
@@ -65,7 +75,7 @@ export class ViewAxisSelection extends TM1Object {
             );
             bodyAsDict['Subset@odata.bind'] = subsetPath;
         }
-        
+
         return bodyAsDict;
     }
 }
@@ -104,6 +114,10 @@ export class ViewTitleSelection {
         return this._selected;
     }
 
+    public set selected(value: string) {
+        this._selected = value;
+    }
+
     public get body(): string {
         return JSON.stringify(this.constructBody());
     }
@@ -112,9 +126,35 @@ export class ViewTitleSelection {
         return this.constructBody();
     }
 
-    public static fromDict(_data: Record<string, any>): ViewTitleSelection {
-        // Basic implementation - would need actual data structure
-        return new ViewTitleSelection('', new AnonymousSubset('', ''), '');
+    public static fromDict(data: Record<string, any>): ViewTitleSelection {
+        let subset: AnonymousSubset | Subset;
+        let dimName: string;
+
+        if ('Subset' in data) {
+            subset = AnonymousSubset.fromDict(data['Subset']);
+            dimName = subset.dimensionName;
+        } else if ('Subset@odata.bind' in data) {
+            const parts = parseODataBindUrl(data['Subset@odata.bind']);
+            dimName = parts[0] || '';
+            const hierName = parts[1] || '';
+            const subsetName = parts[2] || '';
+            subset = new Subset(subsetName, dimName, hierName);
+        } else {
+            throw new Error("ViewTitleSelection dict must contain 'Subset' or 'Subset@odata.bind'");
+        }
+
+        let selected: string;
+        if ('Selected@odata.bind' in data) {
+            // URL format: Dimensions('D')/Hierarchies('H')/Elements('E')
+            const parts = parseODataBindUrl(data['Selected@odata.bind']);
+            selected = parts[2] || '';
+        } else if ('Selected' in data && data['Selected']) {
+            selected = data['Selected'].Name || '';
+        } else {
+            selected = '';
+        }
+
+        return new ViewTitleSelection(dimName, subset, selected);
     }
 
     private constructBody(): Record<string, any> {
@@ -123,7 +163,7 @@ export class ViewTitleSelection {
          * :return: string, the valid JSON
          */
         const bodyAsDict: Record<string, any> = {};
-        
+
         if (this._subset instanceof AnonymousSubset) {
             bodyAsDict['Subset'] = JSON.parse(this._subset.body);
         } else if (this._subset instanceof Subset) {
@@ -135,7 +175,7 @@ export class ViewTitleSelection {
             );
             bodyAsDict['Subset@odata.bind'] = subsetPath;
         }
-        
+
         const elementPath = formatUrl(
             "Dimensions('{}')/Hierarchies('{}')/Elements('{}')",
             this._dimensionName,
@@ -143,7 +183,7 @@ export class ViewTitleSelection {
             this._selected
         );
         bodyAsDict['Selected@odata.bind'] = elementPath;
-        
+
         return bodyAsDict;
     }
 }

--- a/src/objects/Axis.ts
+++ b/src/objects/Axis.ts
@@ -19,7 +19,7 @@ export class ViewAxisSelection extends TM1Object {
         super();
         this._subset = subset;
         this._dimensionName = dimensionName;
-        this._hierarchyName = dimensionName;
+        this._hierarchyName = subset.hierarchyName || dimensionName;
     }
 
     public get subset(): Subset | AnonymousSubset {
@@ -93,7 +93,7 @@ export class ViewTitleSelection {
 
     constructor(dimensionName: string, subset: AnonymousSubset | Subset, selected: string) {
         this._dimensionName = dimensionName;
-        this._hierarchyName = dimensionName;
+        this._hierarchyName = subset.hierarchyName || dimensionName;
         this._subset = subset;
         this._selected = selected;
     }

--- a/src/objects/ElementAttribute.ts
+++ b/src/objects/ElementAttribute.ts
@@ -1,4 +1,5 @@
 import { TM1Object } from './TM1Object';
+import { caseAndSpaceInsensitiveEquals } from '../utils/Utils';
 
 export enum ElementAttributeType {
     NUMERIC = 1,
@@ -102,9 +103,8 @@ export class ElementAttribute extends TM1Object {
 
     public equals(other: TM1Object): boolean {
         if (other instanceof ElementAttribute) {
-            const sameName = this._name.toLowerCase().replace(/\s+/g, '') ===
-                             other._name.toLowerCase().replace(/\s+/g, '');
-            return sameName && this._attributeType === other._attributeType;
+            return caseAndSpaceInsensitiveEquals(this._name, other._name) &&
+                   this._attributeType === other._attributeType;
         }
         return false;
     }

--- a/src/objects/ElementAttribute.ts
+++ b/src/objects/ElementAttribute.ts
@@ -102,8 +102,9 @@ export class ElementAttribute extends TM1Object {
 
     public equals(other: TM1Object): boolean {
         if (other instanceof ElementAttribute) {
-            return this._name.toLowerCase().replace(/\s+/g, '') === 
-                   other._name.toLowerCase().replace(/\s+/g, '');
+            const sameName = this._name.toLowerCase().replace(/\s+/g, '') ===
+                             other._name.toLowerCase().replace(/\s+/g, '');
+            return sameName && this._attributeType === other._attributeType;
         }
         return false;
     }

--- a/src/objects/Hierarchy.ts
+++ b/src/objects/Hierarchy.ts
@@ -1,6 +1,7 @@
 import { TM1Object } from './TM1Object';
 import { Element, ElementType } from './Element';
 import { ElementAttribute } from './ElementAttribute';
+import { lowerAndDropSpaces } from '../utils/Utils';
 
 export class Hierarchy extends TM1Object {
     private _name: string;
@@ -232,27 +233,13 @@ export class Hierarchy extends TM1Object {
             ea.name.toLowerCase() === attributeName.toLowerCase());
     }
 
-    private normalize(name: string): string {
-        return name.toLowerCase().replace(/\s+/g, '');
-    }
-
-    private getChildrenOf(elementName: string): Map<string, number> | undefined {
-        const normalized = this.normalize(elementName);
-        for (const [parent, children] of this._edges) {
-            if (this.normalize(parent) === normalized) {
-                return children;
-            }
-        }
-        return undefined;
-    }
-
     public getAncestors(elementName: string, recursive: boolean = false): string[] {
-        const normalizedTarget = this.normalize(elementName);
+        const normalizedTarget = lowerAndDropSpaces(elementName);
         const directParents: string[] = [];
 
         for (const [parent, children] of this._edges) {
             for (const child of children.keys()) {
-                if (this.normalize(child) === normalizedTarget) {
+                if (lowerAndDropSpaces(child) === normalizedTarget) {
                     directParents.push(parent);
                     break;
                 }
@@ -263,6 +250,7 @@ export class Hierarchy extends TM1Object {
             return directParents;
         }
 
+        // BFS; uses non-recursive call to avoid re-scanning for already-visited ancestors
         const result = new Set<string>(directParents);
         const queue = [...directParents];
         while (queue.length > 0) {
@@ -278,11 +266,11 @@ export class Hierarchy extends TM1Object {
     }
 
     public getDescendants(elementName: string, recursive: boolean = false, leavesOnly: boolean = false): string[] {
-        const normalizedTarget = this.normalize(elementName);
+        const normalizedTarget = lowerAndDropSpaces(elementName);
         const directChildren: string[] = [];
 
         for (const [parent, children] of this._edges) {
-            if (this.normalize(parent) === normalizedTarget) {
+            if (lowerAndDropSpaces(parent) === normalizedTarget) {
                 directChildren.push(...children.keys());
             }
         }
@@ -293,7 +281,8 @@ export class Hierarchy extends TM1Object {
             const queue = [...directChildren];
             while (queue.length > 0) {
                 const current = queue.shift()!;
-                const grandChildren = this.getChildrenOf(current);
+                // current comes directly from stored edge values; use O(1) Map lookup
+                const grandChildren = this._edges.get(current);
                 if (grandChildren) {
                     for (const child of grandChildren.keys()) {
                         if (!seen.has(child)) {
@@ -309,44 +298,38 @@ export class Hierarchy extends TM1Object {
         }
 
         if (leavesOnly) {
-            const allParents = new Set(
-                Array.from(this._edges.keys()).map(p => this.normalize(p))
-            );
-            return result.filter(d => !allParents.has(this.normalize(d)));
+            const allParents = new Set(Array.from(this._edges.keys()).map(lowerAndDropSpaces));
+            return result.filter(d => !allParents.has(lowerAndDropSpaces(d)));
+        }
+        return result;
+    }
+
+    private buildEdgeMap(elements: string[]): Map<string, Map<string, number>> {
+        const result = new Map<string, Map<string, number>>();
+        for (const element of elements) {
+            // elements come from stored edge keys/values; O(1) lookup suffices
+            const children = this._edges.get(element);
+            if (children) {
+                result.set(element, new Map(children));
+            }
         }
         return result;
     }
 
     public getDescendantEdges(elementName: string, recursive: boolean = false): Map<string, Map<string, number>> {
-        const descendants = this.getDescendants(elementName, recursive);
-        const result = new Map<string, Map<string, number>>();
-        for (const descendant of descendants) {
-            const children = this.getChildrenOf(descendant);
-            if (children) {
-                result.set(descendant, new Map(children));
-            }
-        }
-        return result;
+        return this.buildEdgeMap(this.getDescendants(elementName, recursive));
     }
 
     public getAncestorEdges(elementName: string, recursive: boolean = false): Map<string, Map<string, number>> {
-        const ancestors = this.getAncestors(elementName, recursive);
-        const result = new Map<string, Map<string, number>>();
-        for (const ancestor of ancestors) {
-            const children = this.getChildrenOf(ancestor);
-            if (children) {
-                result.set(ancestor, new Map(children));
-            }
-        }
-        return result;
+        return this.buildEdgeMap(this.getAncestors(elementName, recursive));
     }
 
     public replaceElement(oldName: string, newName: string): void {
-        const normalizedOld = this.normalize(oldName);
+        const normalizedOld = lowerAndDropSpaces(oldName);
 
         // Rename in _elements
         const oldKey = Array.from(this._elements.keys()).find(
-            k => this.normalize(k) === normalizedOld
+            k => lowerAndDropSpaces(k) === normalizedOld
         );
         if (oldKey) {
             const element = this._elements.get(oldKey)!;
@@ -358,10 +341,10 @@ export class Hierarchy extends TM1Object {
         // Rebuild edges replacing all occurrences of oldName
         const newEdges = new Map<string, Map<string, number>>();
         for (const [parent, children] of this._edges) {
-            const newParent = this.normalize(parent) === normalizedOld ? newName : parent;
+            const newParent = lowerAndDropSpaces(parent) === normalizedOld ? newName : parent;
             const newChildren = new Map<string, number>();
             for (const [child, weight] of children) {
-                const newChild = this.normalize(child) === normalizedOld ? newName : child;
+                const newChild = lowerAndDropSpaces(child) === normalizedOld ? newName : child;
                 newChildren.set(newChild, weight);
             }
             newEdges.set(newParent, newChildren);

--- a/src/objects/Hierarchy.ts
+++ b/src/objects/Hierarchy.ts
@@ -34,7 +34,9 @@ export class Hierarchy extends TM1Object {
         }
 
         this._elementAttributes = elementAttributes ? [...elementAttributes] : [];
-        this._edges = edges ? new Map(edges) : new Map();
+        this._edges = edges
+            ? new Map(Array.from(edges, ([k, v]) => [k, new Map(v)]))
+            : new Map();
         this._subsets = subsets ? [...subsets] : [];
         this._balanced = structure !== undefined ? structure === 0 : false;
         this._defaultMember = defaultMember;

--- a/src/objects/Hierarchy.ts
+++ b/src/objects/Hierarchy.ts
@@ -1,5 +1,5 @@
 import { TM1Object } from './TM1Object';
-import { Element } from './Element';
+import { Element, ElementType } from './Element';
 import { ElementAttribute } from './ElementAttribute';
 
 export class Hierarchy extends TM1Object {
@@ -7,7 +7,7 @@ export class Hierarchy extends TM1Object {
     private _dimensionName: string;
     private _elements: Map<string, Element> = new Map();
     private _elementAttributes: ElementAttribute[] = [];
-    private _edges: Map<string, number> = new Map();
+    private _edges: Map<string, Map<string, number>> = new Map();
     private _subsets: string[] = [];
     private _balanced: boolean = false;
     private _defaultMember?: string;
@@ -17,7 +17,7 @@ export class Hierarchy extends TM1Object {
         dimensionName: string,
         elements?: Element[],
         elementAttributes?: ElementAttribute[],
-        edges?: Map<string, number>,
+        edges?: Map<string, Map<string, number>>,
         subsets?: string[],
         structure?: number,
         defaultMember?: string
@@ -25,13 +25,13 @@ export class Hierarchy extends TM1Object {
         super();
         this._name = name;
         this._dimensionName = dimensionName;
-        
+
         if (elements) {
             for (const elem of elements) {
                 this._elements.set(elem.name.toLowerCase(), elem);
             }
         }
-        
+
         this._elementAttributes = elementAttributes ? [...elementAttributes] : [];
         this._edges = edges ? new Map(edges) : new Map();
         this._subsets = subsets ? [...subsets] : [];
@@ -40,17 +40,21 @@ export class Hierarchy extends TM1Object {
     }
 
     public static fromDict(hierarchyAsDict: any, dimensionName: string): Hierarchy {
-        const elements = hierarchyAsDict.Elements ? 
+        const elements = hierarchyAsDict.Elements ?
             hierarchyAsDict.Elements.map((e: any) => Element.fromDict(e)) : [];
-        
-        const elementAttributes = hierarchyAsDict.ElementAttributes ? 
+
+        const elementAttributes = hierarchyAsDict.ElementAttributes ?
             hierarchyAsDict.ElementAttributes.map((ea: any) => ElementAttribute.fromDict(ea)) : [];
-        
-        const edges = new Map<string, number>();
+
+        const edges = new Map<string, Map<string, number>>();
         if (hierarchyAsDict.Edges) {
             for (const edge of hierarchyAsDict.Edges) {
-                const key = `${edge.ParentName}:${edge.ComponentName}`;
-                edges.set(key, edge.Weight || 1);
+                const parentName: string = edge.ParentName;
+                const componentName: string = edge.ComponentName;
+                if (!edges.has(parentName)) {
+                    edges.set(parentName, new Map());
+                }
+                edges.get(parentName)!.set(componentName, edge.Weight || 1);
             }
         }
 
@@ -98,7 +102,7 @@ export class Hierarchy extends TM1Object {
         return this._elementAttributes;
     }
 
-    public get edges(): Map<string, number> {
+    public get edges(): Map<string, Map<string, number>> {
         return this._edges;
     }
 
@@ -150,16 +154,17 @@ export class Hierarchy extends TM1Object {
 
     private constructEdges(): any[] {
         const edges: any[] = [];
-        
-        for (const [key, weight] of this._edges) {
-            const [parentName, componentName] = key.split(':');
-            edges.push({
-                ParentName: parentName,
-                ComponentName: componentName,
-                Weight: weight
-            });
+
+        for (const [parentName, children] of this._edges) {
+            for (const [componentName, weight] of children) {
+                edges.push({
+                    ParentName: parentName,
+                    ComponentName: componentName,
+                    Weight: weight
+                });
+            }
         }
-        
+
         return edges;
     }
 
@@ -180,18 +185,26 @@ export class Hierarchy extends TM1Object {
     }
 
     public addEdge(parentName: string, componentName: string, weight: number = 1): void {
-        const key = `${parentName}:${componentName}`;
-        this._edges.set(key, weight);
+        if (!this._edges.has(parentName)) {
+            this._edges.set(parentName, new Map());
+        }
+        this._edges.get(parentName)!.set(componentName, weight);
     }
 
     public removeEdge(parentName: string, componentName: string): boolean {
-        const key = `${parentName}:${componentName}`;
-        return this._edges.delete(key);
+        const children = this._edges.get(parentName);
+        if (children) {
+            const result = children.delete(componentName);
+            if (children.size === 0) {
+                this._edges.delete(parentName);
+            }
+            return result;
+        }
+        return false;
     }
 
     public getEdgeWeight(parentName: string, componentName: string): number | undefined {
-        const key = `${parentName}:${componentName}`;
-        return this._edges.get(key);
+        return this._edges.get(parentName)?.get(componentName);
     }
 
     public addElementAttribute(elementAttribute: ElementAttribute): void {
@@ -199,9 +212,9 @@ export class Hierarchy extends TM1Object {
     }
 
     public removeElementAttribute(attributeName: string): boolean {
-        const index = this._elementAttributes.findIndex(ea => 
+        const index = this._elementAttributes.findIndex(ea =>
             ea.name.toLowerCase() === attributeName.toLowerCase());
-        
+
         if (index !== -1) {
             this._elementAttributes.splice(index, 1);
             return true;
@@ -210,13 +223,161 @@ export class Hierarchy extends TM1Object {
     }
 
     public getElementAttribute(attributeName: string): ElementAttribute | undefined {
-        return this._elementAttributes.find(ea => 
+        return this._elementAttributes.find(ea =>
             ea.name.toLowerCase() === attributeName.toLowerCase());
     }
 
     public hasElementAttribute(attributeName: string): boolean {
-        return this._elementAttributes.some(ea => 
+        return this._elementAttributes.some(ea =>
             ea.name.toLowerCase() === attributeName.toLowerCase());
+    }
+
+    private normalize(name: string): string {
+        return name.toLowerCase().replace(/\s+/g, '');
+    }
+
+    private getChildrenOf(elementName: string): Map<string, number> | undefined {
+        const normalized = this.normalize(elementName);
+        for (const [parent, children] of this._edges) {
+            if (this.normalize(parent) === normalized) {
+                return children;
+            }
+        }
+        return undefined;
+    }
+
+    public getAncestors(elementName: string, recursive: boolean = false): string[] {
+        const normalizedTarget = this.normalize(elementName);
+        const directParents: string[] = [];
+
+        for (const [parent, children] of this._edges) {
+            for (const child of children.keys()) {
+                if (this.normalize(child) === normalizedTarget) {
+                    directParents.push(parent);
+                    break;
+                }
+            }
+        }
+
+        if (!recursive) {
+            return directParents;
+        }
+
+        const result = new Set<string>(directParents);
+        const queue = [...directParents];
+        while (queue.length > 0) {
+            const current = queue.shift()!;
+            for (const ancestor of this.getAncestors(current, false)) {
+                if (!result.has(ancestor)) {
+                    result.add(ancestor);
+                    queue.push(ancestor);
+                }
+            }
+        }
+        return Array.from(result);
+    }
+
+    public getDescendants(elementName: string, recursive: boolean = false, leavesOnly: boolean = false): string[] {
+        const normalizedTarget = this.normalize(elementName);
+        const directChildren: string[] = [];
+
+        for (const [parent, children] of this._edges) {
+            if (this.normalize(parent) === normalizedTarget) {
+                directChildren.push(...children.keys());
+            }
+        }
+
+        let result: string[];
+        if (recursive) {
+            const seen = new Set<string>(directChildren);
+            const queue = [...directChildren];
+            while (queue.length > 0) {
+                const current = queue.shift()!;
+                const grandChildren = this.getChildrenOf(current);
+                if (grandChildren) {
+                    for (const child of grandChildren.keys()) {
+                        if (!seen.has(child)) {
+                            seen.add(child);
+                            queue.push(child);
+                        }
+                    }
+                }
+            }
+            result = Array.from(seen);
+        } else {
+            result = directChildren;
+        }
+
+        if (leavesOnly) {
+            const allParents = new Set(
+                Array.from(this._edges.keys()).map(p => this.normalize(p))
+            );
+            return result.filter(d => !allParents.has(this.normalize(d)));
+        }
+        return result;
+    }
+
+    public getDescendantEdges(elementName: string, recursive: boolean = false): Map<string, Map<string, number>> {
+        const descendants = this.getDescendants(elementName, recursive);
+        const result = new Map<string, Map<string, number>>();
+        for (const descendant of descendants) {
+            const children = this.getChildrenOf(descendant);
+            if (children) {
+                result.set(descendant, new Map(children));
+            }
+        }
+        return result;
+    }
+
+    public getAncestorEdges(elementName: string, recursive: boolean = false): Map<string, Map<string, number>> {
+        const ancestors = this.getAncestors(elementName, recursive);
+        const result = new Map<string, Map<string, number>>();
+        for (const ancestor of ancestors) {
+            const children = this.getChildrenOf(ancestor);
+            if (children) {
+                result.set(ancestor, new Map(children));
+            }
+        }
+        return result;
+    }
+
+    public replaceElement(oldName: string, newName: string): void {
+        const normalizedOld = this.normalize(oldName);
+
+        // Rename in _elements
+        const oldKey = Array.from(this._elements.keys()).find(
+            k => this.normalize(k) === normalizedOld
+        );
+        if (oldKey) {
+            const element = this._elements.get(oldKey)!;
+            element.name = newName;
+            this._elements.delete(oldKey);
+            this._elements.set(newName.toLowerCase(), element);
+        }
+
+        // Rebuild edges replacing all occurrences of oldName
+        const newEdges = new Map<string, Map<string, number>>();
+        for (const [parent, children] of this._edges) {
+            const newParent = this.normalize(parent) === normalizedOld ? newName : parent;
+            const newChildren = new Map<string, number>();
+            for (const [child, weight] of children) {
+                const newChild = this.normalize(child) === normalizedOld ? newName : child;
+                newChildren.set(newChild, weight);
+            }
+            newEdges.set(newParent, newChildren);
+        }
+        this._edges = newEdges;
+    }
+
+    public addComponent(parent: string, component: string, weight: number = 1): void {
+        const parentElement = this.getElement(parent);
+        if (!parentElement) {
+            throw new Error(`Parent element '${parent}' not found in hierarchy`);
+        }
+        if (parentElement.elementType === ElementType.STRING) {
+            throw new Error(`Parent element '${parent}' is of type String and cannot have components`);
+        }
+        this.addEdge(parent, component, weight);
     }
 
     public *[Symbol.iterator](): Iterator<Element> {

--- a/src/objects/MDXView.ts
+++ b/src/objects/MDXView.ts
@@ -8,10 +8,12 @@ export class MDXView extends View {
      */
 
     private _mdx: string;
+    private _dynamicProperties: Record<string, any>;
 
-    constructor(cubeName: string, viewName: string, MDX: string) {
+    constructor(cubeName: string, viewName: string, MDX: string, dynamicProperties?: Record<string, any>) {
         super(cubeName, viewName);
         this._mdx = MDX;
+        this._dynamicProperties = dynamicProperties || {};
     }
 
     public get mdx(): string {
@@ -28,6 +30,14 @@ export class MDXView extends View {
 
     public set MDX(value: string) {
         this._mdx = value;
+    }
+
+    public get dynamicProperties(): Record<string, any> {
+        return this._dynamicProperties;
+    }
+
+    public set dynamicProperties(value: Record<string, any>) {
+        this._dynamicProperties = value;
     }
 
     public get body(): string {
@@ -77,7 +87,8 @@ export class MDXView extends View {
         return new MDXView(
             viewAsDict.Cube?.Name || cubeName!,
             viewAsDict.Name,
-            viewAsDict.MDX
+            viewAsDict.MDX,
+            viewAsDict.Properties || {}
         );
     }
 
@@ -86,6 +97,9 @@ export class MDXView extends View {
         mdxViewAsDict['@odata.type'] = 'ibm.tm1.api.v1.MDXView';
         mdxViewAsDict['Name'] = this._name;
         mdxViewAsDict['MDX'] = this._mdx;
+        if (Object.keys(this._dynamicProperties).length > 0) {
+            mdxViewAsDict['Properties'] = this._dynamicProperties;
+        }
         return JSON.stringify(mdxViewAsDict);
     }
 }

--- a/src/objects/NativeView.ts
+++ b/src/objects/NativeView.ts
@@ -61,9 +61,9 @@ export class NativeView extends View {
     }
 
     public get asMDX(): string {
-        /** Build a valid MDX Query from an Existing cubeview. 
-         * Takes Zero suppression into account. 
-         * Throws an Exception when no elements are place on the columns.
+        /** Build a valid MDX Query from an Existing cubeview.
+         * Takes Zero suppression into account.
+         * Throws an Exception when no elements are placed on the columns.
          * Subsets are referenced in the result-MDX through the TM1SubsetToSet Function
          *
          * :return: String, the MDX Query
@@ -72,63 +72,42 @@ export class NativeView extends View {
             throw new Error("Column selection must not be empty");
         }
 
-        // Basic MDX construction - this would need a full MDX builder implementation
-        let mdx = "SELECT ";
-        
-        // Build column axis
-        const columnSets: string[] = [];
-        for (const columnSelection of this.columns) {
-            const subset = columnSelection.subset;
-            if (subset instanceof AnonymousSubset) {
-                if (subset.expression) {
-                    columnSets.push(subset.expression);
-                } else {
-                    const members = subset.elements.map(e => `[${subset.dimensionName}].[${e}]`);
-                    columnSets.push(`{${members.join(', ')}}`);
-                }
-            } else {
-                columnSets.push(`TM1SubsetToSet([${subset.dimensionName}], "${subset.name}")`);
-            }
-        }
-        
-        if (this._suppressEmptyColumns) {
-            mdx += `NON EMPTY (${columnSets.join(' * ')}) ON COLUMNS`;
-        } else {
-            mdx += `(${columnSets.join(' * ')}) ON COLUMNS`;
-        }
-
-        // Build row axis if exists
-        if (this.rows && this.rows.length > 0) {
-            const rowSets: string[] = [];
-            for (const rowSelection of this.rows) {
-                const subset = rowSelection.subset;
+        const buildAxisMdx = (selections: ViewAxisSelection[], axisOrdinal: number, suppress: boolean): string => {
+            const sets: string[] = [];
+            for (const sel of selections) {
+                const subset = sel.subset;
                 if (subset instanceof AnonymousSubset) {
                     if (subset.expression) {
-                        rowSets.push(subset.expression);
+                        sets.push(subset.expression);
                     } else {
-                        const members = subset.elements.map(e => `[${subset.dimensionName}].[${e}]`);
-                        rowSets.push(`{${members.join(', ')}}`);
+                        const members = subset.elements.map(e =>
+                            `[${subset.dimensionName}].[${subset.hierarchyName}].[${e}]`
+                        );
+                        sets.push(`{${members.join(', ')}}`);
                     }
                 } else {
-                    rowSets.push(`TM1SubsetToSet([${subset.dimensionName}], "${subset.name}")`);
+                    sets.push(`TM1SubsetToSet([${subset.dimensionName}].[${subset.hierarchyName}], "${subset.name}")`);
                 }
             }
-            
-            if (this._suppressEmptyRows) {
-                mdx += `, NON EMPTY (${rowSets.join(' * ')}) ON ROWS`;
-            } else {
-                mdx += `, (${rowSets.join(' * ')}) ON ROWS`;
-            }
+            const combined = sets.join(' * ');
+            const prefix = suppress ? 'NON EMPTY ' : '';
+            return `${prefix}{${combined}} DIMENSION PROPERTIES MEMBER_NAME ON ${axisOrdinal}`;
+        };
+
+        const axisParts: string[] = [];
+        axisParts.push(buildAxisMdx(this.columns, 0, this._suppressEmptyColumns));
+
+        if (this.rows && this.rows.length > 0) {
+            axisParts.push(buildAxisMdx(this.rows, 1, this._suppressEmptyRows));
         }
 
-        mdx += ` FROM [${this.cube}]`;
+        let mdx = `SELECT ${axisParts.join(',\n')} FROM [${this.cube}]`;
 
-        // Add WHERE clause for titles
         if (this.titles && this.titles.length > 0) {
             const titleSelections: string[] = [];
             for (const title of this.titles) {
-                if (title.selected && title.selected.length > 0) {
-                    titleSelections.push(`[${title.dimensionName}].[${title.selected[0]}]`);
+                if (title.selected) {
+                    titleSelections.push(`[${title.dimensionName}].[${title.hierarchyName}].[${title.selected}]`);
                 }
             }
             if (titleSelections.length > 0) {
@@ -155,6 +134,15 @@ export class NativeView extends View {
         this._suppressEmptyRows = value;
     }
 
+    public get suppressEmptyCells(): boolean {
+        return this._suppressEmptyColumns && this._suppressEmptyRows;
+    }
+
+    public set suppressEmptyCells(value: boolean) {
+        this._suppressEmptyColumns = value;
+        this._suppressEmptyRows = value;
+    }
+
     public get formatString(): string {
         return this._formatString;
     }
@@ -176,7 +164,7 @@ export class NativeView extends View {
     }
 
     public removeTitle(dimensionName: string): boolean {
-        const index = this._titles.findIndex(t => 
+        const index = this._titles.findIndex(t =>
             caseAndSpaceInsensitiveEquals(t.dimensionName, dimensionName));
         if (index !== -1) {
             this._titles.splice(index, 1);
@@ -186,7 +174,7 @@ export class NativeView extends View {
     }
 
     public removeColumn(dimensionName: string): boolean {
-        const index = this._columns.findIndex(c => 
+        const index = this._columns.findIndex(c =>
             caseAndSpaceInsensitiveEquals(c.subset.dimensionName, dimensionName));
         if (index !== -1) {
             this._columns.splice(index, 1);
@@ -196,13 +184,28 @@ export class NativeView extends View {
     }
 
     public removeRow(dimensionName: string): boolean {
-        const index = this._rows.findIndex(r => 
+        const index = this._rows.findIndex(r =>
             caseAndSpaceInsensitiveEquals(r.subset.dimensionName, dimensionName));
         if (index !== -1) {
             this._rows.splice(index, 1);
             return true;
         }
         return false;
+    }
+
+    public substituteTitle(dimension: string, element: string): void {
+        /** Substitute the title element for a given dimension
+         *
+         * :param dimension: str, name of dimension
+         * :param element: str, name of element
+         */
+        for (const title of this._titles) {
+            if (caseAndSpaceInsensitiveEquals(title.dimensionName, dimension)) {
+                title.selected = element;
+                return;
+            }
+        }
+        throw new Error(`No title with dimension: '${dimension}'`);
     }
 
     public static fromJSON(viewAsJson: string, cubeName: string): NativeView {
@@ -256,10 +259,10 @@ export class NativeView extends View {
 
         // Add titles
         viewAsDict['Titles'] = this._titles.map(title => title.bodyAsDict);
-        
+
         // Add columns
         viewAsDict['Columns'] = this._columns.map(column => column.bodyAsDict);
-        
+
         // Add rows
         viewAsDict['Rows'] = this._rows.map(row => row.bodyAsDict);
 

--- a/src/services/HierarchyService.ts
+++ b/src/services/HierarchyService.ts
@@ -83,17 +83,17 @@ export class HierarchyService extends ObjectService {
         await this.removeAllEdges(hierarchy.dimensionName, hierarchy.name);
         
         // Add all edges from hierarchy
-        for (const [key, weight] of hierarchy.edges) {
-            const [parentName, componentName] = key.split(':');
-            const edgeBody = {
-                ParentName: parentName,
-                ComponentName: componentName,
-                Weight: weight
-            };
-            
-            const url = this.formatUrl("/Dimensions('{}')/Hierarchies('{}')/Edges", 
-                hierarchy.dimensionName, hierarchy.name);
-            await this.rest.post(url, JSON.stringify(edgeBody));
+        const url = this.formatUrl("/Dimensions('{}')/Hierarchies('{}')/Edges",
+            hierarchy.dimensionName, hierarchy.name);
+        for (const [parentName, children] of hierarchy.edges) {
+            for (const [componentName, weight] of children) {
+                const edgeBody = {
+                    ParentName: parentName,
+                    ComponentName: componentName,
+                    Weight: weight
+                };
+                await this.rest.post(url, JSON.stringify(edgeBody));
+            }
         }
     }
 

--- a/src/services/ViewService.ts
+++ b/src/services/ViewService.ts
@@ -70,7 +70,7 @@ export class ViewService extends ObjectService {
         const viewAsDict = response.data;
         
         if ("MDX" in viewAsDict) {
-            return new MDXView(cubeName, viewName, viewAsDict.MDX);
+            return MDXView.fromDict(viewAsDict, cubeName);
         } else {
             return await this.getNativeView(cubeName, viewName, isPrivate);
         }
@@ -146,7 +146,7 @@ export class ViewService extends ObjectService {
         
         for (const viewDict of response.data.value) {
             if ("MDX" in viewDict) {
-                mdxViews.push(new MDXView(cubeName, viewDict.Name, viewDict.MDX));
+                mdxViews.push(MDXView.fromDict(viewDict, cubeName));
             } else {
                 const nativeView = await this.getNativeView(cubeName, viewDict.Name, false);
                 nativeViews.push(nativeView);

--- a/src/tests/objectModelParity.test.ts
+++ b/src/tests/objectModelParity.test.ts
@@ -57,6 +57,18 @@ describe('ViewAxisSelection.fromDict', () => {
     test('throws when neither Subset nor Subset@odata.bind present', () => {
         expect(() => ViewAxisSelection.fromDict({})).toThrow();
     });
+
+    test('registered subset preserves non-default hierarchy name in constructBody', () => {
+        const dict = {
+            'Subset@odata.bind': "Dimensions('Product')/Hierarchies('Product_Alt')/Subsets('MySubset')"
+        };
+        const sel = ViewAxisSelection.fromDict(dict);
+        expect(sel.dimensionName).toBe('Product');
+        expect((sel.subset as Subset).hierarchyName).toBe('Product_Alt');
+        // constructBody must use the actual hierarchy name
+        const body = sel.bodyAsDict;
+        expect(body['Subset@odata.bind']).toContain("Hierarchies('Product_Alt')");
+    });
 });
 
 describe('ViewTitleSelection.fromDict', () => {
@@ -391,6 +403,45 @@ describe('Hierarchy.getDescendants', () => {
     test('returns empty array for leaf elements', () => {
         const h = buildHierarchy();
         expect(h.getDescendants('North')).toEqual([]);
+    });
+});
+
+describe('Hierarchy.getDescendantEdges and getAncestorEdges', () => {
+    function buildHierarchy(): Hierarchy {
+        const h = new Hierarchy('H', 'D');
+        h.addEdge('Total', 'Region', 1);
+        h.addEdge('Region', 'North', 1);
+        h.addEdge('Region', 'South', 1);
+        return h;
+    }
+
+    test('getDescendantEdges returns edges for direct descendants', () => {
+        const h = buildHierarchy();
+        const edges = h.getDescendantEdges('Total');
+        expect(edges.has('Region')).toBe(true);
+        expect(edges.get('Region')?.get('North')).toBe(1);
+    });
+
+    test('getDescendantEdges returns all descendant edges recursively', () => {
+        const h = buildHierarchy();
+        const edges = h.getDescendantEdges('Total', true);
+        expect(edges.has('Region')).toBe(true);
+        expect(edges.has('North')).toBe(false); // North has no children
+        expect(edges.has('South')).toBe(false);
+    });
+
+    test('getAncestorEdges returns edges for direct ancestors', () => {
+        const h = buildHierarchy();
+        const edges = h.getAncestorEdges('North');
+        expect(edges.has('Region')).toBe(true);
+        expect(edges.get('Region')?.get('North')).toBe(1);
+    });
+
+    test('getAncestorEdges returns all ancestor edges recursively', () => {
+        const h = buildHierarchy();
+        const edges = h.getAncestorEdges('North', true);
+        expect(edges.has('Region')).toBe(true);
+        expect(edges.has('Total')).toBe(true);
     });
 });
 

--- a/src/tests/objectModelParity.test.ts
+++ b/src/tests/objectModelParity.test.ts
@@ -1,0 +1,523 @@
+/**
+ * Object Model Parity Tests — Issue #35
+ * Verifies fixes for 7 critical bugs found during tm1py v2.2.4 parity review.
+ */
+
+import { ViewAxisSelection, ViewTitleSelection } from '../objects/Axis';
+import { AnonymousSubset, Subset } from '../objects/Subset';
+import { NativeView } from '../objects/NativeView';
+import { MDXView } from '../objects/MDXView';
+import { Hierarchy } from '../objects/Hierarchy';
+import { Element, ElementType } from '../objects/Element';
+import { ElementAttribute, ElementAttributeType } from '../objects/ElementAttribute';
+
+// ---------------------------------------------------------------------------
+// Bug 1 & 2 (Axis.ts): ViewAxisSelection.fromDict and ViewTitleSelection.fromDict
+// ---------------------------------------------------------------------------
+
+describe('ViewAxisSelection.fromDict', () => {
+    test('parses anonymous subset with Subset key (expression)', () => {
+        const dict = {
+            Subset: {
+                'Hierarchy@odata.bind': "Dimensions('Region')/Hierarchies('Region')",
+                Expression: '{[Region].[Region].Members}'
+            }
+        };
+        const sel = ViewAxisSelection.fromDict(dict);
+        expect(sel.dimensionName).toBe('Region');
+        expect(sel.subset).toBeInstanceOf(AnonymousSubset);
+        const anon = sel.subset as AnonymousSubset;
+        expect(anon.expression).toBe('{[Region].[Region].Members}');
+    });
+
+    test('parses anonymous subset with Subset key (static elements)', () => {
+        const dict = {
+            Subset: {
+                'Hierarchy@odata.bind': "Dimensions('Month')/Hierarchies('Month')",
+                Elements: [{ Name: 'Jan' }, { Name: 'Feb' }]
+            }
+        };
+        const sel = ViewAxisSelection.fromDict(dict);
+        expect(sel.dimensionName).toBe('Month');
+        const anon = sel.subset as AnonymousSubset;
+        expect(anon.elements).toEqual(['Jan', 'Feb']);
+    });
+
+    test('parses registered subset with Subset@odata.bind key', () => {
+        const dict = {
+            'Subset@odata.bind': "Dimensions('Product')/Hierarchies('Product')/Subsets('AllProducts')"
+        };
+        const sel = ViewAxisSelection.fromDict(dict);
+        expect(sel.dimensionName).toBe('Product');
+        expect(sel.subset).toBeInstanceOf(Subset);
+        expect(sel.subset.name).toBe('AllProducts');
+        expect((sel.subset as Subset).hierarchyName).toBe('Product');
+    });
+
+    test('throws when neither Subset nor Subset@odata.bind present', () => {
+        expect(() => ViewAxisSelection.fromDict({})).toThrow();
+    });
+});
+
+describe('ViewTitleSelection.fromDict', () => {
+    test('parses anonymous subset with Selected@odata.bind', () => {
+        const dict = {
+            Subset: {
+                'Hierarchy@odata.bind': "Dimensions('Region')/Hierarchies('Region')",
+                Elements: [{ Name: 'North' }, { Name: 'South' }]
+            },
+            'Selected@odata.bind': "Dimensions('Region')/Hierarchies('Region')/Elements('North')"
+        };
+        const sel = ViewTitleSelection.fromDict(dict);
+        expect(sel.dimensionName).toBe('Region');
+        expect(sel.selected).toBe('North');
+    });
+
+    test('parses anonymous subset with Selected.Name (expanded)', () => {
+        const dict = {
+            Subset: {
+                'Hierarchy@odata.bind': "Dimensions('Year')/Hierarchies('Year')",
+                Elements: [{ Name: '2024' }]
+            },
+            Selected: { Name: '2024' }
+        };
+        const sel = ViewTitleSelection.fromDict(dict);
+        expect(sel.selected).toBe('2024');
+    });
+
+    test('parses registered subset title', () => {
+        const dict = {
+            'Subset@odata.bind': "Dimensions('Scenario')/Hierarchies('Scenario')/Subsets('ActualOnly')",
+            'Selected@odata.bind': "Dimensions('Scenario')/Hierarchies('Scenario')/Elements('Actual')"
+        };
+        const sel = ViewTitleSelection.fromDict(dict);
+        expect(sel.dimensionName).toBe('Scenario');
+        expect(sel.subset).toBeInstanceOf(Subset);
+        expect(sel.subset.name).toBe('ActualOnly');
+        expect(sel.selected).toBe('Actual');
+    });
+
+    test('selected setter updates value', () => {
+        const subset = new AnonymousSubset('Region', 'Region', undefined, ['North']);
+        const sel = new ViewTitleSelection('Region', subset, 'North');
+        sel.selected = 'South';
+        expect(sel.selected).toBe('South');
+    });
+});
+
+// ---------------------------------------------------------------------------
+// Bug 2 (NativeView.ts): NativeView.asMDX format
+// ---------------------------------------------------------------------------
+
+describe('NativeView.asMDX', () => {
+    test('uses ON 0 and ON 1 instead of ON COLUMNS / ON ROWS', () => {
+        const colSubset = new AnonymousSubset('Month', 'Month', undefined, ['Jan', 'Feb']);
+        const rowSubset = new AnonymousSubset('Region', 'Region', undefined, ['North']);
+        const view = new NativeView('SalesCube', 'TestView');
+        view.addColumn(new ViewAxisSelection('Month', colSubset));
+        view.addRow(new ViewAxisSelection('Region', rowSubset));
+        const mdx = view.asMDX;
+        expect(mdx).toContain('ON 0');
+        expect(mdx).toContain('ON 1');
+        expect(mdx).not.toContain('ON COLUMNS');
+        expect(mdx).not.toContain('ON ROWS');
+    });
+
+    test('wraps axis sets in curly braces', () => {
+        const colSubset = new AnonymousSubset('Month', 'Month', undefined, ['Jan']);
+        const view = new NativeView('Cube', 'View');
+        view.addColumn(new ViewAxisSelection('Month', colSubset));
+        const mdx = view.asMDX;
+        // Should have { ... } DIMENSION PROPERTIES MEMBER_NAME ON 0
+        expect(mdx).toMatch(/\{.*\} DIMENSION PROPERTIES MEMBER_NAME ON 0/);
+    });
+
+    test('uses TM1SubsetToSet with hierarchy argument', () => {
+        const subset = new Subset('AllProducts', 'Product', 'Product');
+        const view = new NativeView('Cube', 'View');
+        view.addColumn(new ViewAxisSelection('Product', subset));
+        const mdx = view.asMDX;
+        expect(mdx).toContain('TM1SubsetToSet([Product].[Product], "AllProducts")');
+        expect(mdx).not.toMatch(/TM1SubsetToSet\(\[Product\], /);
+    });
+
+    test('includes DIMENSION PROPERTIES MEMBER_NAME', () => {
+        const subset = new AnonymousSubset('Month', 'Month', undefined, ['Jan']);
+        const view = new NativeView('Cube', 'View');
+        view.addColumn(new ViewAxisSelection('Month', subset));
+        expect(view.asMDX).toContain('DIMENSION PROPERTIES MEMBER_NAME');
+    });
+
+    test('WHERE clause uses triple-bracket format [dim].[hier].[element]', () => {
+        const colSubset = new AnonymousSubset('Month', 'Month', undefined, ['Jan']);
+        const titleSubset = new AnonymousSubset('Region', 'Region', undefined, ['North']);
+        const view = new NativeView('Cube', 'View');
+        view.addColumn(new ViewAxisSelection('Month', colSubset));
+        view.addTitle(new ViewTitleSelection('Region', titleSubset, 'North'));
+        const mdx = view.asMDX;
+        expect(mdx).toContain('WHERE ([Region].[Region].[North])');
+    });
+
+    test('NON EMPTY prefix applied when suppress flags set', () => {
+        const colSubset = new AnonymousSubset('Month', 'Month', undefined, ['Jan']);
+        const view = new NativeView('Cube', 'View', true, true);
+        view.addColumn(new ViewAxisSelection('Month', colSubset));
+        expect(view.asMDX).toContain('NON EMPTY');
+    });
+
+    test('throws when columns are empty', () => {
+        const view = new NativeView('Cube', 'View');
+        expect(() => view.asMDX).toThrow('Column selection must not be empty');
+    });
+
+    test('uses expression verbatim for anonymous subset with expression', () => {
+        const subset = new AnonymousSubset('Region', 'Region', '{[Region].[Region].Members}');
+        const view = new NativeView('Cube', 'View');
+        view.addColumn(new ViewAxisSelection('Region', subset));
+        const mdx = view.asMDX;
+        expect(mdx).toContain('{[Region].[Region].Members}');
+    });
+});
+
+// ---------------------------------------------------------------------------
+// Bug 3 (NativeView.ts): substituteTitle and suppressEmptyCells
+// ---------------------------------------------------------------------------
+
+describe('NativeView.substituteTitle', () => {
+    test('updates the selected element for a title dimension', () => {
+        const subset = new AnonymousSubset('Region', 'Region', undefined, ['North', 'South']);
+        const view = new NativeView('Cube', 'View');
+        view.addTitle(new ViewTitleSelection('Region', subset, 'North'));
+        view.substituteTitle('Region', 'South');
+        expect(view.titles[0].selected).toBe('South');
+    });
+
+    test('is case and space insensitive for dimension name lookup', () => {
+        const subset = new AnonymousSubset('Region', 'Region', undefined, ['North']);
+        const view = new NativeView('Cube', 'View');
+        view.addTitle(new ViewTitleSelection('Region', subset, 'North'));
+        view.substituteTitle(' region ', 'South');
+        expect(view.titles[0].selected).toBe('South');
+    });
+
+    test('throws when dimension not found in titles', () => {
+        const view = new NativeView('Cube', 'View');
+        expect(() => view.substituteTitle('NonExistent', 'Value')).toThrow();
+    });
+});
+
+describe('NativeView.suppressEmptyCells', () => {
+    test('getter returns true only when both column and row suppress are true', () => {
+        expect(new NativeView('C', 'V', true, true).suppressEmptyCells).toBe(true);
+        expect(new NativeView('C', 'V', true, false).suppressEmptyCells).toBe(false);
+        expect(new NativeView('C', 'V', false, true).suppressEmptyCells).toBe(false);
+        expect(new NativeView('C', 'V', false, false).suppressEmptyCells).toBe(false);
+    });
+
+    test('setter sets both suppressEmptyColumns and suppressEmptyRows', () => {
+        const view = new NativeView('C', 'V');
+        view.suppressEmptyCells = true;
+        expect(view.suppressEmptyColumns).toBe(true);
+        expect(view.suppressEmptyRows).toBe(true);
+        view.suppressEmptyCells = false;
+        expect(view.suppressEmptyColumns).toBe(false);
+        expect(view.suppressEmptyRows).toBe(false);
+    });
+});
+
+// ---------------------------------------------------------------------------
+// NativeView.fromDict round-trip
+// ---------------------------------------------------------------------------
+
+describe('NativeView.fromDict', () => {
+    test('reconstructs a NativeView with registered subsets and titles from API dict', () => {
+        const dict = {
+            Name: 'TestView',
+            SuppressEmptyColumns: true,
+            SuppressEmptyRows: false,
+            FormatString: '0.##',
+            Titles: [
+                {
+                    'Subset@odata.bind': "Dimensions('Scenario')/Hierarchies('Scenario')/Subsets('All')",
+                    'Selected@odata.bind': "Dimensions('Scenario')/Hierarchies('Scenario')/Elements('Actual')"
+                }
+            ],
+            Columns: [
+                {
+                    'Subset@odata.bind': "Dimensions('Month')/Hierarchies('Month')/Subsets('AllMonths')"
+                }
+            ],
+            Rows: [
+                {
+                    Subset: {
+                        'Hierarchy@odata.bind': "Dimensions('Region')/Hierarchies('Region')",
+                        Elements: [{ Name: 'North' }, { Name: 'South' }]
+                    }
+                }
+            ]
+        };
+        const view = NativeView.fromDict(dict, 'SalesCube');
+        expect(view.name).toBe('TestView');
+        expect(view.cube).toBe('SalesCube');
+        expect(view.suppressEmptyColumns).toBe(true);
+        expect(view.suppressEmptyRows).toBe(false);
+        expect(view.titles).toHaveLength(1);
+        expect(view.titles[0].selected).toBe('Actual');
+        expect(view.columns).toHaveLength(1);
+        expect(view.columns[0].subset.name).toBe('AllMonths');
+        expect(view.rows).toHaveLength(1);
+        const rowSubset = view.rows[0].subset as AnonymousSubset;
+        expect(rowSubset.elements).toEqual(['North', 'South']);
+    });
+});
+
+// ---------------------------------------------------------------------------
+// Bug 4 & 5 (Hierarchy.ts): Edge key type + traversal methods
+// ---------------------------------------------------------------------------
+
+describe('Hierarchy edges (Map<string, Map<string, number>>)', () => {
+    test('addEdge stores in nested map structure', () => {
+        const h = new Hierarchy('H', 'D');
+        h.addEdge('Total', 'North', 1);
+        h.addEdge('Total', 'South', 1);
+        const children = h.edges.get('Total');
+        expect(children).toBeDefined();
+        expect(children!.get('North')).toBe(1);
+        expect(children!.get('South')).toBe(1);
+    });
+
+    test('removeEdge removes child and cleans up empty parent', () => {
+        const h = new Hierarchy('H', 'D');
+        h.addEdge('Total', 'North', 1);
+        h.removeEdge('Total', 'North');
+        expect(h.edges.has('Total')).toBe(false);
+    });
+
+    test('getEdgeWeight returns correct weight', () => {
+        const h = new Hierarchy('H', 'D');
+        h.addEdge('Total', 'North', 3);
+        expect(h.getEdgeWeight('Total', 'North')).toBe(3);
+        expect(h.getEdgeWeight('Total', 'Missing')).toBeUndefined();
+    });
+
+    test('fromDict parses edges into nested map', () => {
+        const dict = {
+            Name: 'H',
+            Edges: [
+                { ParentName: 'Total', ComponentName: 'North', Weight: 1 },
+                { ParentName: 'Total', ComponentName: 'South', Weight: 1 }
+            ]
+        };
+        const h = Hierarchy.fromDict(dict, 'D');
+        expect(h.edges.get('Total')?.get('North')).toBe(1);
+        expect(h.edges.get('Total')?.get('South')).toBe(1);
+    });
+
+    test('body serializes edges correctly', () => {
+        const h = new Hierarchy('H', 'D');
+        h.addEdge('Total', 'North', 1);
+        const body = JSON.parse(h.body);
+        expect(body.Edges).toEqual([{ ParentName: 'Total', ComponentName: 'North', Weight: 1 }]);
+    });
+});
+
+describe('Hierarchy.getAncestors', () => {
+    function buildHierarchy(): Hierarchy {
+        const h = new Hierarchy('H', 'D');
+        // Total -> Region -> North
+        //                 -> South
+        h.addEdge('Total', 'Region', 1);
+        h.addEdge('Region', 'North', 1);
+        h.addEdge('Region', 'South', 1);
+        return h;
+    }
+
+    test('returns direct parents only (non-recursive)', () => {
+        const h = buildHierarchy();
+        expect(h.getAncestors('North')).toEqual(['Region']);
+        expect(h.getAncestors('Region')).toEqual(['Total']);
+    });
+
+    test('returns all ancestors recursively', () => {
+        const h = buildHierarchy();
+        const ancestors = h.getAncestors('North', true);
+        expect(ancestors).toContain('Region');
+        expect(ancestors).toContain('Total');
+    });
+
+    test('returns empty array for root elements', () => {
+        const h = buildHierarchy();
+        expect(h.getAncestors('Total')).toEqual([]);
+    });
+
+    test('is case and space insensitive', () => {
+        const h = buildHierarchy();
+        expect(h.getAncestors(' NORTH ')).toEqual(['Region']);
+    });
+});
+
+describe('Hierarchy.getDescendants', () => {
+    function buildHierarchy(): Hierarchy {
+        const h = new Hierarchy('H', 'D');
+        h.addEdge('Total', 'Region', 1);
+        h.addEdge('Region', 'North', 1);
+        h.addEdge('Region', 'South', 1);
+        return h;
+    }
+
+    test('returns direct children (non-recursive)', () => {
+        const h = buildHierarchy();
+        expect(h.getDescendants('Total')).toEqual(['Region']);
+        const regionChildren = h.getDescendants('Region').sort();
+        expect(regionChildren).toEqual(['North', 'South']);
+    });
+
+    test('returns all descendants recursively', () => {
+        const h = buildHierarchy();
+        const all = h.getDescendants('Total', true);
+        expect(all).toContain('Region');
+        expect(all).toContain('North');
+        expect(all).toContain('South');
+    });
+
+    test('leavesOnly returns only leaf elements', () => {
+        const h = buildHierarchy();
+        const leaves = h.getDescendants('Total', true, true);
+        expect(leaves).toContain('North');
+        expect(leaves).toContain('South');
+        expect(leaves).not.toContain('Region');
+    });
+
+    test('returns empty array for leaf elements', () => {
+        const h = buildHierarchy();
+        expect(h.getDescendants('North')).toEqual([]);
+    });
+});
+
+describe('Hierarchy.replaceElement', () => {
+    test('renames element and updates all edge references', () => {
+        const elem = new Element('North', 'Numeric');
+        const h = new Hierarchy('H', 'D', [elem]);
+        h.addEdge('Region', 'North', 1);
+        h.addEdge('North', 'NorthEast', 1);
+
+        h.replaceElement('North', 'NorthRegion');
+
+        // Old name gone from edges
+        expect(h.edges.has('North')).toBe(false);
+        expect(h.edges.get('Region')?.has('North')).toBeFalsy();
+
+        // New name present in edges
+        expect(h.edges.has('NorthRegion')).toBe(true);
+        expect(h.edges.get('Region')?.get('NorthRegion')).toBe(1);
+        expect(h.edges.get('NorthRegion')?.get('NorthEast')).toBe(1);
+    });
+});
+
+describe('Hierarchy.addComponent', () => {
+    test('adds edge when parent exists and is not String type', () => {
+        const parent = new Element('Total', 'Consolidated');
+        const h = new Hierarchy('H', 'D', [parent]);
+        h.addComponent('Total', 'Child1', 1);
+        expect(h.getEdgeWeight('Total', 'Child1')).toBe(1);
+    });
+
+    test('throws when parent element not found', () => {
+        const h = new Hierarchy('H', 'D');
+        expect(() => h.addComponent('NonExistent', 'Child')).toThrow(/not found/);
+    });
+
+    test('throws when parent is of type String', () => {
+        const stringElem = new Element('StringParent', 'String');
+        const h = new Hierarchy('H', 'D', [stringElem]);
+        expect(() => h.addComponent('StringParent', 'Child')).toThrow(/String/);
+    });
+});
+
+// ---------------------------------------------------------------------------
+// Bug 6 (MDXView.ts): dynamicProperties
+// ---------------------------------------------------------------------------
+
+describe('MDXView.dynamicProperties', () => {
+    test('constructor sets dynamicProperties to empty object by default', () => {
+        const view = new MDXView('Cube', 'View', 'SELECT ...');
+        expect(view.dynamicProperties).toEqual({});
+    });
+
+    test('constructor accepts dynamicProperties argument', () => {
+        const props = { Meta: { ExpandAboves: true } };
+        const view = new MDXView('Cube', 'View', 'SELECT ...', props);
+        expect(view.dynamicProperties).toEqual(props);
+    });
+
+    test('fromDict parses Properties key', () => {
+        const dict = {
+            Name: 'V',
+            MDX: 'SELECT ...',
+            Properties: { Aliases: ['Default'] }
+        };
+        const view = MDXView.fromDict(dict, 'Cube');
+        expect(view.dynamicProperties).toEqual({ Aliases: ['Default'] });
+    });
+
+    test('fromDict handles missing Properties gracefully', () => {
+        const view = MDXView.fromDict({ Name: 'V', MDX: 'SELECT ...' }, 'Cube');
+        expect(view.dynamicProperties).toEqual({});
+    });
+
+    test('body includes Properties when dynamicProperties is non-empty', () => {
+        const view = new MDXView('Cube', 'View', 'SELECT ...', { ContextSets: [] });
+        const body = JSON.parse(view.body);
+        expect(body.Properties).toEqual({ ContextSets: [] });
+    });
+
+    test('body omits Properties when dynamicProperties is empty', () => {
+        const view = new MDXView('Cube', 'View', 'SELECT ...');
+        const body = JSON.parse(view.body);
+        expect(body).not.toHaveProperty('Properties');
+    });
+
+    test('dynamicProperties round-trips through body and fromDict', () => {
+        const props = { Meta: true, Aliases: ['Default'] };
+        const original = new MDXView('Cube', 'View', 'SELECT ...', props);
+        const bodyStr = original.body;
+        const restored = MDXView.fromDict(JSON.parse(bodyStr), 'Cube');
+        expect(restored.dynamicProperties).toEqual(props);
+    });
+});
+
+// ---------------------------------------------------------------------------
+// Bug 7 (ElementAttribute.ts): equals() compares name AND type
+// ---------------------------------------------------------------------------
+
+describe('ElementAttribute.equals', () => {
+    test('same name and same type returns true', () => {
+        const a = new ElementAttribute('Revenue', ElementAttributeType.NUMERIC);
+        const b = new ElementAttribute('Revenue', ElementAttributeType.NUMERIC);
+        expect(a.equals(b)).toBe(true);
+    });
+
+    test('same name different type returns false', () => {
+        const a = new ElementAttribute('Revenue', ElementAttributeType.NUMERIC);
+        const b = new ElementAttribute('Revenue', ElementAttributeType.STRING);
+        expect(a.equals(b)).toBe(false);
+    });
+
+    test('different name same type returns false', () => {
+        const a = new ElementAttribute('Revenue', ElementAttributeType.NUMERIC);
+        const b = new ElementAttribute('Cost', ElementAttributeType.NUMERIC);
+        expect(a.equals(b)).toBe(false);
+    });
+
+    test('name comparison is case and space insensitive', () => {
+        const a = new ElementAttribute('My Attr', ElementAttributeType.STRING);
+        const b = new ElementAttribute('myattr', ElementAttributeType.STRING);
+        expect(a.equals(b)).toBe(true);
+    });
+
+    test('returns false when compared to non-ElementAttribute', () => {
+        const a = new ElementAttribute('Revenue', ElementAttributeType.NUMERIC);
+        const b = new Element('Revenue', 'Numeric');
+        expect(a.equals(b)).toBe(false);
+    });
+});

--- a/src/utils/Utils.ts
+++ b/src/utils/Utils.ts
@@ -338,6 +338,13 @@ export function readObjectNameFromUrl(url: string): string {
     return match ? match[1] : '';
 }
 
+export function parseODataBindUrl(url: string): string[] {
+    // Extract all ('name') segments from OData URLs in order
+    // e.g. "Dimensions('D')/Hierarchies('H')/Subsets('S')" -> ['D', 'H', 'S']
+    const matches = [...url.matchAll(/\('([^']+)'\)/g)];
+    return matches.map(m => m[1]);
+}
+
 export function integerizeVersion(version: string): number {
     // Convert version string like "11.8.01300.1" to integer like 1180
     const parts = version.split('.');


### PR DESCRIPTION
## Summary

Fixes 7 critical object model bugs found during tm1py v2.2.4 parity review. All bugs affected serialization/deserialization and downstream service consumers.

### Bugs Fixed

1. **`ViewAxisSelection.fromDict` / `ViewTitleSelection.fromDict` stubbed** — Both returned empty objects. Now correctly parses both anonymous (`Subset` key) and registered (`Subset@odata.bind` key) subsets, extracts element name from `Selected@odata.bind`, and propagates hierarchy name.

2. **`NativeView.asMDX` wrong MDX format** — Fixed: `ON COLUMNS`→`ON 0`, `ON ROWS`→`ON 1`, `(sets)`→`{sets}`, `TM1SubsetToSet([dim], ...)`→`TM1SubsetToSet([dim].[hier], ...)`, added `DIMENSION PROPERTIES MEMBER_NAME`, fixed WHERE clause triple-bracket format.

3. **`NativeView` missing `substituteTitle()` and `suppressEmptyCells`** — Both implemented, matching tm1py behavior.

4. **`Hierarchy` edge keys used `"parent:child"` string keys** — Changed `_edges` from `Map<string, number>` to `Map<string, Map<string, number>>` (nested parent→child→weight map). Deep copy in constructor prevents shared-reference corruption.

5. **`Hierarchy` missing traversal methods** — Added `getAncestors`, `getDescendants`, `getDescendantEdges`, `getAncestorEdges`, `replaceElement`, `addComponent`.

6. **`MDXView` missing `dynamicProperties`** — Added field, constructor param, getter/setter, `fromDict` parsing (`Properties` key), and body serialization. Also updated `ViewService.get()` and `getAll()` to use `MDXView.fromDict()` so `Properties` is preserved end-to-end.

7. **`ElementAttribute.equals()` only compared name** — Now compares both name (case+space insensitive) and `attributeType`.

### Additional

- Added `parseODataBindUrl()` utility for extracting all named segments from OData bind URL strings
- `HierarchyService.updateEdges()` updated for new nested map structure; URL construction hoisted outside loop
- 56 new unit tests covering all 7 bugs

## Test Plan

- [x] `tsc --noEmit` — clean
- [x] 56 new tests in `objectModelParity.test.ts` — all pass
- [x] 1059 total tests passing (2 credential-dependent integration suites pre-existing)

Closes #35