### PR TITLE
fix(#28): SubsetService defaults, ApplicationService methods, SessionService filter

### DIFF
--- a/src/services/ApplicationService.ts
+++ b/src/services/ApplicationService.ts
@@ -38,7 +38,7 @@ export class ApplicationService extends ObjectService {
     public async getNames(path: string, isPrivate: boolean = false): Promise<string[]> {
         const contents = this.getContentsCollection(isPrivate);
         const mid = this.buildPathSegments(path);
-        const baseUrl = "/api/v1/Contents('Applications')" + mid + "/" + contents;
+        const baseUrl = "/Contents('Applications')" + mid + "/" + contents;
         const response = await this.rest.get(baseUrl);
         return response.data.value.map((application: any) => application.Name);
     }
@@ -182,7 +182,7 @@ export class ApplicationService extends ObjectService {
                 "/Contents('Applications')" + mid + "/" + contents + "('{}')/Document/Content",
                 requestName
             );
-            return await this.rest.patch(url, application.content, {
+            return await this.rest.post(url, application.content, {
                 headers: this.binaryHttpHeader
             } as AxiosRequestConfig);
         }
@@ -191,7 +191,7 @@ export class ApplicationService extends ObjectService {
             "/Contents('Applications')" + mid + "/" + contents + "('{}')",
             requestName
         );
-        return await this.rest.patch(url, application.body);
+        return await this.rest.post(url, application.body);
     }
 
     public async delete(

--- a/src/services/SessionService.ts
+++ b/src/services/SessionService.ts
@@ -40,7 +40,7 @@ export class SessionService extends ObjectService {
     }
 
     public async getThreadsForCurrent(excludeIdle: boolean = true): Promise<any[]> {
-        let url = "/ActiveSession/Threads?$filter=Function ne 'GET /ActiveSession/Threads'";
+        let url = "/ActiveSession/Threads?$filter=Function ne 'GET /api/v1/ActiveSession/Threads'";
         if (excludeIdle) {
             url += " and State ne 'Idle'";
         }

--- a/src/services/SubsetService.ts
+++ b/src/services/SubsetService.ts
@@ -61,7 +61,7 @@ export class SubsetService extends ObjectService {
         dimensionName: string,
         hierarchyName: string,
         subsetName: string,
-        isPrivate: boolean = true
+        isPrivate: boolean = false
     ): Promise<any> {
         const visibility = this.getSubsetCollection(isPrivate);
         const url = this.formatUrl(
@@ -118,7 +118,7 @@ export class SubsetService extends ObjectService {
         dimensionName: string,
         hierarchyName: string,
         subsetName: string,
-        isPrivate: boolean = true
+        isPrivate: boolean = false
     ): Promise<AxiosResponse> {
         const visibility = this.getSubsetCollection(isPrivate);
         const url = this.formatUrl(
@@ -135,7 +135,7 @@ export class SubsetService extends ObjectService {
         dimensionName: string,
         hierarchyName: string,
         subsetName: string,
-        isPrivate: boolean = true
+        isPrivate: boolean = false
     ): Promise<boolean> {
         const visibility = this.getSubsetCollection(isPrivate);
         const url = this.formatUrl(
@@ -160,7 +160,7 @@ export class SubsetService extends ObjectService {
     public async getAllNames(
         dimensionName: string,
         hierarchyName: string,
-        isPrivate: boolean = true
+        isPrivate: boolean = false
     ): Promise<string[]> {
         const visibility = this.getSubsetCollection(isPrivate);
         const url = this.formatUrl(

--- a/src/tests/bugfix28.test.ts
+++ b/src/tests/bugfix28.test.ts
@@ -1,0 +1,236 @@
+/**
+ * Bug fix tests for issue #28 (epic)
+ *
+ * Bug #10 - SubsetService: isPrivate defaults to false (matching tm1py)
+ * Bug #11 - ApplicationService: update() uses POST not PATCH
+ * Bug #12 - ApplicationService: getNames() does not inject /api/v1/ prefix
+ * Bug #13 - SessionService: getThreadsForCurrent() includes /api/v1/ in filter
+ */
+
+import { SubsetService } from '../services/SubsetService';
+import { ApplicationService } from '../services/ApplicationService';
+import { SessionService } from '../services/SessionService';
+import { RestService } from '../services/RestService';
+import { Subset } from '../objects/Subset';
+import { CubeApplication, ApplicationTypes } from '../objects/Application';
+
+const createMockResponse = (data: any, status: number = 200) => ({
+    data,
+    status,
+    statusText: 'OK',
+    headers: {},
+    config: {} as any
+});
+
+function createMockRestService(): jest.Mocked<RestService> {
+    return {
+        get: jest.fn(),
+        post: jest.fn(),
+        patch: jest.fn(),
+        delete: jest.fn(),
+        put: jest.fn(),
+        version: '12.0.0',
+        config: {} as any,
+        rest: {} as any,
+        buildBaseUrl: jest.fn(),
+        extractErrorMessage: jest.fn()
+    } as any;
+}
+
+describe('Bug #10 - SubsetService isPrivate defaults to false', () => {
+    let subsetService: SubsetService;
+    let mockRest: jest.Mocked<RestService>;
+
+    beforeEach(() => {
+        mockRest = createMockRestService();
+        subsetService = new SubsetService(mockRest);
+    });
+
+    test('get() should default isPrivate to false and use Subsets collection', async () => {
+        mockRest.get.mockResolvedValue(createMockResponse({ Name: 'TestSubset' }));
+
+        await subsetService.get('Dim1', 'Hier1', 'TestSubset');
+
+        const calledUrl = mockRest.get.mock.calls[0][0] as string;
+        expect(calledUrl).toContain('/Subsets(');
+        expect(calledUrl).not.toContain('/PrivateSubsets(');
+    });
+
+    test('get() with isPrivate=true should use PrivateSubsets collection', async () => {
+        mockRest.get.mockResolvedValue(createMockResponse({ Name: 'TestSubset' }));
+
+        await subsetService.get('Dim1', 'Hier1', 'TestSubset', true);
+
+        const calledUrl = mockRest.get.mock.calls[0][0] as string;
+        expect(calledUrl).toContain('/PrivateSubsets(');
+    });
+
+    test('delete() should default isPrivate to false and use Subsets collection', async () => {
+        mockRest.delete.mockResolvedValue(createMockResponse({}, 204));
+
+        await subsetService.delete('Dim1', 'Hier1', 'TestSubset');
+
+        const calledUrl = mockRest.delete.mock.calls[0][0] as string;
+        expect(calledUrl).toContain('/Subsets(');
+        expect(calledUrl).not.toContain('/PrivateSubsets(');
+    });
+
+    test('exists() should default isPrivate to false and use Subsets collection', async () => {
+        mockRest.get.mockResolvedValue(createMockResponse({ Name: 'TestSubset' }));
+
+        await subsetService.exists('Dim1', 'Hier1', 'TestSubset');
+
+        const calledUrl = mockRest.get.mock.calls[0][0] as string;
+        expect(calledUrl).toContain('/Subsets(');
+        expect(calledUrl).not.toContain('/PrivateSubsets(');
+    });
+
+    test('getAllNames() should default isPrivate to false and use Subsets collection', async () => {
+        mockRest.get.mockResolvedValue(createMockResponse({ value: [{ Name: 'Sub1' }] }));
+
+        await subsetService.getAllNames('Dim1', 'Hier1');
+
+        const calledUrl = mockRest.get.mock.calls[0][0] as string;
+        expect(calledUrl).toContain('/Subsets?');
+        expect(calledUrl).not.toContain('/PrivateSubsets?');
+    });
+
+    test('getAllNames() with isPrivate=true should use PrivateSubsets', async () => {
+        mockRest.get.mockResolvedValue(createMockResponse({ value: [{ Name: 'Sub1' }] }));
+
+        await subsetService.getAllNames('Dim1', 'Hier1', true);
+
+        const calledUrl = mockRest.get.mock.calls[0][0] as string;
+        expect(calledUrl).toContain('/PrivateSubsets?');
+    });
+});
+
+describe('Bug #11 - ApplicationService update() uses POST not PATCH', () => {
+    let appService: ApplicationService;
+    let mockRest: jest.Mocked<RestService>;
+
+    beforeEach(() => {
+        mockRest = createMockRestService();
+        appService = new ApplicationService(mockRest);
+    });
+
+    test('update() should call rest.post for non-document applications', async () => {
+        const app = new CubeApplication('', 'TestApp', 'SalesCube');
+        mockRest.post.mockResolvedValue(createMockResponse({}, 200));
+
+        await appService.update(app);
+
+        expect(mockRest.post).toHaveBeenCalledTimes(1);
+        expect(mockRest.patch).not.toHaveBeenCalled();
+    });
+
+    test('update() should use POST on the correct URL', async () => {
+        const app = new CubeApplication('Planning', 'TestApp', 'SalesCube');
+        mockRest.post.mockResolvedValue(createMockResponse({}, 200));
+
+        await appService.update(app);
+
+        const calledUrl = mockRest.post.mock.calls[0][0] as string;
+        expect(calledUrl).toContain("/Contents('Applications')");
+        expect(calledUrl).toContain("/Contents('Planning')");
+        expect(calledUrl).toContain("/Contents('TestApp')");
+    });
+});
+
+describe('Bug #12 - ApplicationService getNames() should not inject /api/v1/ prefix', () => {
+    let appService: ApplicationService;
+    let mockRest: jest.Mocked<RestService>;
+
+    beforeEach(() => {
+        mockRest = createMockRestService();
+        appService = new ApplicationService(mockRest);
+    });
+
+    test('getNames() URL should not contain /api/v1/', async () => {
+        mockRest.get.mockResolvedValue(createMockResponse({ value: [{ Name: 'App1' }] }));
+
+        await appService.getNames('Planning');
+
+        const calledUrl = mockRest.get.mock.calls[0][0] as string;
+        expect(calledUrl).not.toContain('/api/v1/');
+        expect(calledUrl).toMatch(/^\/Contents\('Applications'\)/);
+    });
+
+    test('getNames() URL format should match other methods in the service', async () => {
+        mockRest.get.mockResolvedValue(createMockResponse({ value: [{ Name: 'App1' }] }));
+
+        await appService.getNames('Planning', false);
+
+        const calledUrl = mockRest.get.mock.calls[0][0] as string;
+        expect(calledUrl).toBe("/Contents('Applications')/Contents('Planning')/Contents");
+    });
+
+    test('getNames() with isPrivate should use PrivateContents', async () => {
+        mockRest.get.mockResolvedValue(createMockResponse({ value: [{ Name: 'App1' }] }));
+
+        await appService.getNames('Planning', true);
+
+        const calledUrl = mockRest.get.mock.calls[0][0] as string;
+        expect(calledUrl).not.toContain('/api/v1/');
+        expect(calledUrl).toBe("/Contents('Applications')/Contents('Planning')/PrivateContents");
+    });
+
+    test('getNames() with empty path', async () => {
+        mockRest.get.mockResolvedValue(createMockResponse({ value: [{ Name: 'App1' }] }));
+
+        await appService.getNames('');
+
+        const calledUrl = mockRest.get.mock.calls[0][0] as string;
+        expect(calledUrl).not.toContain('/api/v1/');
+        expect(calledUrl).toBe("/Contents('Applications')/Contents");
+    });
+});
+
+describe('Bug #13 - SessionService getThreadsForCurrent() filter condition', () => {
+    let sessionService: SessionService;
+    let mockRest: jest.Mocked<RestService>;
+
+    beforeEach(() => {
+        mockRest = createMockRestService();
+        sessionService = new SessionService(mockRest);
+    });
+
+    test('getThreadsForCurrent() should include /api/v1/ in the filter Function value', async () => {
+        mockRest.get.mockResolvedValue(createMockResponse({ value: [] }));
+
+        await sessionService.getThreadsForCurrent();
+
+        const calledUrl = mockRest.get.mock.calls[0][0] as string;
+        expect(calledUrl).toContain("Function ne 'GET /api/v1/ActiveSession/Threads'");
+    });
+
+    test('getThreadsForCurrent() with excludeIdle=true should add State filter', async () => {
+        mockRest.get.mockResolvedValue(createMockResponse({ value: [] }));
+
+        await sessionService.getThreadsForCurrent(true);
+
+        const calledUrl = mockRest.get.mock.calls[0][0] as string;
+        expect(calledUrl).toContain("Function ne 'GET /api/v1/ActiveSession/Threads'");
+        expect(calledUrl).toContain("and State ne 'Idle'");
+    });
+
+    test('getThreadsForCurrent() with excludeIdle=false should not add State filter', async () => {
+        mockRest.get.mockResolvedValue(createMockResponse({ value: [] }));
+
+        await sessionService.getThreadsForCurrent(false);
+
+        const calledUrl = mockRest.get.mock.calls[0][0] as string;
+        expect(calledUrl).toContain("Function ne 'GET /api/v1/ActiveSession/Threads'");
+        expect(calledUrl).not.toContain("State ne 'Idle'");
+    });
+
+    test('getThreadsForCurrent() URL path should NOT include /api/v1/ prefix', async () => {
+        mockRest.get.mockResolvedValue(createMockResponse({ value: [] }));
+
+        await sessionService.getThreadsForCurrent();
+
+        const calledUrl = mockRest.get.mock.calls[0][0] as string;
+        // The URL path itself should start with /ActiveSession, not /api/v1/ActiveSession
+        expect(calledUrl).toMatch(/^\/ActiveSession\/Threads/);
+    });
+});


### PR DESCRIPTION
## Summary

Fixes 4 bugs from epic issue #28, ensuring tm1py parity:

- **Bug #10** — `SubsetService`: Changed `isPrivate` default from `true` to `false` in `get()`, `delete()`, `exists()`, and `getAllNames()` to match tm1py's `private=False` default
- **Bug #11** — `ApplicationService`: Changed `update()` to use `POST` instead of `PATCH`, matching tm1py's `self._rest.POST()` semantics
- **Bug #12** — `ApplicationService`: Removed erroneous `/api/v1/` prefix from `getNames()` URL — the `RestService` adds the base path automatically, so this was being doubled
- **Bug #13** — `SessionService`: Added `/api/v1/` prefix to the filter value in `getThreadsForCurrent()` (`Function ne 'GET /api/v1/ActiveSession/Threads'`), matching how TM1 server records function names in thread metadata

## Files Changed

| File | Change |
|------|--------|
| `src/services/SubsetService.ts` | `isPrivate` default `true` → `false` in 4 methods |
| `src/services/ApplicationService.ts` | `update()` `PATCH` → `POST`; `getNames()` remove `/api/v1/` |
| `src/services/SessionService.ts` | Filter string includes `/api/v1/` prefix |
| `src/tests/bugfix28.test.ts` | 16 new unit tests covering all 4 fixes |

## Test Plan

- [x] `tsc --noEmit` passes with zero errors
- [x] All 16 new tests in `bugfix28.test.ts` pass
- [x] All 17 existing tests in `subsetService.test.ts` pass (no regressions)
- [ ] Integration testing against TM1 server (requires credentials)

Closes #28