### PR TITLE
fix(#53): use executeProcessWithReturn in executeTiCode

### DIFF
--- a/src/services/MessageLogService.ts
+++ b/src/services/MessageLogService.ts
@@ -163,7 +163,7 @@ export class MessageLogService extends ObjectService {
         // Execute TI code directly instead of creating a process
         const tiCode = `LogOutput('${level}', '${message}');`;
         const result = await processService.executeTiCode([tiCode]);
-        if (result?.ProcessExecuteStatusCode && result.ProcessExecuteStatusCode !== 'CompletedSuccessfully') {
+        if (result?.ProcessExecuteStatusCode !== 'CompletedSuccessfully') {
             throw new Error(`Failed to write to TM1 Message Log. Status: '${result.ProcessExecuteStatusCode}'`);
         }
     }

--- a/src/services/MessageLogService.ts
+++ b/src/services/MessageLogService.ts
@@ -163,7 +163,7 @@ export class MessageLogService extends ObjectService {
         // Execute TI code directly instead of creating a process
         const tiCode = `LogOutput('${level}', '${message}');`;
         const result = await processService.executeTiCode([tiCode]);
-        if (result?.ProcessExecuteStatusCode !== 'CompletedSuccessfully') {
+        if (result.ProcessExecuteStatusCode !== 'CompletedSuccessfully') {
             throw new Error(`Failed to write to TM1 Message Log. Status: '${result.ProcessExecuteStatusCode}'`);
         }
     }

--- a/src/services/MessageLogService.ts
+++ b/src/services/MessageLogService.ts
@@ -162,9 +162,9 @@ export class MessageLogService extends ObjectService {
         
         // Execute TI code directly instead of creating a process
         const tiCode = `LogOutput('${level}', '${message}');`;
-        const response = await processService.executeTiCode([tiCode]);
-        if (response.status !== 200) {
-            throw new Error(`Failed to write to TM1 Message Log. Status: '${response.status}'`);
+        const result = await processService.executeTiCode([tiCode]);
+        if (result?.ProcessExecuteStatusCode && result.ProcessExecuteStatusCode !== 'CompletedSuccessfully') {
+            throw new Error(`Failed to write to TM1 Message Log. Status: '${result.ProcessExecuteStatusCode}'`);
         }
     }
 

--- a/src/services/ProcessService.ts
+++ b/src/services/ProcessService.ts
@@ -527,7 +527,7 @@ export class ProcessService extends ObjectService {
         );
         await this.create(p);
         try {
-            return await this.execute(name, parameters);
+            return await this.executeProcessWithReturn(name, parameters);
         } finally {
             try {
                 await this.delete(name);

--- a/src/services/ServerService.ts
+++ b/src/services/ServerService.ts
@@ -251,14 +251,14 @@ export class ServerService extends ObjectService {
 
     @deprecatedInVersion("12.0.0")
     
-    public async saveData(): Promise<AxiosResponse> {
+    public async saveData(): Promise<any> {
         const ti = "SaveDataAll;";
         const processService = new ProcessService(this.rest);
         return await processService.executeTiCode([ti]);
     }
 
-    
-    public async deletePersistentFeeders(): Promise<AxiosResponse> {
+
+    public async deletePersistentFeeders(): Promise<any> {
         const ti = "DeleteAllPersistentFeeders;";
         const processService = new ProcessService(this.rest);
         return await processService.executeTiCode([ti]);

--- a/src/tests/processService.comprehensive.test.ts
+++ b/src/tests/processService.comprehensive.test.ts
@@ -413,7 +413,6 @@ describe('ProcessService - Comprehensive Tests', () => {
 
             const result = await processService.executeTiCode(['InvalidFunction();']);
 
-            // The key fix: executeTiCode now returns the status so callers can detect failures
             expect(result.ProcessExecuteStatusCode).toBe('Aborted');
             expect(result.ErrorLogFile).toBeDefined();
         });

--- a/src/tests/processService.comprehensive.test.ts
+++ b/src/tests/processService.comprehensive.test.ts
@@ -351,9 +351,9 @@ describe('ProcessService - Comprehensive Tests', () => {
             const createCall = mockRestService.post.mock.calls[0];
             expect(createCall[0]).toBe('/Processes');
 
-            // Second call: execute
+            // Second call: executeWithReturn
             const executeCall = mockRestService.post.mock.calls[1];
-            expect(executeCall[0]).toMatch(/\/Processes\('.*'\)\/tm1\.Execute/);
+            expect(executeCall[0]).toMatch(/\/Processes\('.*'\)\/tm1\.ExecuteWithReturn\?\$expand=\*/);
         });
 
         test('should execute TI code with parameters', async () => {

--- a/src/tests/processService.comprehensive.test.ts
+++ b/src/tests/processService.comprehensive.test.ts
@@ -386,6 +386,38 @@ describe('ProcessService - Comprehensive Tests', () => {
             expect(mockRestService.delete).toHaveBeenCalledTimes(1);
         });
 
+        test('should return execution status from executeTiCode', async () => {
+            const executionResult = {
+                ProcessExecuteStatusCode: 'CompletedSuccessfully',
+                ErrorLogFile: null
+            };
+            mockRestService.post
+                .mockResolvedValueOnce(mockResponse({})) // create
+                .mockResolvedValueOnce(mockResponse(executionResult)); // executeWithReturn
+            mockRestService.delete.mockResolvedValue(mockResponse({}));
+
+            const result = await processService.executeTiCode(['sTest = "hello";']);
+
+            expect(result).toEqual(executionResult);
+        });
+
+        test('should surface failed TI execution status', async () => {
+            const failedResult = {
+                ProcessExecuteStatusCode: 'Aborted',
+                ErrorLogFile: { Filename: 'TM1ProcessError_12345.log' }
+            };
+            mockRestService.post
+                .mockResolvedValueOnce(mockResponse({})) // create
+                .mockResolvedValueOnce(mockResponse(failedResult)); // executeWithReturn
+            mockRestService.delete.mockResolvedValue(mockResponse({}));
+
+            const result = await processService.executeTiCode(['InvalidFunction();']);
+
+            // The key fix: executeTiCode now returns the status so callers can detect failures
+            expect(result.ProcessExecuteStatusCode).toBe('Aborted');
+            expect(result.ErrorLogFile).toBeDefined();
+        });
+
         test('should execute TI code with prolog only', async () => {
             mockRestService.post.mockResolvedValue(mockResponse({}));
             mockRestService.delete.mockResolvedValue(mockResponse({}));


### PR DESCRIPTION
## Summary

Closes #53. Changes `executeTiCode` from `this.execute()` (`tm1.Execute` — silently returns 200 on TI failure) to `this.executeProcessWithReturn()` (`tm1.ExecuteWithReturn` — returns execution status).

### Changes
- `ProcessService.ts` — `execute()` → `executeProcessWithReturn()`
- `MessageLogService.ts` / `ServerService.ts` — updated for new return shape
- 2 new tests for execution status handling

## Test plan
- [x] All tests pass
- [x] External review: approved in 1 round