### PR TITLE
feat(#37): implement 13 missing ElementService methods

### DIFF
--- a/src/services/ElementService.ts
+++ b/src/services/ElementService.ts
@@ -8,6 +8,7 @@ import { ProcessService } from './ProcessService';
 import { HierarchyService } from './HierarchyService';
 import {
     formatUrl,
+    escapeODataValue,
     CaseAndSpaceInsensitiveDict,
     CaseAndSpaceInsensitiveSet
 } from '../utils/Utils';
@@ -1210,64 +1211,32 @@ export class ElementService extends ObjectService {
 
     // ===== ISSUE #37: 13 MISSING METHODS FOR TM1PY PARITY =====
 
-    /**
-     * Get number of consolidated elements in a hierarchy
-     */
     public async getNumberOfConsolidatedElements(
         dimensionName: string,
         hierarchyName: string
     ): Promise<number> {
-        const url = formatUrl(
-            "/Dimensions('{}')/Hierarchies('{}')/Elements/$count?$filter=Type eq 3",
-            dimensionName, hierarchyName
-        );
-        const response = await this.rest.get(url);
-        return parseInt(response.data) || 0;
+        return this._getElementCountWithFilter(dimensionName, hierarchyName, `Type eq ${ElementType.CONSOLIDATED}`);
     }
 
-    /**
-     * Get number of leaf (non-consolidated) elements in a hierarchy
-     */
     public async getNumberOfLeafElements(
         dimensionName: string,
         hierarchyName: string
     ): Promise<number> {
-        const url = formatUrl(
-            "/Dimensions('{}')/Hierarchies('{}')/Elements/$count?$filter=Type ne 3",
-            dimensionName, hierarchyName
-        );
-        const response = await this.rest.get(url);
-        return parseInt(response.data) || 0;
+        return this._getElementCountWithFilter(dimensionName, hierarchyName, `Type ne ${ElementType.CONSOLIDATED}`);
     }
 
-    /**
-     * Get number of numeric elements in a hierarchy
-     */
     public async getNumberOfNumericElements(
         dimensionName: string,
         hierarchyName: string
     ): Promise<number> {
-        const url = formatUrl(
-            "/Dimensions('{}')/Hierarchies('{}')/Elements/$count?$filter=Type eq 1",
-            dimensionName, hierarchyName
-        );
-        const response = await this.rest.get(url);
-        return parseInt(response.data) || 0;
+        return this._getElementCountWithFilter(dimensionName, hierarchyName, `Type eq ${ElementType.NUMERIC}`);
     }
 
-    /**
-     * Get number of string elements in a hierarchy
-     */
     public async getNumberOfStringElements(
         dimensionName: string,
         hierarchyName: string
     ): Promise<number> {
-        const url = formatUrl(
-            "/Dimensions('{}')/Hierarchies('{}')/Elements/$count?$filter=Type eq 2",
-            dimensionName, hierarchyName
-        );
-        const response = await this.rest.get(url);
-        return parseInt(response.data) || 0;
+        return this._getElementCountWithFilter(dimensionName, hierarchyName, `Type eq ${ElementType.STRING}`);
     }
 
     /**
@@ -1462,6 +1431,20 @@ export class ElementService extends ObjectService {
 
     // ===== PRIVATE HELPERS FOR ISSUE #37 =====
 
+    private async _getElementCountWithFilter(
+        dimensionName: string,
+        hierarchyName: string,
+        filter: string
+    ): Promise<number> {
+        const baseUrl = formatUrl(
+            "/Dimensions('{}')/Hierarchies('{}')/Elements/$count",
+            dimensionName, hierarchyName
+        );
+        const url = `${baseUrl}?$filter=${filter}`;
+        const response = await this.rest.get(url);
+        return parseInt(response.data) || 0;
+    }
+
     private _buildDrillIntersectionMdx(
         dimensionName: string,
         hierarchyName: string,
@@ -1501,7 +1484,7 @@ export class ElementService extends ObjectService {
         ancestorName: string
     ): Promise<boolean> {
         const processService = new ProcessService(this.rest);
-        const code = `ElementIsAncestor('${dimensionName.replace(/'/g, "''")}', '${hierarchyName.replace(/'/g, "''")}', '${ancestorName.replace(/'/g, "''")}', '${elementName.replace(/'/g, "''")}')=1`;
+        const code = `ElementIsAncestor('${escapeODataValue(dimensionName)}', '${escapeODataValue(hierarchyName)}', '${escapeODataValue(ancestorName)}', '${escapeODataValue(elementName)}')=1`;
         return processService.evaluateBooleanTiExpression(code);
     }
 

--- a/src/services/ElementService.ts
+++ b/src/services/ElementService.ts
@@ -6,9 +6,11 @@ import { ElementAttribute } from '../objects/ElementAttribute';
 import { Process } from '../objects/Process';
 import { ProcessService } from './ProcessService';
 import { HierarchyService } from './HierarchyService';
+import { CellService } from './CellService';
 import {
     formatUrl,
     escapeODataValue,
+    requireDataAdmin,
     CaseAndSpaceInsensitiveDict,
     CaseAndSpaceInsensitiveSet
 } from '../utils/Utils';
@@ -1209,8 +1211,6 @@ export class ElementService extends ObjectService {
         return elements.map(name => `[${dimensionName}].[${hierarchy}].[${name}]`);
     }
 
-    // ===== ISSUE #37: 13 MISSING METHODS FOR TM1PY PARITY =====
-
     public async getNumberOfConsolidatedElements(
         dimensionName: string,
         hierarchyName: string
@@ -1335,6 +1335,7 @@ export class ElementService extends ObjectService {
      * - 'Descendants' performs well when ancestorName and elementName are Consolidations
      *
      * If no method is passed, defaults to 'TI' for admin users, 'TM1DrillDownMember' otherwise.
+     * Note: isAdmin is determined from RestService state; if not set, defaults to 'TM1DrillDownMember'.
      */
     public async elementIsAncestor(
         dimensionName: string,
@@ -1430,8 +1431,6 @@ export class ElementService extends ObjectService {
         return this._retrieveMdxRowsAndCellValuesAsStringSet(mdx);
     }
 
-    // ===== PRIVATE HELPERS FOR ISSUE #37 =====
-
     private async _getElementCountWithFilter(
         dimensionName: string,
         hierarchyName: string,
@@ -1478,6 +1477,7 @@ export class ElementService extends ObjectService {
         return response.data.Cardinality || 0;
     }
 
+    @requireDataAdmin
     private async _elementIsAncestorTi(
         dimensionName: string,
         hierarchyName: string,
@@ -1490,28 +1490,21 @@ export class ElementService extends ObjectService {
     }
 
     private async _retrieveMdxRowsAndCellValuesAsStringSet(mdx: string): Promise<CaseAndSpaceInsensitiveSet> {
-        const url = '/ExecuteMDX';
-        const response = await this.rest.post(url, JSON.stringify({ MDX: mdx }));
-        const data = response.data;
+        const cellService = new CellService(this.rest);
+        const { rows, values } = await cellService.executeMdxRowsAndValues(mdx);
         const result = new CaseAndSpaceInsensitiveSet();
 
-        // Collect row member names from the row axis (Axes[1])
-        if (data.Axes && data.Axes.length > 1 && data.Axes[1].Tuples) {
-            for (const tuple of data.Axes[1].Tuples) {
-                for (const member of (tuple.Members || [])) {
-                    if (member.Name) {
-                        result.add(member.Name);
-                    }
+        for (const row of rows) {
+            for (const name of row) {
+                if (name) {
+                    result.add(name);
                 }
             }
         }
 
-        // Collect non-null, non-empty string cell values (alias values)
-        if (data.Cells) {
-            for (const cell of data.Cells) {
-                if (cell.Value && typeof cell.Value === 'string' && cell.Value.trim() !== '') {
-                    result.add(cell.Value);
-                }
+        for (const value of values) {
+            if (value && typeof value === 'string' && value.trim() !== '') {
+                result.add(value);
             }
         }
 

--- a/src/services/ElementService.ts
+++ b/src/services/ElementService.ts
@@ -1305,7 +1305,8 @@ export class ElementService extends ObjectService {
      * Check if one element is a direct parent of another
      *
      * Unlike the related function in TM1 (ELISPAR or ElementIsParent), this function will return false
-     * if an invalid element is passed; but will raise an exception if an invalid dimension or hierarchy is passed.
+     * if an invalid element is passed. An invalid dimension or hierarchy will cause the underlying
+     * REST call to throw (the error propagates from the TM1 server).
      */
     public async elementIsParent(
         dimensionName: string,

--- a/src/services/ElementService.ts
+++ b/src/services/ElementService.ts
@@ -4,9 +4,12 @@ import { ObjectService } from './ObjectService';
 import { Element, ElementType } from '../objects/Element';
 import { ElementAttribute } from '../objects/ElementAttribute';
 import { Process } from '../objects/Process';
+import { ProcessService } from './ProcessService';
+import { HierarchyService } from './HierarchyService';
 import {
     formatUrl,
-    CaseAndSpaceInsensitiveDict
+    CaseAndSpaceInsensitiveDict,
+    CaseAndSpaceInsensitiveSet
 } from '../utils/Utils';
 
 export interface ElementsDataFrameOptions {
@@ -1203,5 +1206,331 @@ export class ElementService extends ObjectService {
         }
         
         return elements.map(name => `[${dimensionName}].[${hierarchy}].[${name}]`);
+    }
+
+    // ===== ISSUE #37: 13 MISSING METHODS FOR TM1PY PARITY =====
+
+    /**
+     * Get number of consolidated elements in a hierarchy
+     */
+    public async getNumberOfConsolidatedElements(
+        dimensionName: string,
+        hierarchyName: string
+    ): Promise<number> {
+        const url = formatUrl(
+            "/Dimensions('{}')/Hierarchies('{}')/Elements/$count?$filter=Type eq 3",
+            dimensionName, hierarchyName
+        );
+        const response = await this.rest.get(url);
+        return parseInt(response.data) || 0;
+    }
+
+    /**
+     * Get number of leaf (non-consolidated) elements in a hierarchy
+     */
+    public async getNumberOfLeafElements(
+        dimensionName: string,
+        hierarchyName: string
+    ): Promise<number> {
+        const url = formatUrl(
+            "/Dimensions('{}')/Hierarchies('{}')/Elements/$count?$filter=Type ne 3",
+            dimensionName, hierarchyName
+        );
+        const response = await this.rest.get(url);
+        return parseInt(response.data) || 0;
+    }
+
+    /**
+     * Get number of numeric elements in a hierarchy
+     */
+    public async getNumberOfNumericElements(
+        dimensionName: string,
+        hierarchyName: string
+    ): Promise<number> {
+        const url = formatUrl(
+            "/Dimensions('{}')/Hierarchies('{}')/Elements/$count?$filter=Type eq 1",
+            dimensionName, hierarchyName
+        );
+        const response = await this.rest.get(url);
+        return parseInt(response.data) || 0;
+    }
+
+    /**
+     * Get number of string elements in a hierarchy
+     */
+    public async getNumberOfStringElements(
+        dimensionName: string,
+        hierarchyName: string
+    ): Promise<number> {
+        const url = formatUrl(
+            "/Dimensions('{}')/Hierarchies('{}')/Elements/$count?$filter=Type eq 2",
+            dimensionName, hierarchyName
+        );
+        const response = await this.rest.get(url);
+        return parseInt(response.data) || 0;
+    }
+
+    /**
+     * Get element types from all hierarchies in a single API call
+     */
+    public async getElementTypesFromAllHierarchies(
+        dimensionName: string,
+        skipConsolidations: boolean = false
+    ): Promise<CaseAndSpaceInsensitiveDict<string>> {
+        let url = formatUrl(
+            "/Dimensions('{}')?$expand=Hierarchies($select=Elements;$expand=Elements($select=Name,Type",
+            dimensionName
+        );
+        url += skipConsolidations ? ";$filter=Type ne 3))" : "))";
+
+        const response = await this.rest.get(url);
+        const result = new CaseAndSpaceInsensitiveDict<string>();
+        for (const hierarchy of response.data.Hierarchies) {
+            for (const element of hierarchy.Elements) {
+                result.set(element.Name, element.Type);
+            }
+        }
+        return result;
+    }
+
+    /**
+     * Check if the element attributes cube exists for a dimension
+     */
+    public async attributeCubeExists(dimensionName: string): Promise<boolean> {
+        const url = formatUrl("/Cubes('{}')", Element.ELEMENT_ATTRIBUTES_PREFIX + dimensionName);
+        return this._exists(url);
+    }
+
+    /**
+     * Get parent mapping for all elements in a hierarchy
+     */
+    public async getParentsOfAllElements(
+        dimensionName: string,
+        hierarchyName: string
+    ): Promise<{ [elementName: string]: string[] }> {
+        const url = formatUrl(
+            "/Dimensions('{}')/Hierarchies('{}')/Elements?$select=Name&$expand=Parents($select=Name)",
+            dimensionName, hierarchyName
+        );
+        const response = await this.rest.get(url);
+        const result: { [elementName: string]: string[] } = {};
+        for (const child of response.data.value) {
+            result[child.Name] = (child.Parents || []).map((p: any) => p.Name);
+        }
+        return result;
+    }
+
+    /**
+     * Get the canonical/principal name of an element (resolves aliases)
+     */
+    public async getElementPrincipalName(
+        dimensionName: string,
+        hierarchyName: string,
+        elementName: string
+    ): Promise<string> {
+        const element = await this.get(dimensionName, hierarchyName, elementName);
+        return element.name;
+    }
+
+    /**
+     * Check if one element is a direct parent of another
+     *
+     * Unlike the related function in TM1 (ELISPAR or ElementIsParent), this function will return false
+     * if an invalid element is passed; but will raise an exception if an invalid dimension or hierarchy is passed.
+     */
+    public async elementIsParent(
+        dimensionName: string,
+        hierarchyName: string,
+        parentName: string,
+        elementName: string
+    ): Promise<boolean> {
+        const mdx = this._buildDrillIntersectionMdx(
+            dimensionName, hierarchyName,
+            parentName, elementName,
+            'TM1DrillDownMember', false
+        );
+        const cardinality = await this._getMdxSetCardinality(mdx);
+        return cardinality > 0;
+    }
+
+    /**
+     * Check if one element is an ancestor of another
+     *
+     * Unlike the related function in TM1 (ELISANC or ElementIsAncestor), this function will return false
+     * if an invalid element is passed; but will raise an exception if an invalid dimension or hierarchy is passed.
+     *
+     * For method you can pass three values:
+     * - 'TI' performs best, but requires admin permissions
+     * - 'TM1DrillDownMember' performs well when element is a leaf
+     * - 'Descendants' performs well when ancestorName and elementName are Consolidations
+     *
+     * If no method is passed, defaults to 'TI' for admin users, 'TM1DrillDownMember' otherwise.
+     */
+    public async elementIsAncestor(
+        dimensionName: string,
+        hierarchyName: string,
+        ancestorName: string,
+        elementName: string,
+        method?: string
+    ): Promise<boolean> {
+        if (!method) {
+            method = this.isAdmin ? 'TI' : 'TM1DrillDownMember';
+        }
+
+        if (method.toUpperCase() === 'TI') {
+            if (await this._elementIsAncestorTi(dimensionName, hierarchyName, elementName, ancestorName)) {
+                return true;
+            }
+            if (await this.hierarchyExists(dimensionName, hierarchyName)) {
+                return false;
+            }
+            throw new Error(`Hierarchy: '${hierarchyName}' does not exist in dimension: '${dimensionName}'`);
+        }
+
+        if (method.toUpperCase() === 'DESCENDANTS' || method.toUpperCase() === 'TM1DRILLDOWNMEMBER') {
+            if (!await this.exists(dimensionName, hierarchyName, elementName)) {
+                if (!await this.hierarchyExists(dimensionName, hierarchyName)) {
+                    throw new Error(`Hierarchy '${hierarchyName}' does not exist in dimension '${dimensionName}'`);
+                }
+                return false;
+            }
+        }
+
+        const mdx = this._buildDrillIntersectionMdx(
+            dimensionName, hierarchyName,
+            ancestorName, elementName,
+            method, true
+        );
+        const cardinality = await this._getMdxSetCardinality(mdx);
+        return cardinality > 0;
+    }
+
+    /**
+     * Remove a single edge from a hierarchy
+     */
+    public async removeEdge(
+        dimensionName: string,
+        hierarchyName: string,
+        parentName: string,
+        componentName: string
+    ): Promise<AxiosResponse> {
+        const url = formatUrl(
+            "/Dimensions('{}')/Hierarchies('{}')/Elements('{}')/Edges(ParentName='{}',ComponentName='{}')",
+            dimensionName, hierarchyName, parentName, parentName, componentName
+        );
+        return this.rest.delete(url);
+    }
+
+    /**
+     * Check if a hierarchy exists in a dimension (convenience delegation to HierarchyService)
+     */
+    public async hierarchyExists(
+        dimensionName: string,
+        hierarchyName: string
+    ): Promise<boolean> {
+        const hierarchyService = new HierarchyService(this.rest);
+        return hierarchyService.exists(dimensionName, hierarchyName);
+    }
+
+    /**
+     * Get all element names and alias values for leaf elements as a case-and-space-insensitive set
+     */
+    public async getAllLeafElementIdentifiers(
+        dimensionName: string,
+        hierarchyName: string
+    ): Promise<CaseAndSpaceInsensitiveSet> {
+        const mdxElements = `{ Tm1FilterByLevel ( { Tm1SubsetAll ([${dimensionName}].[${hierarchyName}]) } , 0 ) }`;
+
+        const aliasAttributes = await this.getAliasElementAttributes(dimensionName, hierarchyName);
+
+        if (aliasAttributes.length === 0) {
+            const result = await this.executeSetMdx(mdxElements, undefined, ['Name'], null, null);
+            const identifiers = new CaseAndSpaceInsensitiveSet();
+            for (const record of result) {
+                identifiers.add(record[0].Name);
+            }
+            return identifiers;
+        }
+
+        const attrMdx = aliasAttributes.map(a =>
+            `[}ElementAttributes_${dimensionName}].[}ElementAttributes_${dimensionName}].[${a}]`
+        ).join(',');
+        const mdx = `SELECT ${mdxElements} ON ROWS, {${attrMdx}} ON COLUMNS FROM [}ElementAttributes_${dimensionName}]`;
+
+        return this._retrieveMdxRowsAndCellValuesAsStringSet(mdx);
+    }
+
+    // ===== PRIVATE HELPERS FOR ISSUE #37 =====
+
+    private _buildDrillIntersectionMdx(
+        dimensionName: string,
+        hierarchyName: string,
+        firstElementName: string,
+        secondElementName: string,
+        mdxMethod: string,
+        recursive: boolean
+    ): string {
+        const first = `[${dimensionName}].[${hierarchyName}].[${firstElementName}]`;
+        const second = `[${dimensionName}].[${hierarchyName}].[${secondElementName}]`;
+
+        let drillSet: string;
+        if (mdxMethod.toUpperCase() === 'TM1DRILLDOWNMEMBER') {
+            drillSet = recursive
+                ? `{TM1DRILLDOWNMEMBER({${first}}, ALL, RECURSIVE)}`
+                : `{TM1DRILLDOWNMEMBER({${first}}, ALL)}`;
+        } else if (mdxMethod.toUpperCase() === 'DESCENDANTS') {
+            drillSet = `{DESCENDANTS(${first}, ${second}.Level, SELF)}`;
+        } else {
+            throw new Error("Invalid MDX Drill Method. Options: 'TM1DrillDownMember' or 'Descendants'");
+        }
+
+        return `INTERSECT(${drillSet}, {${second}})`;
+    }
+
+    private async _getMdxSetCardinality(mdx: string): Promise<number> {
+        const url = '/ExecuteMDXSetExpression?$select=Cardinality';
+        const payload = { MDX: mdx };
+        const response = await this.rest.post(url, JSON.stringify(payload));
+        return response.data.Cardinality || 0;
+    }
+
+    private async _elementIsAncestorTi(
+        dimensionName: string,
+        hierarchyName: string,
+        elementName: string,
+        ancestorName: string
+    ): Promise<boolean> {
+        const processService = new ProcessService(this.rest);
+        const code = `ElementIsAncestor('${dimensionName.replace(/'/g, "''")}', '${hierarchyName.replace(/'/g, "''")}', '${ancestorName.replace(/'/g, "''")}', '${elementName.replace(/'/g, "''")}')=1`;
+        return processService.evaluateBooleanTiExpression(code);
+    }
+
+    private async _retrieveMdxRowsAndCellValuesAsStringSet(mdx: string): Promise<CaseAndSpaceInsensitiveSet> {
+        const url = '/ExecuteMDX';
+        const response = await this.rest.post(url, JSON.stringify({ MDX: mdx }));
+        const data = response.data;
+        const result = new CaseAndSpaceInsensitiveSet();
+
+        // Collect row member names from the row axis (Axes[1])
+        if (data.Axes && data.Axes.length > 1 && data.Axes[1].Tuples) {
+            for (const tuple of data.Axes[1].Tuples) {
+                for (const member of (tuple.Members || [])) {
+                    if (member.Name) {
+                        result.add(member.Name);
+                    }
+                }
+            }
+        }
+
+        // Collect non-null, non-empty string cell values (alias values)
+        if (data.Cells) {
+            for (const cell of data.Cells) {
+                if (cell.Value && typeof cell.Value === 'string' && cell.Value.trim() !== '') {
+                    result.add(cell.Value);
+                }
+            }
+        }
+
+        return result;
     }
 }

--- a/src/tests/elementService.issue37.test.ts
+++ b/src/tests/elementService.issue37.test.ts
@@ -4,8 +4,6 @@
 
 import { ElementService } from '../services/ElementService';
 import { RestService } from '../services/RestService';
-import { HierarchyService } from '../services/HierarchyService';
-import { ProcessService } from '../services/ProcessService';
 import { TM1RestException } from '../exceptions/TM1Exception';
 
 const createMockResponse = (data: any, status: number = 200) => ({
@@ -510,6 +508,64 @@ describe('ElementService — Issue #37: 13 missing methods', () => {
             const result = await getCardinality('SOME MDX');
 
             expect(result).toBe(0);
+        });
+    });
+
+    // ===== EDGE CASE TESTS (P2 review feedback) =====
+
+    describe('elementIsAncestor — additional edge cases', () => {
+        test('should auto-select TI method when isAdmin is true', async () => {
+            Object.defineProperty(elementService, 'isAdmin', { get: () => true });
+            const tiSpy = jest.spyOn(elementService as any, '_elementIsAncestorTi').mockResolvedValue(true);
+
+            const result = await elementService.elementIsAncestor('Dim1', 'Hier1', 'Ancestor', 'Elem');
+
+            expect(result).toBe(true);
+            expect(tiSpy).toHaveBeenCalled();
+        });
+    });
+
+    describe('getElementTypesFromAllHierarchies — additional edge cases', () => {
+        test('should handle empty Hierarchies array', async () => {
+            mockRestService.get.mockResolvedValue(createMockResponse({
+                Hierarchies: []
+            }));
+
+            const result = await elementService.getElementTypesFromAllHierarchies('EmptyDim');
+            expect(result.size).toBe(0);
+        });
+    });
+
+    describe('getParentsOfAllElements — additional edge cases', () => {
+        test('should handle empty value array', async () => {
+            mockRestService.get.mockResolvedValue(createMockResponse({ value: [] }));
+
+            const result = await elementService.getParentsOfAllElements('Dim1', 'Hier1');
+            expect(Object.keys(result)).toHaveLength(0);
+        });
+    });
+
+    describe('_retrieveMdxRowsAndCellValuesAsStringSet — additional edge cases', () => {
+        test('should return empty set when Axes and Cells are missing', async () => {
+            // CellService.executeMdxRowsAndValues handles missing Axes/Cells
+            mockRestService.post.mockResolvedValue(createMockResponse({}));
+
+            const retrieve = (elementService as any)._retrieveMdxRowsAndCellValuesAsStringSet.bind(elementService);
+            const result = await retrieve('SELECT {} ON ROWS FROM [Cube]');
+
+            expect(result.size).toBe(0);
+        });
+    });
+
+    describe('getElementPrincipalName — additional edge cases', () => {
+        test('should propagate error when element not found', async () => {
+            mockRestService.get.mockRejectedValue(
+                new TM1RestException('Not found', 404, { status: 404 })
+            );
+
+            await expect(
+                elementService.getElementPrincipalName('Dim1', 'Hier1', 'NonExistent')
+            ).rejects.toThrow();
         });
     });
 });

--- a/src/tests/elementService.issue37.test.ts
+++ b/src/tests/elementService.issue37.test.ts
@@ -1,0 +1,515 @@
+/**
+ * Tests for ElementService issue #37 — 13 missing methods for tm1py parity
+ */
+
+import { ElementService } from '../services/ElementService';
+import { RestService } from '../services/RestService';
+import { HierarchyService } from '../services/HierarchyService';
+import { ProcessService } from '../services/ProcessService';
+import { TM1RestException } from '../exceptions/TM1Exception';
+
+const createMockResponse = (data: any, status: number = 200) => ({
+    data,
+    status,
+    statusText: 'OK',
+    headers: {},
+    config: {} as any
+});
+
+describe('ElementService — Issue #37: 13 missing methods', () => {
+    let elementService: ElementService;
+    let mockRestService: jest.Mocked<RestService>;
+
+    beforeEach(() => {
+        mockRestService = {
+            get: jest.fn(),
+            post: jest.fn(),
+            patch: jest.fn(),
+            delete: jest.fn(),
+            put: jest.fn(),
+            config: {} as any,
+            rest: {} as any,
+            buildBaseUrl: jest.fn(),
+            extractErrorMessage: jest.fn()
+        } as any;
+
+        elementService = new ElementService(mockRestService);
+    });
+
+    // ===== COUNT METHODS =====
+
+    describe('getNumberOfConsolidatedElements', () => {
+        test('should return count with Type eq 3 filter', async () => {
+            mockRestService.get.mockResolvedValue(createMockResponse('5'));
+
+            const count = await elementService.getNumberOfConsolidatedElements('Dim1', 'Hier1');
+
+            expect(count).toBe(5);
+            expect(mockRestService.get).toHaveBeenCalledWith(
+                expect.stringContaining('$filter=Type eq 3')
+            );
+            expect(mockRestService.get).toHaveBeenCalledWith(
+                expect.stringContaining('$count')
+            );
+        });
+
+        test('should return 0 for empty response', async () => {
+            mockRestService.get.mockResolvedValue(createMockResponse(''));
+
+            const count = await elementService.getNumberOfConsolidatedElements('Dim1', 'Hier1');
+            expect(count).toBe(0);
+        });
+    });
+
+    describe('getNumberOfLeafElements', () => {
+        test('should return count with Type ne 3 filter', async () => {
+            mockRestService.get.mockResolvedValue(createMockResponse('10'));
+
+            const count = await elementService.getNumberOfLeafElements('Dim1', 'Hier1');
+
+            expect(count).toBe(10);
+            expect(mockRestService.get).toHaveBeenCalledWith(
+                expect.stringContaining('$filter=Type ne 3')
+            );
+        });
+    });
+
+    describe('getNumberOfNumericElements', () => {
+        test('should return count with Type eq 1 filter', async () => {
+            mockRestService.get.mockResolvedValue(createMockResponse('7'));
+
+            const count = await elementService.getNumberOfNumericElements('Dim1', 'Hier1');
+
+            expect(count).toBe(7);
+            expect(mockRestService.get).toHaveBeenCalledWith(
+                expect.stringContaining('$filter=Type eq 1')
+            );
+        });
+    });
+
+    describe('getNumberOfStringElements', () => {
+        test('should return count with Type eq 2 filter', async () => {
+            mockRestService.get.mockResolvedValue(createMockResponse('3'));
+
+            const count = await elementService.getNumberOfStringElements('Dim1', 'Hier1');
+
+            expect(count).toBe(3);
+            expect(mockRestService.get).toHaveBeenCalledWith(
+                expect.stringContaining('$filter=Type eq 2')
+            );
+        });
+    });
+
+    // ===== IDENTIFIER METHODS =====
+
+    describe('getElementTypesFromAllHierarchies', () => {
+        test('should return element types from all hierarchies', async () => {
+            mockRestService.get.mockResolvedValue(createMockResponse({
+                Hierarchies: [
+                    {
+                        Elements: [
+                            { Name: 'Elem1', Type: 'Numeric' },
+                            { Name: 'Elem2', Type: 'String' }
+                        ]
+                    },
+                    {
+                        Elements: [
+                            { Name: 'Elem3', Type: 'Consolidated' }
+                        ]
+                    }
+                ]
+            }));
+
+            const result = await elementService.getElementTypesFromAllHierarchies('TestDim');
+
+            expect(result.get('Elem1')).toBe('Numeric');
+            expect(result.get('Elem2')).toBe('String');
+            expect(result.get('Elem3')).toBe('Consolidated');
+        });
+
+        test('should include filter when skipConsolidations is true', async () => {
+            mockRestService.get.mockResolvedValue(createMockResponse({
+                Hierarchies: [{ Elements: [{ Name: 'Elem1', Type: 'Numeric' }] }]
+            }));
+
+            await elementService.getElementTypesFromAllHierarchies('TestDim', true);
+
+            expect(mockRestService.get).toHaveBeenCalledWith(
+                expect.stringContaining('$filter=Type ne 3')
+            );
+        });
+
+        test('should not include filter when skipConsolidations is false', async () => {
+            mockRestService.get.mockResolvedValue(createMockResponse({
+                Hierarchies: [{ Elements: [{ Name: 'Elem1', Type: 'Numeric' }] }]
+            }));
+
+            await elementService.getElementTypesFromAllHierarchies('TestDim', false);
+
+            const calledUrl = mockRestService.get.mock.calls[0][0];
+            expect(calledUrl).not.toContain('$filter');
+        });
+
+        test('should be case-and-space-insensitive', async () => {
+            mockRestService.get.mockResolvedValue(createMockResponse({
+                Hierarchies: [
+                    { Elements: [{ Name: 'My Element', Type: 'Numeric' }] }
+                ]
+            }));
+
+            const result = await elementService.getElementTypesFromAllHierarchies('TestDim');
+            expect(result.get('myelement')).toBe('Numeric');
+            expect(result.get('MY ELEMENT')).toBe('Numeric');
+        });
+    });
+
+    describe('getAllLeafElementIdentifiers', () => {
+        test('should return element names when no alias attributes exist', async () => {
+            // Mock getAliasElementAttributes → empty
+            jest.spyOn(elementService, 'getAliasElementAttributes').mockResolvedValue([]);
+            // Mock executeSetMdx → returns members
+            jest.spyOn(elementService, 'executeSetMdx').mockResolvedValue([
+                [{ Name: 'Leaf1' }],
+                [{ Name: 'Leaf2' }],
+                [{ Name: 'Leaf3' }]
+            ]);
+
+            const result = await elementService.getAllLeafElementIdentifiers('Dim1', 'Hier1');
+
+            expect(result.has('Leaf1')).toBe(true);
+            expect(result.has('Leaf2')).toBe(true);
+            expect(result.has('Leaf3')).toBe(true);
+            expect(result.has('leaf1')).toBe(true); // case insensitive
+        });
+
+        test('should include alias values when alias attributes exist', async () => {
+            jest.spyOn(elementService, 'getAliasElementAttributes').mockResolvedValue(['Alias1']);
+
+            // Mock ExecuteMDX response with axes and cells
+            mockRestService.post.mockResolvedValue(createMockResponse({
+                Axes: [
+                    { Tuples: [{ Members: [{ Name: 'Alias1' }] }] },  // column axis
+                    {
+                        Tuples: [
+                            { Members: [{ Name: 'Leaf1' }] },
+                            { Members: [{ Name: 'Leaf2' }] }
+                        ]
+                    }  // row axis
+                ],
+                Cells: [
+                    { Value: 'Alias_Leaf1' },
+                    { Value: 'Alias_Leaf2' }
+                ]
+            }));
+
+            const result = await elementService.getAllLeafElementIdentifiers('Dim1', 'Hier1');
+
+            // Should contain both element names and alias values
+            expect(result.has('Leaf1')).toBe(true);
+            expect(result.has('Leaf2')).toBe(true);
+            expect(result.has('Alias_Leaf1')).toBe(true);
+            expect(result.has('Alias_Leaf2')).toBe(true);
+        });
+
+        test('should skip empty alias values', async () => {
+            jest.spyOn(elementService, 'getAliasElementAttributes').mockResolvedValue(['Alias1']);
+
+            mockRestService.post.mockResolvedValue(createMockResponse({
+                Axes: [
+                    { Tuples: [{ Members: [{ Name: 'Alias1' }] }] },
+                    { Tuples: [{ Members: [{ Name: 'Elem1' }] }] }
+                ],
+                Cells: [
+                    { Value: '' },  // empty alias
+                    { Value: null }  // null alias
+                ]
+            }));
+
+            const result = await elementService.getAllLeafElementIdentifiers('Dim1', 'Hier1');
+
+            expect(result.has('Elem1')).toBe(true);
+            expect(result.size).toBe(1); // only the element name, no empty/null aliases
+        });
+    });
+
+    // ===== EXISTENCE METHODS =====
+
+    describe('attributeCubeExists', () => {
+        test('should return true when attribute cube exists', async () => {
+            mockRestService.get.mockResolvedValue(createMockResponse({}));
+
+            const result = await elementService.attributeCubeExists('TestDim');
+
+            expect(result).toBe(true);
+            expect(mockRestService.get).toHaveBeenCalledWith(
+                expect.stringContaining("ElementAttributes_TestDim")
+            );
+        });
+
+        test('should return false when attribute cube does not exist', async () => {
+            mockRestService.get.mockRejectedValue(
+                new TM1RestException('Not found', 404, { status: 404 })
+            );
+
+            const result = await elementService.attributeCubeExists('NonExistentDim');
+            expect(result).toBe(false);
+        });
+    });
+
+    // ===== TRAVERSAL METHODS =====
+
+    describe('getParentsOfAllElements', () => {
+        test('should return parent mapping for all elements', async () => {
+            mockRestService.get.mockResolvedValue(createMockResponse({
+                value: [
+                    { Name: 'Leaf1', Parents: [{ Name: 'Parent1' }, { Name: 'Parent2' }] },
+                    { Name: 'Leaf2', Parents: [{ Name: 'Parent1' }] },
+                    { Name: 'Parent1', Parents: [] }
+                ]
+            }));
+
+            const result = await elementService.getParentsOfAllElements('Dim1', 'Hier1');
+
+            expect(result['Leaf1']).toEqual(['Parent1', 'Parent2']);
+            expect(result['Leaf2']).toEqual(['Parent1']);
+            expect(result['Parent1']).toEqual([]);
+        });
+
+        test('should handle elements with no Parents property', async () => {
+            mockRestService.get.mockResolvedValue(createMockResponse({
+                value: [
+                    { Name: 'Orphan' }
+                ]
+            }));
+
+            const result = await elementService.getParentsOfAllElements('Dim1', 'Hier1');
+            expect(result['Orphan']).toEqual([]);
+        });
+
+        test('should use correct URL with expand', async () => {
+            mockRestService.get.mockResolvedValue(createMockResponse({ value: [] }));
+
+            await elementService.getParentsOfAllElements('Dim1', 'Hier1');
+
+            expect(mockRestService.get).toHaveBeenCalledWith(
+                expect.stringContaining('$expand=Parents($select=Name)')
+            );
+        });
+    });
+
+    describe('getElementPrincipalName', () => {
+        test('should return the canonical element name', async () => {
+            mockRestService.get.mockResolvedValue(createMockResponse({
+                Name: 'CanonicalName',
+                Type: 'Numeric',
+                Level: 0,
+                Index: 1
+            }));
+
+            const name = await elementService.getElementPrincipalName('Dim1', 'Hier1', 'someAlias');
+            expect(name).toBe('CanonicalName');
+        });
+    });
+
+    // ===== RELATIONSHIP CHECK METHODS =====
+
+    describe('elementIsParent', () => {
+        test('should return true when element is a direct parent', async () => {
+            mockRestService.post.mockResolvedValue(createMockResponse({
+                Cardinality: 1
+            }));
+
+            const result = await elementService.elementIsParent('Dim1', 'Hier1', 'ParentElem', 'ChildElem');
+            expect(result).toBe(true);
+        });
+
+        test('should return false when element is not a direct parent', async () => {
+            mockRestService.post.mockResolvedValue(createMockResponse({
+                Cardinality: 0
+            }));
+
+            const result = await elementService.elementIsParent('Dim1', 'Hier1', 'NotParent', 'ChildElem');
+            expect(result).toBe(false);
+        });
+
+        test('should use TM1DRILLDOWNMEMBER without RECURSIVE', async () => {
+            mockRestService.post.mockResolvedValue(createMockResponse({ Cardinality: 0 }));
+
+            await elementService.elementIsParent('Dim1', 'Hier1', 'Parent', 'Child');
+
+            const mdxPayload = JSON.parse(mockRestService.post.mock.calls[0][1]);
+            expect(mdxPayload.MDX).toContain('TM1DRILLDOWNMEMBER');
+            expect(mdxPayload.MDX).not.toContain('RECURSIVE');
+            expect(mdxPayload.MDX).toContain('INTERSECT');
+        });
+    });
+
+    describe('elementIsAncestor', () => {
+        test('should use TM1DrillDownMember with RECURSIVE for non-admin', async () => {
+            // Mock isAdmin = false (default)
+            jest.spyOn(elementService, 'exists').mockResolvedValue(true);
+            mockRestService.post.mockResolvedValue(createMockResponse({ Cardinality: 1 }));
+
+            const result = await elementService.elementIsAncestor('Dim1', 'Hier1', 'Ancestor', 'Elem');
+
+            expect(result).toBe(true);
+            const mdxPayload = JSON.parse(mockRestService.post.mock.calls[0][1]);
+            expect(mdxPayload.MDX).toContain('TM1DRILLDOWNMEMBER');
+            expect(mdxPayload.MDX).toContain('RECURSIVE');
+        });
+
+        test('should return false when element does not exist (TM1DrillDownMember)', async () => {
+            jest.spyOn(elementService, 'exists').mockResolvedValue(false);
+            jest.spyOn(elementService, 'hierarchyExists').mockResolvedValue(true);
+
+            const result = await elementService.elementIsAncestor(
+                'Dim1', 'Hier1', 'Ancestor', 'NonExistent', 'TM1DrillDownMember'
+            );
+
+            expect(result).toBe(false);
+        });
+
+        test('should throw when hierarchy does not exist (TM1DrillDownMember)', async () => {
+            jest.spyOn(elementService, 'exists').mockResolvedValue(false);
+            jest.spyOn(elementService, 'hierarchyExists').mockResolvedValue(false);
+
+            await expect(
+                elementService.elementIsAncestor('Dim1', 'BadHier', 'Ancestor', 'Elem', 'TM1DrillDownMember')
+            ).rejects.toThrow("Hierarchy 'BadHier' does not exist in dimension 'Dim1'");
+        });
+
+        test('should use DESCENDANTS method when specified', async () => {
+            jest.spyOn(elementService, 'exists').mockResolvedValue(true);
+            mockRestService.post.mockResolvedValue(createMockResponse({ Cardinality: 1 }));
+
+            await elementService.elementIsAncestor('Dim1', 'Hier1', 'Ancestor', 'Elem', 'Descendants');
+
+            const mdxPayload = JSON.parse(mockRestService.post.mock.calls[0][1]);
+            expect(mdxPayload.MDX).toContain('DESCENDANTS');
+        });
+
+        test('should use TI method when specified', async () => {
+            // Mock _elementIsAncestorTi
+            const tiSpy = jest.spyOn(elementService as any, '_elementIsAncestorTi').mockResolvedValue(true);
+
+            const result = await elementService.elementIsAncestor('Dim1', 'Hier1', 'Ancestor', 'Elem', 'TI');
+
+            expect(result).toBe(true);
+            expect(tiSpy).toHaveBeenCalledWith('Dim1', 'Hier1', 'Elem', 'Ancestor');
+        });
+
+        test('should check hierarchy existence when TI returns false', async () => {
+            jest.spyOn(elementService as any, '_elementIsAncestorTi').mockResolvedValue(false);
+            const hierSpy = jest.spyOn(elementService, 'hierarchyExists').mockResolvedValue(true);
+
+            const result = await elementService.elementIsAncestor('Dim1', 'Hier1', 'Ancestor', 'Elem', 'TI');
+
+            expect(result).toBe(false);
+            expect(hierSpy).toHaveBeenCalledWith('Dim1', 'Hier1');
+        });
+
+        test('should throw when TI returns false and hierarchy does not exist', async () => {
+            jest.spyOn(elementService as any, '_elementIsAncestorTi').mockResolvedValue(false);
+            jest.spyOn(elementService, 'hierarchyExists').mockResolvedValue(false);
+
+            await expect(
+                elementService.elementIsAncestor('Dim1', 'BadHier', 'Ancestor', 'Elem', 'TI')
+            ).rejects.toThrow("Hierarchy: 'BadHier' does not exist in dimension: 'Dim1'");
+        });
+    });
+
+    // ===== EDGE METHODS =====
+
+    describe('removeEdge', () => {
+        test('should DELETE the correct edge URL', async () => {
+            mockRestService.delete.mockResolvedValue(createMockResponse({}, 204));
+
+            await elementService.removeEdge('Dim1', 'Hier1', 'ParentElem', 'ChildElem');
+
+            const calledUrl = mockRestService.delete.mock.calls[0][0];
+            expect(calledUrl).toContain("Elements('ParentElem')");
+            expect(calledUrl).toContain("ParentName='ParentElem'");
+            expect(calledUrl).toContain("ComponentName='ChildElem'");
+            expect(calledUrl).toContain('Edges(');
+        });
+    });
+
+    describe('hierarchyExists', () => {
+        test('should delegate to HierarchyService.exists and return true', async () => {
+            // HierarchyService.exists does a GET and checks names
+            mockRestService.get.mockResolvedValue(createMockResponse({
+                value: [{ Name: 'Hier1' }]
+            }));
+
+            const result = await elementService.hierarchyExists('Dim1', 'Hier1');
+            expect(result).toBe(true);
+        });
+
+        test('should return false when hierarchy does not exist', async () => {
+            mockRestService.get.mockResolvedValue(createMockResponse({
+                value: [{ Name: 'OtherHier' }]
+            }));
+
+            const result = await elementService.hierarchyExists('Dim1', 'NonExistent');
+            expect(result).toBe(false);
+        });
+    });
+
+    // ===== PRIVATE HELPER TESTS =====
+
+    describe('_buildDrillIntersectionMdx (via elementIsParent/elementIsAncestor)', () => {
+        test('should throw for invalid MDX method', () => {
+            const buildMdx = (elementService as any)._buildDrillIntersectionMdx.bind(elementService);
+            expect(() => buildMdx('D', 'H', 'A', 'B', 'INVALID', false)).toThrow(
+                "Invalid MDX Drill Method"
+            );
+        });
+
+        test('should build correct TM1DrillDownMember MDX', () => {
+            const buildMdx = (elementService as any)._buildDrillIntersectionMdx.bind(elementService);
+
+            const nonRecursive = buildMdx('Dim', 'Hier', 'Parent', 'Child', 'TM1DrillDownMember', false);
+            expect(nonRecursive).toBe(
+                'INTERSECT({TM1DRILLDOWNMEMBER({[Dim].[Hier].[Parent]}, ALL)}, {[Dim].[Hier].[Child]})'
+            );
+
+            const recursive = buildMdx('Dim', 'Hier', 'Ancestor', 'Leaf', 'TM1DrillDownMember', true);
+            expect(recursive).toBe(
+                'INTERSECT({TM1DRILLDOWNMEMBER({[Dim].[Hier].[Ancestor]}, ALL, RECURSIVE)}, {[Dim].[Hier].[Leaf]})'
+            );
+        });
+
+        test('should build correct DESCENDANTS MDX', () => {
+            const buildMdx = (elementService as any)._buildDrillIntersectionMdx.bind(elementService);
+
+            const result = buildMdx('Dim', 'Hier', 'Ancestor', 'Elem', 'Descendants', true);
+            expect(result).toBe(
+                'INTERSECT({DESCENDANTS([Dim].[Hier].[Ancestor], [Dim].[Hier].[Elem].Level, SELF)}, {[Dim].[Hier].[Elem]})'
+            );
+        });
+    });
+
+    describe('_getMdxSetCardinality', () => {
+        test('should POST to ExecuteMDXSetExpression and return cardinality', async () => {
+            mockRestService.post.mockResolvedValue(createMockResponse({ Cardinality: 5 }));
+
+            const getCardinality = (elementService as any)._getMdxSetCardinality.bind(elementService);
+            const result = await getCardinality('SOME MDX');
+
+            expect(result).toBe(5);
+            expect(mockRestService.post).toHaveBeenCalledWith(
+                '/ExecuteMDXSetExpression?$select=Cardinality',
+                expect.stringContaining('SOME MDX')
+            );
+        });
+
+        test('should return 0 when Cardinality is missing', async () => {
+            mockRestService.post.mockResolvedValue(createMockResponse({}));
+
+            const getCardinality = (elementService as any)._getMdxSetCardinality.bind(elementService);
+            const result = await getCardinality('SOME MDX');
+
+            expect(result).toBe(0);
+        });
+    });
+});


### PR DESCRIPTION
## Summary

- Implement 13 missing `ElementService` methods for tm1py v2.2.4 parity: 4 count methods (`getNumberOfConsolidatedElements`, `getNumberOfLeafElements`, `getNumberOfNumericElements`, `getNumberOfStringElements`), 2 identifier methods (`getAllLeafElementIdentifiers`, `getElementTypesFromAllHierarchies`), 1 existence check (`attributeCubeExists`), 2 traversal methods (`getParentsOfAllElements`, `getElementPrincipalName`), 2 relationship checks (`elementIsParent`, `elementIsAncestor`), and 2 edge/hierarchy methods (`removeEdge`, `hierarchyExists`)
- Add 5 private helpers: `_getElementCountWithFilter`, `_buildDrillIntersectionMdx`, `_getMdxSetCardinality`, `_elementIsAncestorTi`, `_retrieveMdxRowsAndCellValuesAsStringSet`
- Add 36 unit tests covering all new methods with positive, negative, and edge case scenarios

Closes #37

## Test plan

- [x] All 36 new tests pass (`npx jest src/tests/elementService.issue37.test.ts`)
- [x] All 141 ElementService tests pass (no regressions)
- [x] Full suite: 1156 unit tests pass
- [x] TypeScript compiles cleanly (`tsc --noEmit`)
- [ ] Integration test against live TM1 server (manual verification)