### PR TITLE
fix(#33): correct executeTiCode and searchStringInCode parity

### DIFF
--- a/src/services/ProcessService.ts
+++ b/src/services/ProcessService.ts
@@ -1,10 +1,11 @@
 import { AxiosResponse } from 'axios';
+import { v4 as uuidv4 } from 'uuid';
 import { RestService } from './RestService';
 import { ObjectService } from './ObjectService';
 import { Process } from '../objects/Process';
 import { ProcessDebugBreakpoint } from '../objects/ProcessDebugBreakpoint';
 import { TM1RestException, TM1Exception } from '../exceptions/TM1Exception';
-import { formatUrl } from '../utils/Utils';
+import { formatUrl, lowerAndDropSpaces } from '../utils/Utils';
 import { OperationStatus, OperationType } from './AsyncOperationService';
 
 export class ProcessService extends ObjectService {
@@ -92,42 +93,25 @@ export class ProcessService extends ObjectService {
     }
 
     public async searchStringInCode(searchString: string, skipControlProcesses: boolean = false): Promise<string[]> {
-        /** Search for a string in all process code
+        /** Search for a string in all process code (server-side OData filter)
          *
-         * :param search_string: string to search for
+         * :param search_string: case insensitive string to search for
          * :param skip_control_processes: bool, True to exclude processes that begin with "}" or "{"
          * :return: List of process names that contain the search string
          */
-        const allProcesses = await this.getAll(skipControlProcesses);
-        const matchingProcesses: string[] = [];
+        const normalized = lowerAndDropSpaces(searchString).replace(/'/g, "''");
+        const fields = ['PrologProcedure', 'MetadataProcedure', 'DataProcedure', 'EpilogProcedure'];
+        const codeFilter = fields
+            .map(f => `contains(tolower(replace(${f},' ','')), '${normalized}')`)
+            .join(' or ');
 
-        for (const process of allProcesses) {
-            if (this.processContainsString(process, searchString)) {
-                matchingProcesses.push(process.name);
-            }
+        let url = `/Processes?$select=Name&$filter=(${codeFilter})`;
+        if (skipControlProcesses) {
+            url += " and (startswith(Name, '}') eq false and startswith(Name, '{') eq false)";
         }
 
-        return matchingProcesses;
-    }
-
-    private processContainsString(process: Process, searchString: string): boolean {
-        /** Check if a process contains a specific string in its code
-         */
-        const codeProperties = [
-            'prologProcedure',
-            'metadataProcedure', 
-            'dataProcedure',
-            'epilogProcedure'
-        ];
-
-        for (const property of codeProperties) {
-            const code = (process as any)[property];
-            if (code && code.toLowerCase().includes(searchString.toLowerCase())) {
-                return true;
-            }
-        }
-
-        return false;
+        const response = await this.rest.get(url);
+        return response.data.value.map((p: { Name: string }) => p.Name);
     }
 
     public async create(process: Process): Promise<AxiosResponse> {
@@ -517,46 +501,40 @@ export class ProcessService extends ObjectService {
     }
 
     public async executeTiCode(
-        linesProlog?: string[],
-        linesMetadata?: string[],
-        linesData?: string[],
+        linesProlog: string[],
         linesEpilog?: string[],
         parameters?: Record<string, any>
     ): Promise<any> {
-        /** Execute TI code directly on TM1 Server with separate sections
+        /** Execute lines of code on the TM1 Server
          *
-         * :param lines_prolog: TI code for prolog section
-         * :param lines_metadata: TI code for metadata section
-         * :param lines_data: TI code for data section
-         * :param lines_epilog: TI code for epilog section
+         * :param lines_prolog: list - where each element is a valid statement of TI code.
+         * :param lines_epilog: list - where each element is a valid statement of TI code.
          * :param parameters: dictionary of parameters
          * :return: execution result
          */
-        const url = "/ExecuteProcessWithReturn";
-        
-        const body: any = {};
-        
-        if (linesProlog && linesProlog.length > 0) {
-            body.PrologProcedure = linesProlog.join('\n');
+        const name = `}TM1py${uuidv4()}`;
+        const p = new Process(
+            name,
+            false,
+            undefined,
+            undefined,
+            undefined,
+            undefined,
+            Process.AUTO_GENERATED_STATEMENTS + linesProlog.join('\r\n'),
+            '',
+            '',
+            linesEpilog ? Process.AUTO_GENERATED_STATEMENTS + linesEpilog.join('\r\n') : ''
+        );
+        await this.create(p);
+        try {
+            return await this.execute(name, parameters);
+        } finally {
+            try {
+                await this.delete(name);
+            } catch (_deleteError) {
+                // Cleanup failure should not mask the original execution error
+            }
         }
-        if (linesMetadata && linesMetadata.length > 0) {
-            body.MetadataProcedure = linesMetadata.join('\n');
-        }
-        if (linesData && linesData.length > 0) {
-            body.DataProcedure = linesData.join('\n');
-        }
-        if (linesEpilog && linesEpilog.length > 0) {
-            body.EpilogProcedure = linesEpilog.join('\n');
-        }
-        
-        if (parameters && Object.keys(parameters).length > 0) {
-            body.Parameters = Object.entries(parameters).map(([name, value]) => ({
-                Name: name,
-                Value: value
-            }));
-        }
-
-        return await this.rest.post(url, JSON.stringify(body));
     }
 
     public async compileSingleStatement(statement: string): Promise<any> {

--- a/src/tests/processService.comprehensive.test.ts
+++ b/src/tests/processService.comprehensive.test.ts
@@ -338,70 +338,65 @@ describe('ProcessService - Comprehensive Tests', () => {
             mockRestService.post.mockResolvedValue(mockResponse({}));
 
             const prologLines = ['sMessage = "Starting";', 'WriteToMessageLog(INFO, sMessage);'];
-            const metadataLines = ['DimensionCreate("TestDim");'];
-            const dataLines = ['CellPutN(100, "TestCube", "Element1");'];
             const epilogLines = ['sMessage = "Completed";', 'WriteToMessageLog(INFO, sMessage);'];
 
-            const result = await processService.executeTiCode(
-                prologLines,
-                metadataLines,
-                dataLines,
-                epilogLines
-            );
-            
+            const result = await processService.executeTiCode(prologLines, epilogLines);
+
             expect(result).toBeDefined();
-            expect(mockRestService.post).toHaveBeenCalledWith(
-                "/ExecuteProcessWithReturn",
-                JSON.stringify({
-                    PrologProcedure: prologLines.join('\n'),
-                    MetadataProcedure: metadataLines.join('\n'),
-                    DataProcedure: dataLines.join('\n'),
-                    EpilogProcedure: epilogLines.join('\n')
-                })
-            );
+            // Should create temp process, execute, then delete
+            expect(mockRestService.post).toHaveBeenCalledTimes(2); // create + execute
+            expect(mockRestService.delete).toHaveBeenCalledTimes(1); // cleanup
+
+            // First call: create temp process (name starts with }TM1py)
+            const createCall = mockRestService.post.mock.calls[0];
+            expect(createCall[0]).toBe('/Processes');
+
+            // Second call: execute
+            const executeCall = mockRestService.post.mock.calls[1];
+            expect(executeCall[0]).toMatch(/\/Processes\('.*'\)\/tm1\.Execute/);
         });
 
         test('should execute TI code with parameters', async () => {
             mockRestService.post.mockResolvedValue(mockResponse({}));
+            mockRestService.delete.mockResolvedValue(mockResponse({}));
 
             const prologLines = ['WriteToMessageLog(INFO, pMessage);'];
             const parameters = { pMessage: 'Test Message', pValue: 123 };
 
-            const result = await processService.executeTiCode(
-                prologLines,
-                undefined,
-                undefined,
-                undefined,
-                parameters
-            );
-            
-            expect(result).toBeDefined();
-            expect(mockRestService.post).toHaveBeenCalledWith(
-                "/ExecuteProcessWithReturn",
-                JSON.stringify({
-                    PrologProcedure: prologLines.join('\n'),
-                    Parameters: [
-                        { Name: 'pMessage', Value: 'Test Message' },
-                        { Name: 'pValue', Value: 123 }
-                    ]
-                })
-            );
+            await processService.executeTiCode(prologLines, undefined, parameters);
+
+            // Execute call should include parameters
+            const executeCall = mockRestService.post.mock.calls[1];
+            const executeBody = JSON.parse(executeCall[1]);
+            expect(executeBody.Parameters).toEqual([
+                { Name: 'pMessage', Value: 'Test Message' },
+                { Name: 'pValue', Value: 123 }
+            ]);
         });
 
-        test('should execute TI code with partial sections', async () => {
+        test('should cleanup temp process even on execution failure', async () => {
+            mockRestService.post
+                .mockResolvedValueOnce(mockResponse({})) // create succeeds
+                .mockRejectedValueOnce(new Error('Execution failed')); // execute fails
+            mockRestService.delete.mockResolvedValue(mockResponse({}));
+
+            await expect(processService.executeTiCode(['sTest = "fail";'])).rejects.toThrow('Execution failed');
+
+            // Delete should still be called for cleanup
+            expect(mockRestService.delete).toHaveBeenCalledTimes(1);
+        });
+
+        test('should execute TI code with prolog only', async () => {
             mockRestService.post.mockResolvedValue(mockResponse({}));
+            mockRestService.delete.mockResolvedValue(mockResponse({}));
 
             const prologLines = ['sTest = "Prolog only";'];
 
             const result = await processService.executeTiCode(prologLines);
-            
+
             expect(result).toBeDefined();
-            expect(mockRestService.post).toHaveBeenCalledWith(
-                "/ExecuteProcessWithReturn",
-                JSON.stringify({
-                    PrologProcedure: prologLines.join('\n')
-                })
-            );
+            expect(mockRestService.post).toHaveBeenCalledTimes(2);
+            expect(mockRestService.delete).toHaveBeenCalledTimes(1);
         });
 
         test('should compile single TI statement', async () => {
@@ -424,57 +419,47 @@ describe('ProcessService - Comprehensive Tests', () => {
     });
 
     describe('Process Search Operations', () => {
-        test('should search string in process code', async () => {
-            const processes = [
-                {
-                    name: 'Process1',
-                    prologProcedure: 'WriteToMessageLog(INFO, "Hello");',
-                    metadataProcedure: '',
-                    dataProcedure: '',
-                    epilogProcedure: ''
-                },
-                {
-                    name: 'Process2',
-                    prologProcedure: 'sMessage = "World";',
-                    metadataProcedure: '',
-                    dataProcedure: '',
-                    epilogProcedure: 'WriteToMessageLog(INFO, sMessage);'
-                },
-                {
-                    name: 'Process3',
-                    prologProcedure: 'CellPutN(100, "Cube", "Element");',
-                    metadataProcedure: '',
-                    dataProcedure: '',
-                    epilogProcedure: ''
-                }
-            ];
-
-            // Mock getAll method
-            jest.spyOn(processService, 'getAll').mockResolvedValue(processes as any);
+        test('should search string in process code using server-side OData filter', async () => {
+            const processData = {
+                value: [
+                    { Name: 'Process1' },
+                    { Name: 'Process2' }
+                ]
+            };
+            mockRestService.get.mockResolvedValue(mockResponse(processData));
 
             const result = await processService.searchStringInCode('WriteToMessageLog');
-            
+
             expect(result).toEqual(['Process1', 'Process2']);
-            expect(processService.getAll).toHaveBeenCalledWith(false);
+            const url = mockRestService.get.mock.calls[0][0];
+            expect(url).toContain('/Processes?$select=Name&$filter=');
+            expect(url).toContain("contains(tolower(replace(PrologProcedure,' ',''))");
+            expect(url).toContain("contains(tolower(replace(MetadataProcedure,' ',''))");
+            expect(url).toContain("contains(tolower(replace(DataProcedure,' ',''))");
+            expect(url).toContain("contains(tolower(replace(EpilogProcedure,' ',''))");
+            expect(url).toContain("'writetomessagelog'");
         });
 
         test('should search string in process code excluding control processes', async () => {
-            const processes = [
-                {
-                    name: 'Process1',
-                    prologProcedure: 'WriteToMessageLog(INFO, "Test");',
-                    metadataProcedure: '',
-                    dataProcedure: '',
-                    epilogProcedure: ''
-                }
-            ];
-
-            jest.spyOn(processService, 'getAll').mockResolvedValue(processes as any);
+            const processData = {
+                value: [{ Name: 'Process1' }]
+            };
+            mockRestService.get.mockResolvedValue(mockResponse(processData));
 
             const result = await processService.searchStringInCode('WriteToMessageLog', true);
-            
+
             expect(result).toEqual(['Process1']);
-            expect(processService.getAll).toHaveBeenCalledWith(true);
+            const url = mockRestService.get.mock.calls[0][0];
+            expect(url).toContain("and (startswith(Name, '}') eq false and startswith(Name, '{') eq false)");
+        });
+
+        test('should escape single quotes in search string', async () => {
+            mockRestService.get.mockResolvedValue(mockResponse({ value: [] }));
+
+            await processService.searchStringInCode("it's a test");
+
+            const url = mockRestService.get.mock.calls[0][0];
+            expect(url).toContain("it''satest");
         });
 
         test('should search string in process names', async () => {
@@ -863,26 +848,19 @@ describe('ProcessService - Comprehensive Tests', () => {
         });
 
         test('should handle search with no matches', async () => {
-            jest.spyOn(processService, 'getAll').mockResolvedValue([]);
+            mockRestService.get.mockResolvedValue(mockResponse({ value: [] }));
 
             const result = await processService.searchStringInCode('NonExistentString');
-            
+
             expect(result).toEqual([]);
         });
 
-        test('should handle large numbers of processes', async () => {
-            const largeProcessList = Array.from({ length: 1000 }, (_, i) => ({
-                name: `Process${i}`,
-                prologProcedure: `WriteToMessageLog(INFO, "Process ${i}");`,
-                metadataProcedure: '',
-                dataProcedure: '',
-                epilogProcedure: ''
-            }));
-
-            jest.spyOn(processService, 'getAll').mockResolvedValue(largeProcessList as any);
+        test('should handle large result sets from searchStringInCode', async () => {
+            const largeResult = Array.from({ length: 1000 }, (_, i) => ({ Name: `Process${i}` }));
+            mockRestService.get.mockResolvedValue(mockResponse({ value: largeResult }));
 
             const result = await processService.searchStringInCode('WriteToMessageLog');
-            
+
             expect(result).toHaveLength(1000);
         });
     });
@@ -1225,8 +1203,6 @@ describe('ProcessService - Comprehensive Tests', () => {
         });
 
         test('should support comprehensive process analysis', async () => {
-            const processes = [mockProcess];
-            jest.spyOn(processService, 'getAll').mockResolvedValue(processes as any);
             mockRestService.get.mockResolvedValue(mockResponse({ value: [] }));
 
             // Analysis workflow: search code, search names, get error logs
@@ -1234,8 +1210,7 @@ describe('ProcessService - Comprehensive Tests', () => {
             await processService.searchStringInName('Test');
             await processService.getErrorLogFilenames();
 
-            expect(processService.getAll).toHaveBeenCalled();
-            expect(mockRestService.get).toHaveBeenCalledTimes(2);
+            expect(mockRestService.get).toHaveBeenCalledTimes(3);
         });
     });
 });

--- a/src/tests/processService.test.ts
+++ b/src/tests/processService.test.ts
@@ -340,47 +340,46 @@ describe('ProcessService Tests', () => {
     });
 
     describe('Process Search Operations', () => {
-        test('should handle searchStringInCode functionality', async () => {
+        test('should use server-side OData filter in searchStringInCode', async () => {
             mockRestService.get.mockResolvedValue(createMockResponse({
                 value: [
-                    { 
-                        Name: 'ProcessWithCode', 
-                        PrologProcedure: 'sMessage = "Hello World";',
-                        HasSecurityAccess: true 
-                    },
-                    { 
-                        Name: 'ProcessWithoutCode', 
-                        PrologProcedure: 'nValue = 123;',
-                        HasSecurityAccess: true 
-                    }
+                    { Name: 'ProcessWithCode' }
                 ]
             }));
 
             const results = await processService.searchStringInCode('Hello');
-            
+
             expect(Array.isArray(results)).toBe(true);
             expect(results.length).toBe(1);
-            expect(results[0]).toBe('ProcessWithCode'); // Returns process name string, not object
-            
-            console.log('✅ Search string in code functionality working');
+            expect(results[0]).toBe('ProcessWithCode');
+            const url = mockRestService.get.mock.calls[0][0];
+            expect(url).toContain('/Processes?$select=Name&$filter=');
+            expect(url).toContain("'hello'");
+
+            console.log('✅ searchStringInCode uses server-side OData filter');
+        });
+
+        test('should include skipControlProcesses filter in searchStringInCode', async () => {
+            mockRestService.get.mockResolvedValue(createMockResponse({ value: [] }));
+
+            await processService.searchStringInCode('test', true);
+
+            const url = mockRestService.get.mock.calls[0][0];
+            expect(url).toContain("startswith(Name, '}') eq false");
+
+            console.log('✅ searchStringInCode includes skipControlProcesses filter');
         });
 
         test('should handle empty search results gracefully', async () => {
             mockRestService.get.mockResolvedValue(createMockResponse({
-                value: [
-                    { 
-                        Name: 'Process1', 
-                        PrologProcedure: 'nValue = 123;',
-                        HasSecurityAccess: true 
-                    }
-                ]
+                value: []
             }));
 
             const results = await processService.searchStringInCode('NonExistentString');
-            
+
             expect(Array.isArray(results)).toBe(true);
             expect(results.length).toBe(0);
-            
+
             console.log('✅ Empty search results handled gracefully');
         });
     });


### PR DESCRIPTION
## Summary

Fixes the remaining 2 parity bugs from issue #33 that were not covered by PR #27. Closes #33.

| Method | Wrong (before) | Correct (after) |
|--------|---------------|-----------------|
| `executeTiCode` | `POST /ExecuteProcessWithReturn` with raw body | Create temp `}TM1py{uuid}` process → `execute` → `delete` in `finally` |
| `searchStringInCode` | Fetches all processes, filters client-side | Server-side OData `$filter` with `contains(tolower(replace(...)))` |

### Additional fixes
- `searchStringInCode`: wraps code filter in parentheses for correct `and`/`or` precedence with `skipControlProcesses`
- `searchStringInCode`: escapes single quotes (`'` → `''`) to prevent OData filter injection
- `executeTiCode`: signature simplified to match tm1py (`linesProlog`, `linesEpilog`, `parameters`)

## Test plan
- [x] 1085 unit tests passing
- [x] TypeScript build clean (`tsc --noEmit`)
- [x] Tests cover: create/execute/delete lifecycle, cleanup on failure, OData URL construction, single-quote escaping, skipControlProcesses filter
- [ ] Integration test against live TM1 server (manual)