### PR TITLE
fix(#32,#52): correct ElementService parity with tm1py v2.2.4

### DIFF
--- a/src/services/ElementService.ts
+++ b/src/services/ElementService.ts
@@ -119,7 +119,7 @@ export class ElementService extends ObjectService {
         let url = formatUrl("/Dimensions('{}')/Hierarchies('{}')/Elements?$select=Name", dimensionName, hierarchy);
 
         if (skipConsolidatedElements) {
-            url += "&$filter=Type ne 3";
+            url += `&$filter=Type ne ${ElementType.CONSOLIDATED}`;
         }
 
         const response = await this.rest.get(url);
@@ -163,7 +163,7 @@ export class ElementService extends ObjectService {
     ): Promise<Element[]> {
         const hierarchy = hierarchyName || dimensionName;
         const url = formatUrl(
-            "/Dimensions('{}')/Hierarchies('{}')/Elements?$expand=*&$filter=Type ne 3",
+            `/Dimensions('{}')/Hierarchies('{}')/Elements?$expand=*&$filter=Type ne ${ElementType.CONSOLIDATED}`,
             dimensionName, hierarchy
         );
         const response = await this.rest.get(url);
@@ -179,7 +179,7 @@ export class ElementService extends ObjectService {
     ): Promise<string[]> {
         const hierarchy = hierarchyName || dimensionName;
         const url = formatUrl(
-            "/Dimensions('{}')/Hierarchies('{}')/Elements?$select=Name&$filter=Type ne 3",
+            `/Dimensions('{}')/Hierarchies('{}')/Elements?$select=Name&$filter=Type ne ${ElementType.CONSOLIDATED}`,
             dimensionName, hierarchy
         );
         const response = await this.rest.get(url);
@@ -195,7 +195,7 @@ export class ElementService extends ObjectService {
     ): Promise<Element[]> {
         const hierarchy = hierarchyName || dimensionName;
         const url = formatUrl(
-            "/Dimensions('{}')/Hierarchies('{}')/Elements?$expand=*&$filter=Type eq 3",
+            `/Dimensions('{}')/Hierarchies('{}')/Elements?$expand=*&$filter=Type eq ${ElementType.CONSOLIDATED}`,
             dimensionName, hierarchy
         );
         const response = await this.rest.get(url);
@@ -211,7 +211,7 @@ export class ElementService extends ObjectService {
     ): Promise<string[]> {
         const hierarchy = hierarchyName || dimensionName;
         const url = formatUrl(
-            "/Dimensions('{}')/Hierarchies('{}')/Elements?$select=Name&$filter=Type eq 3",
+            `/Dimensions('{}')/Hierarchies('{}')/Elements?$select=Name&$filter=Type eq ${ElementType.CONSOLIDATED}`,
             dimensionName, hierarchy
         );
         const response = await this.rest.get(url);
@@ -227,7 +227,7 @@ export class ElementService extends ObjectService {
     ): Promise<Element[]> {
         const hierarchy = hierarchyName || dimensionName;
         const url = formatUrl(
-            "/Dimensions('{}')/Hierarchies('{}')/Elements?$expand=*&$filter=Type eq 1",
+            `/Dimensions('{}')/Hierarchies('{}')/Elements?$expand=*&$filter=Type eq ${ElementType.NUMERIC}`,
             dimensionName, hierarchy
         );
         const response = await this.rest.get(url);
@@ -243,7 +243,7 @@ export class ElementService extends ObjectService {
     ): Promise<string[]> {
         const hierarchy = hierarchyName || dimensionName;
         const url = formatUrl(
-            "/Dimensions('{}')/Hierarchies('{}')/Elements?$select=Name&$filter=Type eq 1",
+            `/Dimensions('{}')/Hierarchies('{}')/Elements?$select=Name&$filter=Type eq ${ElementType.NUMERIC}`,
             dimensionName, hierarchy
         );
         const response = await this.rest.get(url);
@@ -259,7 +259,7 @@ export class ElementService extends ObjectService {
     ): Promise<Element[]> {
         const hierarchy = hierarchyName || dimensionName;
         const url = formatUrl(
-            "/Dimensions('{}')/Hierarchies('{}')/Elements?$expand=*&$filter=Type eq 2",
+            `/Dimensions('{}')/Hierarchies('{}')/Elements?$expand=*&$filter=Type eq ${ElementType.STRING}`,
             dimensionName, hierarchy
         );
         const response = await this.rest.get(url);
@@ -275,7 +275,7 @@ export class ElementService extends ObjectService {
     ): Promise<string[]> {
         const hierarchy = hierarchyName || dimensionName;
         const url = formatUrl(
-            "/Dimensions('{}')/Hierarchies('{}')/Elements?$select=Name&$filter=Type eq 2",
+            `/Dimensions('{}')/Hierarchies('{}')/Elements?$select=Name&$filter=Type eq ${ElementType.STRING}`,
             dimensionName, hierarchy
         );
         const response = await this.rest.get(url);
@@ -338,7 +338,7 @@ export class ElementService extends ObjectService {
 
         // Add consolidation filter if requested
         if (skip_consolidations) {
-            const filter = "Type ne 3";
+            const filter = `Type ne ${ElementType.CONSOLIDATED}`;
             url += url.includes('?') ? `&$filter=${filter}` : `?$filter=${filter}`;
         }
 
@@ -870,7 +870,7 @@ export class ElementService extends ObjectService {
             dimensionName, hierarchy);
 
         if (skipConsolidatedElements) {
-            url += "?$filter=Type ne 3";
+            url += `?$filter=Type ne ${ElementType.CONSOLIDATED}`;
         }
 
         const response = await this.rest.get(url);

--- a/src/services/ElementService.ts
+++ b/src/services/ElementService.ts
@@ -329,17 +329,19 @@ export class ElementService extends ObjectService {
             url += '?$expand=Parents($select=Name)';
         }
 
-        // Add element filter if specified
+        // Build combined filter
+        const filters: string[] = [];
         if (elements) {
             const elementArray = Array.isArray(elements) ? elements : [elements];
-            const filter = elementArray.map(e => `Name eq '${e}'`).join(' or ');
-            url += url.includes('?') ? `&$filter=(${filter})` : `?$filter=(${filter})`;
+            filters.push(`(${elementArray.map(e => `Name eq '${e.replace(/'/g, "''")}'`).join(' or ')})`);
         }
-
-        // Add consolidation filter if requested
         if (skip_consolidations) {
-            const filter = `Type ne ${ElementType.CONSOLIDATED}`;
-            url += url.includes('?') ? `&$filter=${filter}` : `?$filter=${filter}`;
+            filters.push(`Type ne ${ElementType.CONSOLIDATED}`);
+        }
+        if (filters.length > 0) {
+            url += url.includes('?')
+                ? `&$filter=${filters.join(' and ')}`
+                : `?$filter=${filters.join(' and ')}`;
         }
 
         const response = await this.rest.get(url);

--- a/src/services/ElementService.ts
+++ b/src/services/ElementService.ts
@@ -119,7 +119,7 @@ export class ElementService extends ObjectService {
         let url = formatUrl("/Dimensions('{}')/Hierarchies('{}')/Elements?$select=Name", dimensionName, hierarchy);
 
         if (skipConsolidatedElements) {
-            url += "&$filter=Type ne 'Consolidated'";
+            url += "&$filter=Type ne 3";
         }
 
         const response = await this.rest.get(url);
@@ -163,7 +163,7 @@ export class ElementService extends ObjectService {
     ): Promise<Element[]> {
         const hierarchy = hierarchyName || dimensionName;
         const url = formatUrl(
-            "/Dimensions('{}')/Hierarchies('{}')/Elements?$expand=*&$filter=Type ne 'Consolidated'",
+            "/Dimensions('{}')/Hierarchies('{}')/Elements?$expand=*&$filter=Type ne 3",
             dimensionName, hierarchy
         );
         const response = await this.rest.get(url);
@@ -179,7 +179,7 @@ export class ElementService extends ObjectService {
     ): Promise<string[]> {
         const hierarchy = hierarchyName || dimensionName;
         const url = formatUrl(
-            "/Dimensions('{}')/Hierarchies('{}')/Elements?$select=Name&$filter=Type ne 'Consolidated'",
+            "/Dimensions('{}')/Hierarchies('{}')/Elements?$select=Name&$filter=Type ne 3",
             dimensionName, hierarchy
         );
         const response = await this.rest.get(url);
@@ -195,7 +195,7 @@ export class ElementService extends ObjectService {
     ): Promise<Element[]> {
         const hierarchy = hierarchyName || dimensionName;
         const url = formatUrl(
-            "/Dimensions('{}')/Hierarchies('{}')/Elements?$expand=*&$filter=Type eq 'Consolidated'",
+            "/Dimensions('{}')/Hierarchies('{}')/Elements?$expand=*&$filter=Type eq 3",
             dimensionName, hierarchy
         );
         const response = await this.rest.get(url);
@@ -211,7 +211,7 @@ export class ElementService extends ObjectService {
     ): Promise<string[]> {
         const hierarchy = hierarchyName || dimensionName;
         const url = formatUrl(
-            "/Dimensions('{}')/Hierarchies('{}')/Elements?$select=Name&$filter=Type eq 'Consolidated'",
+            "/Dimensions('{}')/Hierarchies('{}')/Elements?$select=Name&$filter=Type eq 3",
             dimensionName, hierarchy
         );
         const response = await this.rest.get(url);
@@ -227,7 +227,7 @@ export class ElementService extends ObjectService {
     ): Promise<Element[]> {
         const hierarchy = hierarchyName || dimensionName;
         const url = formatUrl(
-            "/Dimensions('{}')/Hierarchies('{}')/Elements?$expand=*&$filter=Type eq 'Numeric'",
+            "/Dimensions('{}')/Hierarchies('{}')/Elements?$expand=*&$filter=Type eq 1",
             dimensionName, hierarchy
         );
         const response = await this.rest.get(url);
@@ -243,7 +243,7 @@ export class ElementService extends ObjectService {
     ): Promise<string[]> {
         const hierarchy = hierarchyName || dimensionName;
         const url = formatUrl(
-            "/Dimensions('{}')/Hierarchies('{}')/Elements?$select=Name&$filter=Type eq 'Numeric'",
+            "/Dimensions('{}')/Hierarchies('{}')/Elements?$select=Name&$filter=Type eq 1",
             dimensionName, hierarchy
         );
         const response = await this.rest.get(url);
@@ -259,7 +259,7 @@ export class ElementService extends ObjectService {
     ): Promise<Element[]> {
         const hierarchy = hierarchyName || dimensionName;
         const url = formatUrl(
-            "/Dimensions('{}')/Hierarchies('{}')/Elements?$expand=*&$filter=Type eq 'String'",
+            "/Dimensions('{}')/Hierarchies('{}')/Elements?$expand=*&$filter=Type eq 2",
             dimensionName, hierarchy
         );
         const response = await this.rest.get(url);
@@ -275,7 +275,7 @@ export class ElementService extends ObjectService {
     ): Promise<string[]> {
         const hierarchy = hierarchyName || dimensionName;
         const url = formatUrl(
-            "/Dimensions('{}')/Hierarchies('{}')/Elements?$select=Name&$filter=Type eq 'String'",
+            "/Dimensions('{}')/Hierarchies('{}')/Elements?$select=Name&$filter=Type eq 2",
             dimensionName, hierarchy
         );
         const response = await this.rest.get(url);
@@ -338,7 +338,7 @@ export class ElementService extends ObjectService {
 
         // Add consolidation filter if requested
         if (skip_consolidations) {
-            const filter = "Type ne 'Consolidated'";
+            const filter = "Type ne 3";
             url += url.includes('?') ? `&$filter=${filter}` : `?$filter=${filter}`;
         }
 
@@ -398,20 +398,12 @@ export class ElementService extends ObjectService {
         dimensionName: string,
         hierarchyName: string,
         elements: Element[]
-    ): Promise<AxiosResponse[]> {
-        const results: AxiosResponse[] = [];
-
-        for (const element of elements) {
-            try {
-                const result = await this.create(dimensionName, hierarchyName, element);
-                results.push(result);
-            } catch (error) {
-                console.warn(`Failed to create element ${element.name}:`, error);
-                // Continue with other elements
-            }
-        }
-
-        return results;
+    ): Promise<AxiosResponse> {
+        const url = formatUrl(
+            "/Dimensions('{}')/Hierarchies('{}')/Elements",
+            dimensionName, hierarchyName);
+        const body = elements.map(e => e.bodyAsDict);
+        return await this.rest.post(url, JSON.stringify(body));
     }
 
     /**
@@ -495,20 +487,22 @@ export class ElementService extends ObjectService {
     public async getEdges(
         dimensionName: string,
         hierarchyName?: string
-    ): Promise<{ [key: string]: number }> {
+    ): Promise<{ [parent: string]: { [child: string]: number } }> {
         const hierarchy = hierarchyName || dimensionName;
         const url = formatUrl(
-            "/Dimensions('{}')/Hierarchies('{}')/Edges",
+            "/Dimensions('{}')/Hierarchies('{}')/Edges?$select=ParentName,ComponentName,Weight",
             dimensionName, hierarchy
         );
 
         const response = await this.rest.get(url);
-        const edges: { [key: string]: number } = {};
+        const edges: { [parent: string]: { [child: string]: number } } = {};
 
         if (response.data.value) {
             for (const edge of response.data.value) {
-                const key = `${edge.ParentName},${edge.ComponentName}`;
-                edges[key] = edge.Weight || 1;
+                if (!edges[edge.ParentName]) {
+                    edges[edge.ParentName] = {};
+                }
+                edges[edge.ParentName][edge.ComponentName] = edge.Weight;
             }
         }
 
@@ -522,26 +516,14 @@ export class ElementService extends ObjectService {
         mdx: string,
         topRecords?: number
     ): Promise<string[]> {
-        let url = '/ExecuteMDX';
-
-        if (topRecords) {
-            url += `?$top=${topRecords}`;
-        }
-
-        const body = { MDX: mdx };
-        const response = await this.rest.post(url, body);
-
-        // Extract element names from response
-        const elements: string[] = [];
-        if (response.data.Axes && response.data.Axes[0] && response.data.Axes[0].Tuples) {
-            for (const tuple of response.data.Axes[0].Tuples) {
-                if (tuple.Members && tuple.Members[0]) {
-                    elements.push(tuple.Members[0].Name);
-                }
-            }
-        }
-
-        return elements;
+        const elements = await this.executeSetMdx(
+            mdx,
+            topRecords,
+            ['Name'],
+            null,
+            null
+        );
+        return elements.map((member: any[]) => member[0].Name);
     }
 
 
@@ -649,19 +631,35 @@ export class ElementService extends ObjectService {
     }
 
     public async executeSetMdx(
-        dimensionName: string,
-        hierarchyName: string,
-        mdx: string
-    ): Promise<string[]> {
-        const url = '/ExecuteMDXSetExpression';
-        const body = {
-            MDX: mdx,
-            Dimension: dimensionName,
-            Hierarchy: hierarchyName
-        };
+        mdx: string,
+        topRecords?: number,
+        memberProperties: string[] | null = ['Name', 'Weight'],
+        parentProperties: string[] | null = ['Name', 'UniqueName'],
+        elementProperties: string[] | null = ['Type', 'Level']
+    ): Promise<any[][]> {
+        const top = topRecords ? `$top=${topRecords};` : '';
 
-        const response = await this.rest.post(url, body);
-        return response.data.value || [];
+        const effectiveMemberProperties = memberProperties || ['Name'];
+        const selectMemberProperties = `$select=${effectiveMemberProperties.join(',')}`;
+
+        const propertiesToExpand: string[] = [];
+        if (parentProperties) {
+            propertiesToExpand.push(`Parent($select=${parentProperties.join(',')})`);
+        }
+        if (elementProperties) {
+            propertiesToExpand.push(`Element($select=${elementProperties.join(',')})`);
+        }
+
+        const expandProperties = propertiesToExpand.length > 0
+            ? `;$expand=${propertiesToExpand.join(',')}`
+            : '';
+
+        const url = `/ExecuteMDXSetExpression?$expand=Tuples(${top}$expand=Members(${selectMemberProperties}${expandProperties}))`;
+
+        const payload = { MDX: mdx };
+        const response = await this.rest.post(url, JSON.stringify(payload));
+        const rawDict = response.data;
+        return (rawDict.Tuples || []).map((tuple: any) => tuple.Members);
     }
 
 
@@ -706,7 +704,7 @@ export class ElementService extends ObjectService {
         elementAttributeName: string
     ): Promise<AxiosResponse> {
         const url = formatUrl(
-            "/Dimensions('{}')/Hierarchies('{}')/ElementAttributes('{}')",
+            "/Dimensions('}ElementAttributes_{}')/Hierarchies('}ElementAttributes_{}')/Elements('{}')",
             dimensionName, hierarchyName, elementAttributeName);
         return await this.rest.delete(url);
     }
@@ -739,21 +737,19 @@ export class ElementService extends ObjectService {
     public async addEdges(
         dimensionName: string,
         hierarchyName: string,
-        edges: Array<{parent: string, child: string, weight?: number}>
-    ): Promise<void> {
-        // Add parent-child relationships with weights
-        for (const edge of edges) {
-            const url = formatUrl(
-                "/Dimensions('{}')/Hierarchies('{}')/Elements('{}')/Components",
-                dimensionName, hierarchyName, edge.parent);
-
-            const body = {
-                Name: edge.child,
-                Weight: edge.weight || 1
-            };
-
-            await this.rest.post(url, body);
+        edges: { [parent: string]: { [child: string]: number } }
+    ): Promise<AxiosResponse> {
+        const hierarchy = hierarchyName || dimensionName;
+        const url = formatUrl(
+            "/Dimensions('{}')/Hierarchies('{}')/Edges",
+            dimensionName, hierarchy);
+        const body: Array<{ ParentName: string; ComponentName: string; Weight: number }> = [];
+        for (const [parent, children] of Object.entries(edges)) {
+            for (const [component, weight] of Object.entries(children)) {
+                body.push({ ParentName: parent, ComponentName: component, Weight: Number(weight) });
+            }
         }
+        return await this.rest.post(url, JSON.stringify(body));
     }
 
     public async deleteEdges(
@@ -823,12 +819,12 @@ export class ElementService extends ObjectService {
         }
 
         // Then create relationships
-        const edges: Array<{parent: string, child: string, weight?: number}> = [];
-        
+        const edges: { [parent: string]: { [child: string]: number } } = {};
+
         for (let i = 1; i < dataFrame.length; i++) {
             const row = dataFrame[i];
             const childName = row[nameIndex];
-            
+
             // Look for parent columns
             for (let j = 0; j < headers.length; j++) {
                 const header = headers[j];
@@ -836,14 +832,15 @@ export class ElementService extends ObjectService {
                     const parentName = row[j];
                     const weightIndex = headers.indexOf(header.replace('Parent', 'Weight'));
                     const weight = weightIndex !== -1 ? parseFloat(row[weightIndex]) || 1 : 1;
-                    
-                    edges.push({ parent: parentName, child: childName, weight });
+
+                    if (!edges[parentName]) edges[parentName] = {};
+                    edges[parentName][childName] = weight;
                 }
             }
         }
 
         // Add all edges
-        if (edges.length > 0) {
+        if (Object.keys(edges).length > 0) {
             await this.addEdges(dimensionName, hierarchyName, edges);
         }
     }
@@ -873,7 +870,7 @@ export class ElementService extends ObjectService {
             dimensionName, hierarchy);
 
         if (skipConsolidatedElements) {
-            url += "?$filter=Type ne 'Consolidated'";
+            url += "?$filter=Type ne 3";
         }
 
         const response = await this.rest.get(url);
@@ -942,28 +939,16 @@ export class ElementService extends ObjectService {
      * Get elements by hierarchy level
      */
     public async getElementsByLevel(
-        dimensionName: string, 
-        hierarchyName: string, 
+        dimensionName: string,
+        hierarchyName: string,
         level: number
-    ): Promise<Element[]> {
+    ): Promise<string[]> {
         const hierarchy = hierarchyName || dimensionName;
-        
-        // Get all elements first
-        const allElements = await this.getElements(dimensionName, hierarchy);
-        
-        // Filter by level (this is a simplified implementation)
-        // In a real implementation, you'd need to calculate levels based on parent-child relationships
-        const levelElements: Element[] = [];
-        
-        for (const element of allElements) {
-            // Simple level calculation - consolidated elements are typically higher levels
-            const elementLevel = element.elementType === ElementType.CONSOLIDATED ? level : 0;
-            if (elementLevel === level) {
-                levelElements.push(element);
-            }
-        }
-        
-        return levelElements;
+        const url = formatUrl(
+            "/Dimensions('{}')/Hierarchies('{}')/Elements?$select=Name&$filter=Level eq {}",
+            dimensionName, hierarchy, String(level));
+        const response = await this.rest.get(url);
+        return response.data.value.map((e: any) => e.Name);
     }
 
     /**
@@ -1054,56 +1039,45 @@ export class ElementService extends ObjectService {
      * Get the number of levels in hierarchy
      */
     public async getLevelsCount(
-        dimensionName: string, 
+        dimensionName: string,
         hierarchyName: string
     ): Promise<number> {
         const hierarchy = hierarchyName || dimensionName;
-        
-        // Get all elements and calculate maximum level
-        const elements = await this.getElements(dimensionName, hierarchy);
-        let maxLevel = 0;
-        
-        // Simple level calculation - in real implementation would need proper hierarchy traversal
-        for (const element of elements) {
-            if (element.elementType === ElementType.CONSOLIDATED) {
-                maxLevel = Math.max(maxLevel, 1);
-            }
-        }
-        
-        return maxLevel + 1; // Include leaf level
+        const url = formatUrl(
+            "/Dimensions('{}')/Hierarchies('{}')/Levels/$count",
+            dimensionName, hierarchy);
+        const response = await this.rest.get(url);
+        return parseInt(response.data) || 0;
     }
 
-    /**
-     * Get level names from hierarchy
-     */
     public async getLevelNames(
-        dimensionName: string, 
-        hierarchyName: string
+        dimensionName: string,
+        hierarchyName: string,
+        descending: boolean = true
     ): Promise<string[]> {
-        const levelsCount = await this.getLevelsCount(dimensionName, hierarchyName);
-        const levelNames: string[] = [];
-        
-        for (let i = 0; i < levelsCount; i++) {
-            levelNames.push(`Level ${i}`);
+        const hierarchy = hierarchyName || dimensionName;
+        const url = formatUrl(
+            "/Dimensions('{}')/Hierarchies('{}')/Levels?$select=Name",
+            dimensionName, hierarchy);
+        const response = await this.rest.get(url);
+        const levels = response.data.value.map((level: any) => level.Name);
+        if (descending) {
+            return levels.reverse();
         }
-        
-        return levelNames;
+        return levels;
     }
 
     /**
      * Get alias element attributes
      */
     public async getAliasElementAttributes(
-        dimensionName: string, 
+        dimensionName: string,
         hierarchyName: string
-    ): Promise<ElementAttribute[]> {
-        const hierarchy = hierarchyName || dimensionName;
-        const url = formatUrl(
-            "/Dimensions('{}')/Hierarchies('{}')/ElementAttributes?$filter=Type eq 'Alias'",
-            dimensionName, hierarchy);
-        
-        const response = await this.rest.get(url);
-        return response.data.value.map((attr: any) => ElementAttribute.fromDict(attr));
+    ): Promise<string[]> {
+        const attributes = await this.getElementAttributes(dimensionName, hierarchyName);
+        return attributes
+            .filter(attr => attr.attributeType === 'Alias')
+            .map(attr => attr.name);
     }
 
     /**

--- a/src/services/HierarchyService.ts
+++ b/src/services/HierarchyService.ts
@@ -150,7 +150,7 @@ export class HierarchyService extends ObjectService {
     }
 
     public async deleteElementAttribute(dimensionName: string, hierarchyName: string, attributeName: string): Promise<AxiosResponse> {
-        const url = this.formatUrl("/Dimensions('{}')/Hierarchies('{}')/ElementAttributes('{}')",
+        const url = this.formatUrl("/Dimensions('}ElementAttributes_{}')/Hierarchies('}ElementAttributes_{}')/Elements('{}')",
             dimensionName, hierarchyName, attributeName);
         return await this.rest.delete(url);
     }

--- a/src/tests/elementService.comprehensive.test.ts
+++ b/src/tests/elementService.comprehensive.test.ts
@@ -217,7 +217,7 @@ describe('ElementService - Comprehensive Tests', () => {
             
             expect(result).toEqual(['Element1', 'Element2']);
             expect(mockRestService.get).toHaveBeenCalledWith(
-                "/Dimensions('TestDim')/Hierarchies('TestHierarchy')/Elements?$select=Name&$filter=Type ne 'Consolidated'"
+                "/Dimensions('TestDim')/Hierarchies('TestHierarchy')/Elements?$select=Name&$filter=Type ne 3"
             );
         });
 
@@ -252,7 +252,7 @@ describe('ElementService - Comprehensive Tests', () => {
             
             expect(result).toEqual(['NumericLeaf', 'StringLeaf']);
             expect(mockRestService.get).toHaveBeenCalledWith(
-                "/Dimensions('TestDim')/Hierarchies('TestHierarchy')/Elements?$select=Name&$filter=Type ne 'Consolidated'"
+                "/Dimensions('TestDim')/Hierarchies('TestHierarchy')/Elements?$select=Name&$filter=Type ne 3"
             );
         });
 
@@ -269,7 +269,7 @@ describe('ElementService - Comprehensive Tests', () => {
             
             expect(result).toEqual(['ConsolElement1', 'ConsolElement2']);
             expect(mockRestService.get).toHaveBeenCalledWith(
-                "/Dimensions('TestDim')/Hierarchies('TestHierarchy')/Elements?$select=Name&$filter=Type eq 'Consolidated'"
+                "/Dimensions('TestDim')/Hierarchies('TestHierarchy')/Elements?$select=Name&$filter=Type eq 3"
             );
         });
 
@@ -286,7 +286,7 @@ describe('ElementService - Comprehensive Tests', () => {
             
             expect(result).toEqual(['NumericElement1', 'NumericElement2']);
             expect(mockRestService.get).toHaveBeenCalledWith(
-                "/Dimensions('TestDim')/Hierarchies('TestHierarchy')/Elements?$select=Name&$filter=Type eq 'Numeric'"
+                "/Dimensions('TestDim')/Hierarchies('TestHierarchy')/Elements?$select=Name&$filter=Type eq 1"
             );
         });
 
@@ -303,7 +303,7 @@ describe('ElementService - Comprehensive Tests', () => {
             
             expect(result).toEqual(['StringElement1', 'StringElement2']);
             expect(mockRestService.get).toHaveBeenCalledWith(
-                "/Dimensions('TestDim')/Hierarchies('TestHierarchy')/Elements?$select=Name&$filter=Type eq 'String'"
+                "/Dimensions('TestDim')/Hierarchies('TestHierarchy')/Elements?$select=Name&$filter=Type eq 2"
             );
         });
 
@@ -343,7 +343,7 @@ describe('ElementService - Comprehensive Tests', () => {
             
             expect(result).toBe(10);
             expect(mockRestService.get).toHaveBeenCalledWith(
-                "/Dimensions('TestDim')/Hierarchies('TestHierarchy')/Elements/$count?$filter=Type ne 'Consolidated'"
+                "/Dimensions('TestDim')/Hierarchies('TestHierarchy')/Elements/$count?$filter=Type ne 3"
             );
         });
     });
@@ -438,26 +438,21 @@ describe('ElementService - Comprehensive Tests', () => {
         test('should add edges', async () => {
             mockRestService.post.mockResolvedValue(mockResponse({}));
 
-            const edges = [
-                { parent: 'Parent1', child: 'Child1', weight: 1.5 },
-                { parent: 'Parent1', child: 'Child2', weight: 2.0 },
-                { parent: 'Parent2', child: 'Child1' } // No weight specified
-            ];
+            const edges: { [parent: string]: { [child: string]: number } } = {
+                'Parent1': { 'Child1': 1.5, 'Child2': 2.0 },
+                'Parent2': { 'Child1': 1 }
+            };
 
             await elementService.addEdges('TestDim', 'TestHierarchy', edges);
-            
-            expect(mockRestService.post).toHaveBeenCalledTimes(3);
-            expect(mockRestService.post).toHaveBeenNthCalledWith(1,
-                "/Dimensions('TestDim')/Hierarchies('TestHierarchy')/Elements('Parent1')/Components",
-                { Name: 'Child1', Weight: 1.5 }
-            );
-            expect(mockRestService.post).toHaveBeenNthCalledWith(2,
-                "/Dimensions('TestDim')/Hierarchies('TestHierarchy')/Elements('Parent1')/Components",
-                { Name: 'Child2', Weight: 2.0 }
-            );
-            expect(mockRestService.post).toHaveBeenNthCalledWith(3,
-                "/Dimensions('TestDim')/Hierarchies('TestHierarchy')/Elements('Parent2')/Components",
-                { Name: 'Child1', Weight: 1 }
+
+            expect(mockRestService.post).toHaveBeenCalledTimes(1);
+            expect(mockRestService.post).toHaveBeenCalledWith(
+                "/Dimensions('TestDim')/Hierarchies('TestHierarchy')/Edges",
+                JSON.stringify([
+                    { ParentName: 'Parent1', ComponentName: 'Child1', Weight: 1.5 },
+                    { ParentName: 'Parent1', ComponentName: 'Child2', Weight: 2.0 },
+                    { ParentName: 'Parent2', ComponentName: 'Child1', Weight: 1 }
+                ])
             );
         });
 
@@ -523,11 +518,23 @@ describe('ElementService - Comprehensive Tests', () => {
         test('should add multiple elements', async () => {
             mockRestService.post.mockResolvedValue(mockResponse({}));
 
-            const elements = [mockElement, mockElement, mockElement];
+            const mockEl = {
+                name: 'TestElement',
+                bodyAsDict: { Name: 'TestElement', Type: 'Numeric' }
+            } as any;
+            const elements = [mockEl, mockEl, mockEl];
 
             await elementService.addElements('TestDim', 'TestHierarchy', elements);
-            
-            expect(mockRestService.post).toHaveBeenCalledTimes(3);
+
+            expect(mockRestService.post).toHaveBeenCalledTimes(1);
+            expect(mockRestService.post).toHaveBeenCalledWith(
+                "/Dimensions('TestDim')/Hierarchies('TestHierarchy')/Elements",
+                JSON.stringify([
+                    { Name: 'TestElement', Type: 'Numeric' },
+                    { Name: 'TestElement', Type: 'Numeric' },
+                    { Name: 'TestElement', Type: 'Numeric' }
+                ])
+            );
         });
 
         test('should delete multiple elements using REST API', async () => {
@@ -617,10 +624,10 @@ describe('ElementService - Comprehensive Tests', () => {
             mockRestService.delete.mockResolvedValue(mockResponse({}));
 
             const result = await elementService.deleteElementAttribute('TestDim', 'TestHierarchy', 'TestAttribute');
-            
+
             expect(result).toBeDefined();
             expect(mockRestService.delete).toHaveBeenCalledWith(
-                "/Dimensions('TestDim')/Hierarchies('TestHierarchy')/ElementAttributes('TestAttribute')"
+                "/Dimensions('}ElementAttributes_TestDim')/Hierarchies('}ElementAttributes_TestHierarchy')/Elements('TestAttribute')"
             );
         });
 
@@ -657,70 +664,66 @@ describe('ElementService - Comprehensive Tests', () => {
         });
 
         test('should get alias element attributes', async () => {
-            const aliasAttributesData = {
-                value: [
-                    { Name: 'Caption', Type: 'Alias' },
-                    { Name: 'DisplayName', Type: 'Alias' }
-                ]
-            };
-            mockRestService.get.mockResolvedValue(mockResponse(aliasAttributesData));
+            const mockAttributes = [
+                { name: 'Caption', attributeType: 'Alias' },
+                { name: 'DisplayName', attributeType: 'Alias' },
+                { name: 'Code', attributeType: 'String' }
+            ];
+            jest.spyOn(elementService, 'getElementAttributes').mockResolvedValue(mockAttributes as any);
 
             const result = await elementService.getAliasElementAttributes('TestDim', 'TestHierarchy');
-            
-            expect(result).toHaveLength(2);
-            expect(mockRestService.get).toHaveBeenCalledWith(
-                "/Dimensions('TestDim')/Hierarchies('TestHierarchy')/ElementAttributes?$filter=Type eq 'Alias'"
-            );
+
+            expect(result).toEqual(['Caption', 'DisplayName']);
+            expect(elementService.getElementAttributes).toHaveBeenCalledWith('TestDim', 'TestHierarchy');
         });
     });
 
     describe('MDX and Query Operations', () => {
         test('should execute set MDX', async () => {
             const mdxResult = {
-                value: ['Element1', 'Element2', 'Element3']
+                Tuples: [
+                    { Members: [{ Name: 'Element1', Weight: 1 }] },
+                    { Members: [{ Name: 'Element2', Weight: 1 }] },
+                    { Members: [{ Name: 'Element3', Weight: 1 }] }
+                ]
             };
             mockRestService.post.mockResolvedValue(mockResponse(mdxResult));
 
             const mdx = "{[TestDim].[TestHierarchy].[All]}";
-            const result = await elementService.executeSetMdx('TestDim', 'TestHierarchy', mdx);
-            
-            expect(result).toEqual(['Element1', 'Element2', 'Element3']);
+            const result = await elementService.executeSetMdx(mdx);
+
+            expect(result).toEqual([
+                [{ Name: 'Element1', Weight: 1 }],
+                [{ Name: 'Element2', Weight: 1 }],
+                [{ Name: 'Element3', Weight: 1 }]
+            ]);
             expect(mockRestService.post).toHaveBeenCalledWith(
-                '/ExecuteMDXSetExpression',
-                {
-                    MDX: mdx,
-                    Dimension: 'TestDim',
-                    Hierarchy: 'TestHierarchy'
-                }
+                expect.stringContaining('/ExecuteMDXSetExpression?$expand=Tuples('),
+                JSON.stringify({ MDX: mdx })
             );
         });
 
         test('should execute set MDX for element names', async () => {
-            const mdxResult = {
-                Axes: [{
-                    Tuples: [
-                        { Members: [{ Name: 'Element1' }] },
-                        { Members: [{ Name: 'Element2' }] }
-                    ]
-                }]
-            };
-            mockRestService.post.mockResolvedValue(mockResponse(mdxResult));
+            // executeSetMdxElementNames delegates to executeSetMdx with ['Name'] memberProperties
+            jest.spyOn(elementService, 'executeSetMdx').mockResolvedValue([
+                [{ Name: 'Element1' }],
+                [{ Name: 'Element2' }]
+            ]);
 
             const mdx = "DESCENDANTS({[TestDim].[TestHierarchy].[Total]}, 1, LEAVES)";
             const result = await elementService.executeSetMdxElementNames(mdx);
 
             expect(result).toEqual(['Element1', 'Element2']);
-            expect(mockRestService.post).toHaveBeenCalledWith(
-                '/ExecuteMDX',
-                { MDX: mdx }
+            expect(elementService.executeSetMdx).toHaveBeenCalledWith(
+                mdx, undefined, ['Name'], null, null
             );
         });
 
         test('should handle empty MDX results', async () => {
             mockRestService.post.mockResolvedValue(mockResponse({}));
 
-            const result = await elementService.executeSetMdx('TestDim', 'TestHierarchy', '{[Empty]}');
-            
+            const result = await elementService.executeSetMdx('{[Empty]}');
+
             expect(result).toEqual([]);
         });
     });
@@ -736,7 +739,7 @@ describe('ElementService - Comprehensive Tests', () => {
 
             expect(result).toHaveLength(1);
             expect(mockRestService.get).toHaveBeenCalledWith(
-                "/Dimensions('TestDim')/Hierarchies('TestHierarchy')/Elements?$expand=*&$filter=Type ne 'Consolidated'"
+                "/Dimensions('TestDim')/Hierarchies('TestHierarchy')/Elements?$expand=*&$filter=Type ne 3"
             );
         });
 
@@ -753,7 +756,7 @@ describe('ElementService - Comprehensive Tests', () => {
             
             expect(result).toHaveLength(2);
             expect(mockRestService.get).toHaveBeenCalledWith(
-                "/Dimensions('TestDim')/Hierarchies('TestHierarchy')/Elements?$expand=*&$filter=Type eq 'Consolidated'"
+                "/Dimensions('TestDim')/Hierarchies('TestHierarchy')/Elements?$expand=*&$filter=Type eq 3"
             );
         });
 
@@ -806,15 +809,14 @@ describe('ElementService - Comprehensive Tests', () => {
             ];
 
             jest.spyOn(elementService, 'create').mockResolvedValue(mockResponse({}));
-            jest.spyOn(elementService, 'addEdges').mockResolvedValue();
+            jest.spyOn(elementService, 'addEdges').mockResolvedValue(mockResponse({}) as any);
 
             await elementService.createHierarchyFromDataframe('TestDim', 'TestHierarchy', dataFrame);
-            
+
             expect(elementService.create).toHaveBeenCalledTimes(3);
-            expect(elementService.addEdges).toHaveBeenCalledWith('TestDim', 'TestHierarchy', [
-                { parent: 'Parent1', child: 'Child1', weight: 1.0 },
-                { parent: 'Parent1', child: 'Child2', weight: 2.0 }
-            ]);
+            expect(elementService.addEdges).toHaveBeenCalledWith('TestDim', 'TestHierarchy', {
+                'Parent1': { 'Child1': 1.0, 'Child2': 2.0 }
+            });
         });
 
         test('should throw error for invalid dataframe structure', async () => {
@@ -868,16 +870,20 @@ describe('ElementService - Comprehensive Tests', () => {
         });
 
         test('should get elements by level', async () => {
-            const allElements = [
-                { name: 'Leaf1', elementType: ElementType.NUMERIC },
-                { name: 'Consol1', elementType: ElementType.CONSOLIDATED }
-            ];
-            jest.spyOn(elementService, 'getElements').mockResolvedValue(allElements as any);
+            const levelData = {
+                value: [
+                    { Name: 'Consol1' },
+                    { Name: 'Consol2' }
+                ]
+            };
+            mockRestService.get.mockResolvedValue(mockResponse(levelData));
 
             const result = await elementService.getElementsByLevel('TestDim', 'TestHierarchy', 1);
-            
-            expect(result).toHaveLength(1);
-            expect(result[0].name).toBe('Consol1');
+
+            expect(result).toEqual(['Consol1', 'Consol2']);
+            expect(mockRestService.get).toHaveBeenCalledWith(
+                "/Dimensions('TestDim')/Hierarchies('TestHierarchy')/Elements?$select=Name&$filter=Level eq 1"
+            );
         });
 
         test('should get elements filtered by wildcard', async () => {
@@ -939,24 +945,33 @@ describe('ElementService - Comprehensive Tests', () => {
         });
 
         test('should get levels count', async () => {
-            const elements = [
-                { name: 'Leaf1', elementType: ElementType.NUMERIC },
-                { name: 'Consol1', elementType: ElementType.CONSOLIDATED },
-                { name: 'Leaf2', elementType: ElementType.STRING }
-            ];
-            jest.spyOn(elementService, 'getElements').mockResolvedValue(elements as any);
+            mockRestService.get.mockResolvedValue(mockResponse('3'));
 
             const result = await elementService.getLevelsCount('TestDim', 'TestHierarchy');
-            
-            expect(result).toBe(2); // 1 consolidated level + 1 leaf level
+
+            expect(result).toBe(3);
+            expect(mockRestService.get).toHaveBeenCalledWith(
+                "/Dimensions('TestDim')/Hierarchies('TestHierarchy')/Levels/$count"
+            );
         });
 
         test('should get level names', async () => {
-            jest.spyOn(elementService, 'getLevelsCount').mockResolvedValue(3);
+            const levelsData = {
+                value: [
+                    { Name: 'Level 0' },
+                    { Name: 'Level 1' },
+                    { Name: 'Level 2' }
+                ]
+            };
+            mockRestService.get.mockResolvedValue(mockResponse(levelsData));
 
             const result = await elementService.getLevelNames('TestDim', 'TestHierarchy');
-            
-            expect(result).toEqual(['Level 0', 'Level 1', 'Level 2']);
+
+            // Default descending=true reverses the order
+            expect(result).toEqual(['Level 2', 'Level 1', 'Level 0']);
+            expect(mockRestService.get).toHaveBeenCalledWith(
+                "/Dimensions('TestDim')/Hierarchies('TestHierarchy')/Levels?$select=Name"
+            );
         });
 
         test('should get leaves under consolidation using MDX', async () => {
@@ -1054,7 +1069,7 @@ describe('ElementService - Comprehensive Tests', () => {
             const error = new Error('MDX execution failed');
             mockRestService.post.mockRejectedValue(error);
 
-            await expect(elementService.executeSetMdx('TestDim', 'TestHierarchy', 'INVALID MDX'))
+            await expect(elementService.executeSetMdx('INVALID MDX'))
                 .rejects.toThrow('MDX execution failed');
         });
 
@@ -1162,33 +1177,35 @@ describe('ElementService - Comprehensive Tests', () => {
 
             // Element lifecycle: create, add relationships, update, delete
             await elementService.create('TestDim', 'TestHierarchy', mockElement);
-            await elementService.addEdges('TestDim', 'TestHierarchy', [
-                { parent: 'Parent1', child: 'TestElement', weight: 1.5 }
-            ]);
+            await elementService.addEdges('TestDim', 'TestHierarchy', {
+                'Parent1': { 'TestElement': 1.5 }
+            });
             await elementService.update('TestDim', 'TestHierarchy', mockElement);
             await elementService.delete('TestDim', 'TestHierarchy', 'TestElement');
 
-            expect(mockRestService.post).toHaveBeenCalledTimes(2); // create + add edge
+            expect(mockRestService.post).toHaveBeenCalledTimes(2); // create + add edges batch
             expect(mockRestService.patch).toHaveBeenCalledTimes(1);
             expect(mockRestService.delete).toHaveBeenCalledTimes(1);
         });
 
         test('should support hierarchy building workflow', async () => {
             mockRestService.post.mockResolvedValue(mockResponse({}));
-            jest.spyOn(elementService, 'create').mockResolvedValue(mockResponse({}));
-            jest.spyOn(elementService, 'addEdges').mockResolvedValue();
+            jest.spyOn(elementService, 'addEdges').mockResolvedValue(mockResponse({}) as any);
 
-            const elements = [mockElement, mockElement, mockElement];
-            const edges = [
-                { parent: 'Parent1', child: 'Child1', weight: 1 },
-                { parent: 'Parent1', child: 'Child2', weight: 2 }
-            ];
+            const mockEl = {
+                name: 'TestElement',
+                bodyAsDict: { Name: 'TestElement', Type: 'Numeric' }
+            } as any;
+            const elements = [mockEl, mockEl, mockEl];
+            const edges: { [parent: string]: { [child: string]: number } } = {
+                'Parent1': { 'Child1': 1, 'Child2': 2 }
+            };
 
             // Hierarchy building workflow
             await elementService.addElements('TestDim', 'TestHierarchy', elements);
             await elementService.addEdges('TestDim', 'TestHierarchy', edges);
 
-            expect(elementService.create).toHaveBeenCalledTimes(3);
+            expect(mockRestService.post).toHaveBeenCalledTimes(1); // single batch addElements
             expect(elementService.addEdges).toHaveBeenCalledWith('TestDim', 'TestHierarchy', edges);
         });
 

--- a/src/tests/enhancedElementService.test.ts
+++ b/src/tests/enhancedElementService.test.ts
@@ -65,21 +65,23 @@ describe('Enhanced ElementService Tests', () => {
         });
 
         test('addEdges should create parent-child relationships', async () => {
-            const edges = [
-                { parent: 'Total', child: 'Region1', weight: 1 },
-                { parent: 'Total', child: 'Region2', weight: 2 }
-            ];
+            const edges: { [parent: string]: { [child: string]: number } } = {
+                'Total': { 'Region1': 1, 'Region2': 2 }
+            };
 
             mockRestService.post.mockResolvedValue(createMockResponse({}));
 
             await elementService.addEdges('TestDim', 'TestHier', edges);
 
-            expect(mockRestService.post).toHaveBeenCalledTimes(2);
+            expect(mockRestService.post).toHaveBeenCalledTimes(1);
             expect(mockRestService.post).toHaveBeenCalledWith(
-                "/Dimensions('TestDim')/Hierarchies('TestHier')/Elements('Total')/Components",
-                { Name: 'Region1', Weight: 1 }
+                "/Dimensions('TestDim')/Hierarchies('TestHier')/Edges",
+                JSON.stringify([
+                    { ParentName: 'Total', ComponentName: 'Region1', Weight: 1 },
+                    { ParentName: 'Total', ComponentName: 'Region2', Weight: 2 }
+                ])
             );
-            
+
             console.log('✅ addEdges test passed');
         });
 
@@ -153,8 +155,8 @@ describe('Enhanced ElementService Tests', () => {
 
             await elementService.createHierarchyFromDataframe('TestDim', 'TestHier', dataFrame);
 
-            // Should create 3 elements
-            expect(mockRestService.post).toHaveBeenCalledTimes(5); // 3 creates + 2 edges
+            // Should create 3 elements + 1 batch edge POST
+            expect(mockRestService.post).toHaveBeenCalledTimes(4); // 3 creates + 1 batch edges
             
             // Check element creation calls
             expect(mockRestService.post).toHaveBeenCalledWith(
@@ -190,7 +192,7 @@ describe('Enhanced ElementService Tests', () => {
 
             expect(count).toBe(15);
             expect(mockRestService.get).toHaveBeenCalledWith(
-                "/Dimensions('TestDim')/Hierarchies('TestHier')/Elements/$count?$filter=Type ne 'Consolidated'"
+                "/Dimensions('TestDim')/Hierarchies('TestHier')/Elements/$count?$filter=Type ne 3"
             );
             
             console.log('✅ getElementsCount with filter test passed');
@@ -208,7 +210,7 @@ describe('Enhanced ElementService Tests', () => {
 
             expect(elements).toHaveLength(2);
             expect(mockRestService.get).toHaveBeenCalledWith(
-                "/Dimensions('TestDim')/Hierarchies('TestHier')/Elements?$expand=*&$filter=Type ne 'Consolidated'"
+                "/Dimensions('TestDim')/Hierarchies('TestHier')/Elements?$expand=*&$filter=Type ne 3"
             );
             
             console.log('✅ getLeafElements test passed');
@@ -226,7 +228,7 @@ describe('Enhanced ElementService Tests', () => {
 
             expect(elements).toHaveLength(2);
             expect(mockRestService.get).toHaveBeenCalledWith(
-                "/Dimensions('TestDim')/Hierarchies('TestHier')/Elements?$expand=*&$filter=Type eq 'Consolidated'"
+                "/Dimensions('TestDim')/Hierarchies('TestHier')/Elements?$expand=*&$filter=Type eq 3"
             );
             
             console.log('✅ getConsolidatedElements test passed');
@@ -250,28 +252,21 @@ describe('Enhanced ElementService Tests', () => {
 
     describe('MDX Operations', () => {
         test('executeSetMdxElementNames should return element names from MDX set', async () => {
-            mockRestService.post.mockResolvedValue(createMockResponse({
-                Axes: [{
-                    Tuples: [
-                        { Members: [{ Name: 'Element1' }] },
-                        { Members: [{ Name: 'Element2' }] },
-                        { Members: [{ Name: 'Element3' }] }
-                    ]
-                }]
-            }));
+            // executeSetMdxElementNames delegates to executeSetMdx with ['Name'] memberProperties
+            jest.spyOn(elementService, 'executeSetMdx').mockResolvedValue([
+                [{ Name: 'Element1' }],
+                [{ Name: 'Element2' }],
+                [{ Name: 'Element3' }]
+            ]);
 
-            const elements = await elementService.executeSetMdxElementNames(
-                '{[TestDim].[TestHier].Members}'
-            );
+            const mdx = '{[TestDim].[TestHier].Members}';
+            const elements = await elementService.executeSetMdxElementNames(mdx);
 
             expect(elements).toEqual(['Element1', 'Element2', 'Element3']);
-            expect(mockRestService.post).toHaveBeenCalledWith(
-                '/ExecuteMDX',
-                {
-                    MDX: '{[TestDim].[TestHier].Members}'
-                }
+            expect(elementService.executeSetMdx).toHaveBeenCalledWith(
+                mdx, undefined, ['Name'], null, null
             );
-            
+
             console.log('✅ executeSetMdxElementNames test passed');
         });
     });

--- a/src/tests/hierarchyService.test.ts
+++ b/src/tests/hierarchyService.test.ts
@@ -324,7 +324,8 @@ describe('HierarchyService Tests', () => {
             // Only OldAttr should be deleted
             expect(mockRestService.delete).toHaveBeenCalledTimes(1);
             const deleteUrl = mockRestService.delete.mock.calls[0][0];
-            expect(deleteUrl).toContain("ElementAttributes('OldAttr')");
+            expect(deleteUrl).toContain("}ElementAttributes_TestDimension");
+            expect(deleteUrl).toContain("Elements('OldAttr')");
         });
 
         test('should update attributes with changed type (delete + recreate)', async () => {


### PR DESCRIPTION
## Summary
- Fix 11 ElementService bugs for tm1py v2.2.4 parity (issues #32 and #52)
- Use numeric type codes in OData filters via `ElementType` enum (1=Numeric, 2=String, 3=Consolidated)
- Replace N+1 `addElements`/`addEdges` with single batch POST operations
- Correct `deleteElementAttribute` endpoint to target `}ElementAttributes_` control dimension
- Replace client-side hacks for `getLevelsCount`, `getLevelNames`, `getElementsByLevel` with proper API endpoints
- Fix `executeSetMdx`/`executeSetMdxElementNames` to use `/ExecuteMDXSetExpression` with `$expand=Tuples`
- Fix `getEdges` to return nested parent→child→weight map
- Fix `getAliasElementAttributes` to return `string[]` (names only)
- Align `HierarchyService.deleteElementAttribute` with the corrected endpoint
- Fix double `$filter` bug in `getElementsDataframe`

Closes #32
Closes #52

## Test plan
- [x] All 131 ElementService + HierarchyService tests pass
- [x] Full test suite: 1150 passed (2 pre-existing failures unrelated to this PR)
- [x] TypeScript compiles with zero errors
- [x] All 11 fixes verified against tm1py v2.2.4 source