### PR TITLE
fix(SecurityService): getUsersFromGroup wrong type/URL, addUserToGroups N+1, removeUserFromGroup wrong URL (#34)

### DIFF
--- a/src/services/SecurityService.ts
+++ b/src/services/SecurityService.ts
@@ -172,36 +172,44 @@ export class SecurityService extends ObjectService {
         }
     }
 
-    public async getUsersFromGroup(groupName: string): Promise<string[]> {
+    public async getUsersFromGroup(groupName: string): Promise<User[]> {
         /** Get users that belong to a group
          *
          * :param group_name: name of the group
-         * :return: List of user names
+         * :return: List of User instances
          */
         const actualGroupName = await this.determineActualGroupName(groupName);
-        const url = formatUrl("/Groups('{}')/Users?$select=Name", actualGroupName);
+        const url = formatUrl(
+            "/Groups('{}')?$expand=Users($select=Name,FriendlyName,Password,Type,Enabled;$expand=Groups)",
+            actualGroupName
+        );
         const response = await this.rest.get(url);
-        return response.data.value.map((user: any) => user.Name);
+        return (response.data.Users ?? []).map((userDict: any) => User.fromDict(userDict));
     }
 
     public async getUserNamesFromGroup(groupName: string): Promise<string[]> {
-        return await this.getUsersFromGroup(groupName);
+        const users = await this.getUsersFromGroup(groupName);
+        return users.map(user => user.name);
     }
 
-    
-    public async addUserToGroups(userName: string, groupNames: string[]): Promise<AxiosResponse[]> {
-        /** Add user to multiple groups
+
+    public async addUserToGroups(userName: string, groupNames: string[]): Promise<AxiosResponse | undefined> {
+        /** Add user to multiple groups via a single PATCH request
          *
          * :param user_name: name of the user
          * :param group_names: list of group names
-         * :return: list of responses
+         * :return: response
          */
-        const responses: AxiosResponse[] = [];
-        for (const groupName of groupNames) {
-            const response = await this.addUserToGroup(groupName, userName);
-            responses.push(response);
+        if (groupNames.length === 0) {
+            return undefined;
         }
-        return responses;
+        const actualUserName = await this.determineActualUserName(userName);
+        const url = formatUrl("/Users('{}')", actualUserName);
+        const body = {
+            Name: actualUserName,
+            'Groups@odata.bind': groupNames.map(g => formatUrl("Groups('{}')", g))
+        };
+        return await this.rest.patch(url, JSON.stringify(body));
     }
 
     
@@ -232,8 +240,8 @@ export class SecurityService extends ObjectService {
          */
         const actualGroupName = await this.determineActualGroupName(groupName);
         const actualUserName = await this.determineActualUserName(userName);
-        
-        const url = formatUrl("/Groups('{}')/Users('{}')", actualGroupName, actualUserName);
+
+        const url = formatUrl("/Users('{}')/Groups?$id=Groups('{}')", actualUserName, actualGroupName);
         return await this.rest.delete(url);
     }
 

--- a/src/tests/securityService.comprehensive.test.ts
+++ b/src/tests/securityService.comprehensive.test.ts
@@ -275,22 +275,29 @@ describe('SecurityService - Comprehensive Tests', () => {
 
         test('should get users from group', async () => {
             // Mock determineActualGroupName call
-            mockRestService.get.mockResolvedValueOnce(mockResponse({ 
-                value: [{ Name: 'PowerUser' }] 
+            mockRestService.get.mockResolvedValueOnce(mockResponse({
+                value: [{ Name: 'PowerUser' }]
             }));
-            // Mock getUsersFromGroup call
-            const usersData = {
-                value: [
-                    { Name: 'admin' },
-                    { Name: 'poweruser1' },
-                    { Name: 'poweruser2' }
+            // Mock getUsersFromGroup call — expand URL returns Users array on the group object
+            const groupData = {
+                Users: [
+                    { Name: 'admin', FriendlyName: 'admin', Type: '0', Enabled: true, Groups: [{ Name: 'ADMIN' }] },
+                    { Name: 'poweruser1', FriendlyName: 'poweruser1', Type: '0', Enabled: true, Groups: [{ Name: 'PowerUser' }] },
+                    { Name: 'poweruser2', FriendlyName: 'poweruser2', Type: '0', Enabled: true, Groups: [{ Name: 'PowerUser' }] }
                 ]
             };
-            mockRestService.get.mockResolvedValueOnce(mockResponse(usersData));
+            mockRestService.get.mockResolvedValueOnce(mockResponse(groupData));
+
+            const mockUserFromDict = jest.fn().mockImplementation((data: any) => ({ name: data.Name }));
+            (User as any).fromDict = mockUserFromDict;
 
             const result = await securityService.getUsersFromGroup('PowerUser');
-            
-            expect(result).toEqual(['admin', 'poweruser1', 'poweruser2']);
+
+            expect(result).toHaveLength(3);
+            expect(mockUserFromDict).toHaveBeenCalledTimes(3);
+            expect(mockRestService.get).toHaveBeenCalledWith(
+                "/Groups('PowerUser')?$expand=Users($select=Name,FriendlyName,Password,Type,Enabled;$expand=Groups)"
+            );
         });
 
         test('should get groups for user', async () => {
@@ -331,26 +338,25 @@ describe('SecurityService - Comprehensive Tests', () => {
 
     describe('User-Group Relationship Operations', () => {
         test('should add user to multiple groups', async () => {
-            // Mock determineActualGroupName calls for both groups
-            mockRestService.get.mockResolvedValueOnce(mockResponse({ 
-                value: [{ Name: 'PowerUser' }] 
+            // Single determineActualUserName call — no per-group resolution
+            mockRestService.get.mockResolvedValueOnce(mockResponse({
+                value: [{ Name: 'testuser' }]
             }));
-            mockRestService.get.mockResolvedValueOnce(mockResponse({ 
-                value: [{ Name: 'testuser' }] 
-            }));
-            mockRestService.get.mockResolvedValueOnce(mockResponse({ 
-                value: [{ Name: 'DataEntry' }] 
-            }));
-            mockRestService.get.mockResolvedValueOnce(mockResponse({ 
-                value: [{ Name: 'testuser' }] 
-            }));
-            mockRestService.post.mockResolvedValue(mockResponse({}));
+            mockRestService.patch.mockResolvedValue(mockResponse({}));
 
             const groupNames = ['PowerUser', 'DataEntry'];
-            const results = await securityService.addUserToGroups('testuser', groupNames);
-            
-            expect(results).toHaveLength(2);
-            expect(mockRestService.post).toHaveBeenCalledTimes(2);
+            const result = await securityService.addUserToGroups('testuser', groupNames);
+
+            expect(result).toBeDefined();
+            expect(mockRestService.patch).toHaveBeenCalledTimes(1);
+            expect(mockRestService.patch).toHaveBeenCalledWith(
+                "/Users('testuser')",
+                JSON.stringify({
+                    Name: 'testuser',
+                    'Groups@odata.bind': ["Groups('PowerUser')", "Groups('DataEntry')"]
+                })
+            );
+            expect(mockRestService.post).not.toHaveBeenCalled();
         });
 
         test('should add user to single group', async () => {
@@ -371,24 +377,28 @@ describe('SecurityService - Comprehensive Tests', () => {
 
         test('should remove user from group', async () => {
             // Mock determineActualGroupName call
-            mockRestService.get.mockResolvedValueOnce(mockResponse({ 
-                value: [{ Name: 'PowerUser' }] 
+            mockRestService.get.mockResolvedValueOnce(mockResponse({
+                value: [{ Name: 'PowerUser' }]
             }));
             // Mock determineActualUserName call
-            mockRestService.get.mockResolvedValueOnce(mockResponse({ 
-                value: [{ Name: 'testuser' }] 
+            mockRestService.get.mockResolvedValueOnce(mockResponse({
+                value: [{ Name: 'testuser' }]
             }));
             mockRestService.delete.mockResolvedValue(mockResponse({}));
 
             const result = await securityService.removeUserFromGroup('PowerUser', 'testuser');
-            
+
             expect(result).toBeDefined();
+            expect(mockRestService.delete).toHaveBeenCalledWith(
+                "/Users('testuser')/Groups?$id=Groups('PowerUser')"
+            );
         });
 
         test('should handle empty group list when adding user to groups', async () => {
-            const results = await securityService.addUserToGroups('testuser', []);
-            
-            expect(results).toEqual([]);
+            const result = await securityService.addUserToGroups('testuser', []);
+
+            expect(result).toBeUndefined();
+            expect(mockRestService.patch).not.toHaveBeenCalled();
             expect(mockRestService.post).not.toHaveBeenCalled();
         });
     });

--- a/src/tests/securityService.comprehensive.test.ts
+++ b/src/tests/securityService.comprehensive.test.ts
@@ -300,10 +300,28 @@ describe('SecurityService - Comprehensive Tests', () => {
             );
         });
 
+        test('should get user names from group', async () => {
+            mockRestService.get.mockResolvedValueOnce(mockResponse({
+                value: [{ Name: 'PowerUser' }]
+            }));
+            mockRestService.get.mockResolvedValueOnce(mockResponse({
+                Users: [
+                    { Name: 'admin', FriendlyName: 'admin', Type: '0', Enabled: true, Groups: [{ Name: 'ADMIN' }] },
+                    { Name: 'poweruser1', FriendlyName: 'poweruser1', Type: '0', Enabled: true, Groups: [{ Name: 'PowerUser' }] }
+                ]
+            }));
+            const mockUserFromDict = jest.fn().mockImplementation((d: any) => ({ name: d.Name }));
+            (User as any).fromDict = mockUserFromDict;
+
+            const result = await securityService.getUserNamesFromGroup('PowerUser');
+
+            expect(result).toEqual(['admin', 'poweruser1']);
+        });
+
         test('should get groups for user', async () => {
             // Mock determineActualUserName call
-            mockRestService.get.mockResolvedValueOnce(mockResponse({ 
-                value: [{ Name: 'testuser' }] 
+            mockRestService.get.mockResolvedValueOnce(mockResponse({
+                value: [{ Name: 'testuser' }]
             }));
             // Mock getGroups call
             const groupsData = {
@@ -478,10 +496,14 @@ describe('SecurityService - Comprehensive Tests', () => {
 
     describe('Edge Cases and Special Scenarios', () => {
         test('should handle empty results gracefully', async () => {
-            mockRestService.get.mockResolvedValue(mockResponse({ value: [] }));
-
-            // Mock determineActualGroupName to return the input name
+            // Mock determineActualGroupName to bypass name resolution
             jest.spyOn(securityService as any, 'determineActualGroupName').mockResolvedValue('EmptyGroup');
+
+            // getUserNames and getGroupNames use collection endpoints returning { value: [] }
+            mockRestService.get.mockResolvedValueOnce(mockResponse({ value: [] }));
+            mockRestService.get.mockResolvedValueOnce(mockResponse({ value: [] }));
+            // getUsersFromGroup uses expand endpoint returning { Users: [] }
+            mockRestService.get.mockResolvedValueOnce(mockResponse({ Users: [] }));
 
             const userNames = await securityService.getUserNames();
             const groupNames = await securityService.getGroupNames();
@@ -514,19 +536,19 @@ describe('SecurityService - Comprehensive Tests', () => {
         });
 
         test('should handle case sensitivity in group operations', async () => {
-            // Mock determineActualGroupName calls for both groups
-            mockRestService.get.mockResolvedValueOnce(mockResponse({ 
-                value: [{ Name: 'admin' }] 
+            // Each getUsersFromGroup call: 1 GET for determineActualGroupName, 1 GET for expand
+            mockRestService.get.mockResolvedValueOnce(mockResponse({
+                value: [{ Name: 'admin' }]
             }));
-            mockRestService.get.mockResolvedValueOnce(mockResponse({ value: [] }));
-            mockRestService.get.mockResolvedValueOnce(mockResponse({ 
-                value: [{ Name: 'ADMIN' }] 
+            mockRestService.get.mockResolvedValueOnce(mockResponse({ Users: [] }));
+            mockRestService.get.mockResolvedValueOnce(mockResponse({
+                value: [{ Name: 'ADMIN' }]
             }));
-            mockRestService.get.mockResolvedValueOnce(mockResponse({ value: [] }));
+            mockRestService.get.mockResolvedValueOnce(mockResponse({ Users: [] }));
 
             await securityService.getUsersFromGroup('admin');
             await securityService.getUsersFromGroup('ADMIN');
-            
+
             expect(mockRestService.get).toHaveBeenCalledTimes(4);
         });
 


### PR DESCRIPTION
## Summary

Fixes three P1 bugs in `SecurityService` identified in issue #34, achieving parity with tm1py v2.2.4.

### Bug Fixes

**1. `getUsersFromGroup()` — wrong URL and wrong return type**
- Was: `GET /Groups('{}')/Users?$select=Name` → `string[]`
- Now: `GET /Groups('{}')?$expand=Users($select=Name,FriendlyName,Password,Type,Enabled;$expand=Groups)` → `User[]`

**2. `getUserNamesFromGroup()` — incorrect delegation**
- Was: returned raw result of `getUsersFromGroup()` (now `User[]`, would break)
- Now: delegates to `getUsersFromGroup()` and maps `user.name` → `string[]`

**3. `addUserToGroups()` — N requests instead of 1**
- Was: loop calling `addUserToGroup()` once per group (N POST requests)
- Now: single `PATCH /Users('{}')` with `Groups@odata.bind` array; early-return for empty input

**4. `removeUserFromGroup()` — wrong resource URL**
- Was: `DELETE /Groups('{}')/Users('{}')`
- Now: `DELETE /Users('{}')/Groups?$id=Groups('{}')`

## Breaking Changes

- `getUsersFromGroup()` return type: `Promise<string[]>` → `Promise<User[]>`
- `addUserToGroups()` return type: `Promise<AxiosResponse[]>` → `Promise<AxiosResponse | undefined>`

No internal callers affected.

## Test Plan

- [x] `getUsersFromGroup` — asserts correct expand URL and `User[]` return
- [x] `getUserNamesFromGroup` — new test covering delegation and name mapping
- [x] `addUserToGroups` — asserts single PATCH, correct body with `Groups@odata.bind`, no POST calls
- [x] `addUserToGroups` with empty list — asserts early return (no HTTP call)
- [x] `removeUserFromGroup` — asserts correct DELETE URL
- [x] Edge-case empty results — corrected expand mock shape (`{ Users: [] }`)
- [x] Case-sensitivity tests — corrected expand mock shapes

38 tests passing, TypeScript clean.

Closes #34