### PR TITLE
feat(#38): implement missing HierarchyService, ApplicationService, SubsetService methods

### DIFF
--- a/src/services/ApplicationService.ts
+++ b/src/services/ApplicationService.ts
@@ -461,7 +461,7 @@ export class ApplicationService extends ObjectService {
         useCache: boolean = false
     ): Promise<{ baseUrl: string; inPrivateContext: boolean }> {
         if (!path || !path.trim()) {
-            return { baseUrl: "/Contents('Applications')", inPrivateContext: false };
+            return { baseUrl: "/Contents('Applications')", inPrivateContext: isPrivate };
         }
 
         const segments = path.split('/').filter(s => s.trim().length > 0);

--- a/src/services/ApplicationService.ts
+++ b/src/services/ApplicationService.ts
@@ -97,7 +97,6 @@ export class ApplicationService extends ObjectService {
                 return new FolderApplication(path, name);
             }
             case ApplicationTypes.LINK: {
-                await this.rest.get(baseUrl);
                 const response = await this.rest.get(baseUrl + "?$expand=*");
                 return new LinkApplication(path, response.data?.Name || name, response.data?.URL || '');
             }
@@ -316,20 +315,21 @@ export class ApplicationService extends ObjectService {
         return await this.update(document, isPrivate);
     }
 
+    // NOTE: `flat` parameter is accepted for tm1py signature parity but output is always flat.
+    // Nested (tree) mode is not yet implemented.
     public async discover(
         path: string = '',
         includePrivate: boolean = false,
         recursive: boolean = false,
-        flat: boolean = false
+        _flat: boolean = false
     ): Promise<Array<{ type: string; name: string; path: string; is_private: boolean }>> {
-        return this._discoverAtPath(path, includePrivate, recursive, flat, false);
+        return this._discoverAtPath(path, includePrivate, recursive, false);
     }
 
     private async _discoverAtPath(
         path: string,
         includePrivate: boolean,
         recursive: boolean,
-        flat: boolean,
         inPrivateContext: boolean
     ): Promise<Array<{ type: string; name: string; path: string; is_private: boolean }>> {
         const results: Array<{ type: string; name: string; path: string; is_private: boolean }> = [];
@@ -337,7 +337,7 @@ export class ApplicationService extends ObjectService {
         if (!inPrivateContext) {
             const publicItems = await this._getContentsRaw(path, false, false);
             const processed = await this._processItems(
-                publicItems, path, false, includePrivate, recursive, flat, false
+                publicItems, path, false, includePrivate, recursive, false
             );
             results.push(...processed);
         }
@@ -345,7 +345,7 @@ export class ApplicationService extends ObjectService {
         if (includePrivate || inPrivateContext) {
             const privateItems = await this._getContentsRaw(path, true, inPrivateContext);
             const processed = await this._processItems(
-                privateItems, path, true, includePrivate, recursive, flat, true
+                privateItems, path, true, includePrivate, recursive, true
             );
             results.push(...processed);
         }
@@ -374,7 +374,6 @@ export class ApplicationService extends ObjectService {
         isPrivate: boolean,
         includePrivate: boolean,
         recursive: boolean,
-        flat: boolean,
         inPrivateContext: boolean
     ): Promise<Array<{ type: string; name: string; path: string; is_private: boolean }>> {
         const results: Array<{ type: string; name: string; path: string; is_private: boolean }> = [];
@@ -397,7 +396,7 @@ export class ApplicationService extends ObjectService {
             if (recursive && typeName === 'Folder') {
                 folderPromises.push(
                     this._discoverAtPath(
-                        itemPath, includePrivate, recursive, flat, inPrivateContext || isPrivate
+                        itemPath, includePrivate, recursive, inPrivateContext || isPrivate
                     )
                 );
             }

--- a/src/services/ApplicationService.ts
+++ b/src/services/ApplicationService.ts
@@ -423,7 +423,10 @@ export class ApplicationService extends ObjectService {
     private _extractTypeFromOdata(odataType: string): string {
         if (!odataType) return 'Unknown';
         const parts = odataType.split('.');
-        return parts[parts.length - 1] || 'Unknown';
+        const raw = parts[parts.length - 1] || 'Unknown';
+        // TM1 returns types like 'FolderApplication', 'CubeApplication' — strip suffix
+        // so folder check works consistently
+        return raw.replace(/Application$/, '') || raw;
     }
 
     private async _findPrivateBoundary(segments: string[]): Promise<number> {

--- a/src/services/ApplicationService.ts
+++ b/src/services/ApplicationService.ts
@@ -41,8 +41,8 @@ export class ApplicationService extends ObjectService {
     public async getNames(path: string, isPrivate: boolean = false, useCache: boolean = false): Promise<string[]> {
         if (isPrivate) {
             const resolved = await this._resolvePath(path, true, useCache);
-            const collection = resolved.inPrivateContext ? 'PrivateContents' : 'Contents';
-            const url = resolved.baseUrl + '/' + collection;
+            // Leaf collection is always PrivateContents when isPrivate — even if parent path is public
+            const url = resolved.baseUrl + '/PrivateContents';
             const response = await this.rest.get(url);
             return response.data.value.map((application: any) => application.Name);
         }
@@ -70,8 +70,7 @@ export class ApplicationService extends ObjectService {
         let baseUrl: string;
         if (isPrivate) {
             const resolved = await this._resolvePath(path, true, useCache);
-            const collection = resolved.inPrivateContext ? 'PrivateContents' : 'Contents';
-            baseUrl = formatUrl(resolved.baseUrl + '/' + collection + "('{}')", requestName);
+            baseUrl = formatUrl(resolved.baseUrl + "/PrivateContents('{}')", requestName);
         } else {
             baseUrl = this.buildApplicationUrl(path, isPrivate, requestName);
         }
@@ -256,8 +255,7 @@ export class ApplicationService extends ObjectService {
         if (isPrivate) {
             try {
                 const resolved = await this._resolvePath(path, true, useCache);
-                const collection = resolved.inPrivateContext ? 'PrivateContents' : 'Contents';
-                const url = formatUrl(resolved.baseUrl + '/' + collection + "('{}')", requestName);
+                const url = formatUrl(resolved.baseUrl + "/PrivateContents('{}')", requestName);
                 return await this._exists(url);
             } catch (error: any) {
                 // Path-not-found from _resolvePath means item doesn't exist
@@ -362,11 +360,12 @@ export class ApplicationService extends ObjectService {
 
     private async _getContentsRaw(path: string, isPrivate: boolean, inPrivateContext: boolean): Promise<any[]> {
         try {
-            const usePrivate = inPrivateContext || isPrivate;
-            const mid = usePrivate
+            // Path segments: use PrivateContents only if we're already inside a private folder tree.
+            // Leaf collection: PrivateContents if isPrivate or inPrivateContext, else Contents.
+            const mid = inPrivateContext
                 ? this.buildPrivatePathSegments(path)
                 : this.buildPathSegments(path);
-            const collection = usePrivate ? 'PrivateContents' : 'Contents';
+            const collection = (inPrivateContext || isPrivate) ? 'PrivateContents' : 'Contents';
             const url = "/Contents('Applications')" + mid + "/" + collection;
             const response = await this.rest.get(url);
             return response.data?.value || [];

--- a/src/services/ApplicationService.ts
+++ b/src/services/ApplicationService.ts
@@ -259,8 +259,15 @@ export class ApplicationService extends ObjectService {
                 const collection = resolved.inPrivateContext ? 'PrivateContents' : 'Contents';
                 const url = formatUrl(resolved.baseUrl + '/' + collection + "('{}')", requestName);
                 return await this._exists(url);
-            } catch {
-                return false;
+            } catch (error: any) {
+                // Path-not-found from _resolvePath means item doesn't exist
+                if (error instanceof Error && error.message.includes('not found')) {
+                    return false;
+                }
+                if (error instanceof TM1RestException && error.statusCode === 404) {
+                    return false;
+                }
+                throw error;
             }
         }
         const contents = this.getContentsCollection(isPrivate);
@@ -355,8 +362,11 @@ export class ApplicationService extends ObjectService {
 
     private async _getContentsRaw(path: string, isPrivate: boolean, inPrivateContext: boolean): Promise<any[]> {
         try {
-            const mid = this.buildPathSegments(path);
-            const collection = (inPrivateContext || isPrivate) ? 'PrivateContents' : 'Contents';
+            const usePrivate = inPrivateContext || isPrivate;
+            const mid = usePrivate
+                ? this.buildPrivatePathSegments(path)
+                : this.buildPathSegments(path);
+            const collection = usePrivate ? 'PrivateContents' : 'Contents';
             const url = "/Contents('Applications')" + mid + "/" + collection;
             const response = await this.rest.get(url);
             return response.data?.value || [];
@@ -540,6 +550,17 @@ export class ApplicationService extends ObjectService {
             .split('/')
             .filter(segment => segment.trim().length > 0)
             .map(segment => formatUrl("/Contents('{}')", segment))
+            .join('');
+    }
+
+    private buildPrivatePathSegments(path: string): string {
+        if (!path || !path.trim()) {
+            return '';
+        }
+        return path
+            .split('/')
+            .filter(segment => segment.trim().length > 0)
+            .map(segment => formatUrl("/PrivateContents('{}')", segment))
             .join('');
     }
 

--- a/src/services/ApplicationService.ts
+++ b/src/services/ApplicationService.ts
@@ -17,8 +17,11 @@ import {
     getApplicationMetadata
 } from '../objects/Application';
 import { formatUrl, verifyVersion } from '../utils/Utils';
+import { TM1RestException } from '../exceptions/TM1Exception';
 
 export class ApplicationService extends ObjectService {
+    private pathCache: Map<string, number> = new Map();
+
     constructor(rest: RestService) {
         super(rest);
     }
@@ -285,6 +288,204 @@ export class ApplicationService extends ObjectService {
         const content = await fs.readFile(filePath);
         const document = new DocumentApplication(applicationPath, applicationName, content);
         return await this.update(document, isPrivate);
+    }
+
+    public async discover(
+        path: string = '',
+        includePrivate: boolean = false,
+        recursive: boolean = false,
+        flat: boolean = false
+    ): Promise<Array<{ type: string; name: string; path: string; is_private: boolean }>> {
+        return this._discoverAtPath(path, includePrivate, recursive, flat, false);
+    }
+
+    private async _discoverAtPath(
+        path: string,
+        includePrivate: boolean,
+        recursive: boolean,
+        flat: boolean,
+        inPrivateContext: boolean
+    ): Promise<Array<{ type: string; name: string; path: string; is_private: boolean }>> {
+        const results: Array<{ type: string; name: string; path: string; is_private: boolean }> = [];
+
+        if (!inPrivateContext) {
+            const publicItems = await this._getContentsRaw(path, false, false);
+            const processed = await this._processItems(
+                publicItems, path, false, includePrivate, recursive, flat, false
+            );
+            results.push(...processed);
+        }
+
+        if (includePrivate || inPrivateContext) {
+            const privateItems = await this._getContentsRaw(path, true, inPrivateContext);
+            const processed = await this._processItems(
+                privateItems, path, true, includePrivate, recursive, flat, true
+            );
+            results.push(...processed);
+        }
+
+        return results;
+    }
+
+    private async _getContentsRaw(path: string, isPrivate: boolean, inPrivateContext: boolean): Promise<any[]> {
+        try {
+            const mid = this.buildPathSegments(path);
+            const collection = (inPrivateContext || isPrivate) ? 'PrivateContents' : 'Contents';
+            const url = "/Contents('Applications')" + mid + "/" + collection;
+            const response = await this.rest.get(url);
+            return response.data?.value || [];
+        } catch (error: any) {
+            if (error instanceof TM1RestException && error.statusCode === 404) {
+                return [];
+            }
+            throw error;
+        }
+    }
+
+    private async _processItems(
+        items: any[],
+        path: string,
+        isPrivate: boolean,
+        includePrivate: boolean,
+        recursive: boolean,
+        flat: boolean,
+        inPrivateContext: boolean
+    ): Promise<Array<{ type: string; name: string; path: string; is_private: boolean }>> {
+        const results: Array<{ type: string; name: string; path: string; is_private: boolean }> = [];
+
+        for (const item of items) {
+            const odataType = item['@odata.type'] || '';
+            const typeName = this._extractTypeFromOdata(odataType);
+            const itemName = item.Name || '';
+            const itemPath = path ? `${path}/${itemName}` : itemName;
+
+            results.push({
+                type: typeName,
+                name: itemName,
+                path: itemPath,
+                is_private: isPrivate || inPrivateContext
+            });
+
+            if (recursive && typeName === 'Folder') {
+                const subItems = await this._discoverAtPath(
+                    itemPath, includePrivate, recursive, flat, inPrivateContext || isPrivate
+                );
+                results.push(...subItems);
+            }
+        }
+
+        return results;
+    }
+
+    private _extractTypeFromOdata(odataType: string): string {
+        if (!odataType) return 'Unknown';
+        const parts = odataType.split('.');
+        return parts[parts.length - 1] || 'Unknown';
+    }
+
+    private async _findPrivateBoundary(segments: string[]): Promise<number> {
+        let publicUrl = "/Contents('Applications')";
+        for (let i = 0; i < segments.length; i++) {
+            const testUrl = publicUrl + formatUrl("/Contents('{}')", segments[i]) + "?$top=0";
+            try {
+                await this.rest.get(testUrl);
+                publicUrl += formatUrl("/Contents('{}')", segments[i]);
+            } catch (error: any) {
+                if (error instanceof TM1RestException && error.statusCode === 404) {
+                    const privateTestUrl = publicUrl + formatUrl("/PrivateContents('{}')", segments[i]) + "?$top=0";
+                    try {
+                        await this.rest.get(privateTestUrl);
+                        return i;
+                    } catch {
+                        return -1;
+                    }
+                }
+                throw error;
+            }
+        }
+        return segments.length;
+    }
+
+    private _buildPathUrl(segments: string[], privateBoundary?: number): string {
+        if (!segments.length) return '';
+
+        let url = '';
+        const boundary = privateBoundary ?? segments.length;
+
+        for (let i = 0; i < segments.length; i++) {
+            if (i < boundary) {
+                url += formatUrl("/Contents('{}')", segments[i]);
+            } else {
+                url += formatUrl("/PrivateContents('{}')", segments[i]);
+            }
+        }
+        return url;
+    }
+
+    private async _resolvePath(
+        path: string,
+        isPrivate: boolean = false,
+        useCache: boolean = false
+    ): Promise<{ baseUrl: string; inPrivateContext: boolean }> {
+        if (!path || !path.trim()) {
+            return { baseUrl: "/Contents('Applications')", inPrivateContext: false };
+        }
+
+        const segments = path.split('/').filter(s => s.trim().length > 0);
+
+        if (!isPrivate) {
+            const mid = segments.map(s => formatUrl("/Contents('{}')", s)).join('');
+            return { baseUrl: "/Contents('Applications')" + mid, inPrivateContext: false };
+        }
+
+        const cacheKey = path;
+        if (useCache && this.pathCache.has(cacheKey)) {
+            const boundary = this.pathCache.get(cacheKey)!;
+            const mid = this._buildPathUrl(segments, boundary);
+            return {
+                baseUrl: "/Contents('Applications')" + mid,
+                inPrivateContext: boundary < segments.length
+            };
+        }
+
+        // Try all-public first (optimistic)
+        try {
+            const publicUrl = "/Contents('Applications')" +
+                segments.map(s => formatUrl("/Contents('{}')", s)).join('') + "?$top=0";
+            await this.rest.get(publicUrl);
+            if (useCache) this.pathCache.set(cacheKey, segments.length);
+            return {
+                baseUrl: "/Contents('Applications')" +
+                    segments.map(s => formatUrl("/Contents('{}')", s)).join(''),
+                inPrivateContext: false
+            };
+        } catch { /* fall through */ }
+
+        // Try all-private
+        try {
+            const privateUrl = "/Contents('Applications')" +
+                segments.map(s => formatUrl("/PrivateContents('{}')", s)).join('') + "?$top=0";
+            await this.rest.get(privateUrl);
+            if (useCache) this.pathCache.set(cacheKey, 0);
+            return {
+                baseUrl: "/Contents('Applications')" +
+                    segments.map(s => formatUrl("/PrivateContents('{}')", s)).join(''),
+                inPrivateContext: true
+            };
+        } catch { /* fall through */ }
+
+        // Iterative boundary search
+        const boundary = await this._findPrivateBoundary(segments);
+        if (boundary === -1) {
+            throw new Error(`Application path not found: ${path}`);
+        }
+
+        if (useCache) this.pathCache.set(cacheKey, boundary);
+        const mid = this._buildPathUrl(segments, boundary);
+        return {
+            baseUrl: "/Contents('Applications')" + mid,
+            inPrivateContext: boundary < segments.length
+        };
     }
 
     private parseApplicationType(applicationType: string | ApplicationTypes): ApplicationTypes {

--- a/src/services/ApplicationService.ts
+++ b/src/services/ApplicationService.ts
@@ -38,7 +38,14 @@ export class ApplicationService extends ObjectService {
         return response.data.value.map((application: any) => application.Name);
     }
 
-    public async getNames(path: string, isPrivate: boolean = false): Promise<string[]> {
+    public async getNames(path: string, isPrivate: boolean = false, useCache: boolean = false): Promise<string[]> {
+        if (isPrivate) {
+            const resolved = await this._resolvePath(path, true, useCache);
+            const collection = resolved.inPrivateContext ? 'PrivateContents' : 'Contents';
+            const url = resolved.baseUrl + '/' + collection;
+            const response = await this.rest.get(url);
+            return response.data.value.map((application: any) => application.Name);
+        }
         const contents = this.getContentsCollection(isPrivate);
         const mid = this.buildPathSegments(path);
         const baseUrl = "/Contents('Applications')" + mid + "/" + contents;
@@ -50,7 +57,8 @@ export class ApplicationService extends ObjectService {
         path: string,
         applicationType: string | ApplicationTypes,
         name: string,
-        isPrivate: boolean = false
+        isPrivate: boolean = false,
+        useCache: boolean = false
     ): Promise<Application> {
         const appType = this.parseApplicationType(applicationType);
 
@@ -59,7 +67,14 @@ export class ApplicationService extends ObjectService {
         }
 
         const requestName = this.withLegacySuffix(name, appType);
-        const baseUrl = this.buildApplicationUrl(path, isPrivate, requestName);
+        let baseUrl: string;
+        if (isPrivate) {
+            const resolved = await this._resolvePath(path, true, useCache);
+            const collection = resolved.inPrivateContext ? 'PrivateContents' : 'Contents';
+            baseUrl = formatUrl(resolved.baseUrl + '/' + collection + "('{}')", requestName);
+        } else {
+            baseUrl = this.buildApplicationUrl(path, isPrivate, requestName);
+        }
 
         switch (appType) {
             case ApplicationTypes.CUBE: {
@@ -235,11 +250,22 @@ export class ApplicationService extends ObjectService {
         path: string,
         applicationType: ApplicationTypes,
         name: string,
-        isPrivate: boolean = false
+        isPrivate: boolean = false,
+        useCache: boolean = false
     ): Promise<boolean> {
+        const requestName = this.withLegacySuffix(name, applicationType);
+        if (isPrivate) {
+            try {
+                const resolved = await this._resolvePath(path, true, useCache);
+                const collection = resolved.inPrivateContext ? 'PrivateContents' : 'Contents';
+                const url = formatUrl(resolved.baseUrl + '/' + collection + "('{}')", requestName);
+                return await this._exists(url);
+            } catch {
+                return false;
+            }
+        }
         const contents = this.getContentsCollection(isPrivate);
         const mid = this.buildPathSegments(path);
-        const requestName = this.withLegacySuffix(name, applicationType);
         const url = formatUrl(
             "/Contents('Applications')" + mid + "/" + contents + "('{}')",
             requestName
@@ -353,7 +379,7 @@ export class ApplicationService extends ObjectService {
     ): Promise<Array<{ type: string; name: string; path: string; is_private: boolean }>> {
         const results: Array<{ type: string; name: string; path: string; is_private: boolean }> = [];
 
-        const folderPromises: Array<{ index: number; promise: Promise<Array<{ type: string; name: string; path: string; is_private: boolean }>> }> = [];
+        const folderPromises: Array<Promise<Array<{ type: string; name: string; path: string; is_private: boolean }>>> = [];
 
         for (const item of items) {
             const odataType = item['@odata.type'] || '';
@@ -369,17 +395,15 @@ export class ApplicationService extends ObjectService {
             });
 
             if (recursive && typeName === 'Folder') {
-                folderPromises.push({
-                    index: results.length,
-                    promise: this._discoverAtPath(
+                folderPromises.push(
+                    this._discoverAtPath(
                         itemPath, includePrivate, recursive, flat, inPrivateContext || isPrivate
                     )
-                });
+                );
             }
         }
 
-        // Discover sibling folders in parallel
-        const folderResults = await Promise.all(folderPromises.map(f => f.promise));
+        const folderResults = await Promise.all(folderPromises);
         for (const subItems of folderResults) {
             results.push(...subItems);
         }

--- a/src/services/ApplicationService.ts
+++ b/src/services/ApplicationService.ts
@@ -26,6 +26,10 @@ export class ApplicationService extends ObjectService {
         super(rest);
     }
 
+    public clearPathCache(): void {
+        this.pathCache.clear();
+    }
+
     public async getAllPublicRootNames(): Promise<string[]> {
         const url = "/Contents('Applications')/Contents";
         const response = await this.rest.get(url);

--- a/src/services/ApplicationService.ts
+++ b/src/services/ApplicationService.ts
@@ -442,8 +442,11 @@ export class ApplicationService extends ObjectService {
                     try {
                         await this.rest.get(privateTestUrl);
                         return i;
-                    } catch {
-                        return -1;
+                    } catch (innerError: any) {
+                        if (innerError instanceof TM1RestException && innerError.statusCode === 404) {
+                            return -1;
+                        }
+                        throw innerError;
                     }
                 }
                 throw error;
@@ -505,7 +508,11 @@ export class ApplicationService extends ObjectService {
                     segments.map(s => formatUrl("/Contents('{}')", s)).join(''),
                 inPrivateContext: false
             };
-        } catch { /* fall through */ }
+        } catch (error: any) {
+            if (!(error instanceof TM1RestException && error.statusCode === 404)) {
+                throw error;
+            }
+        }
 
         // Try all-private
         try {
@@ -518,7 +525,11 @@ export class ApplicationService extends ObjectService {
                     segments.map(s => formatUrl("/PrivateContents('{}')", s)).join(''),
                 inPrivateContext: true
             };
-        } catch { /* fall through */ }
+        } catch (error: any) {
+            if (!(error instanceof TM1RestException && error.statusCode === 404)) {
+                throw error;
+            }
+        }
 
         // Iterative boundary search
         const boundary = await this._findPrivateBoundary(segments);

--- a/src/services/ApplicationService.ts
+++ b/src/services/ApplicationService.ts
@@ -353,6 +353,8 @@ export class ApplicationService extends ObjectService {
     ): Promise<Array<{ type: string; name: string; path: string; is_private: boolean }>> {
         const results: Array<{ type: string; name: string; path: string; is_private: boolean }> = [];
 
+        const folderPromises: Array<{ index: number; promise: Promise<Array<{ type: string; name: string; path: string; is_private: boolean }>> }> = [];
+
         for (const item of items) {
             const odataType = item['@odata.type'] || '';
             const typeName = this._extractTypeFromOdata(odataType);
@@ -367,11 +369,19 @@ export class ApplicationService extends ObjectService {
             });
 
             if (recursive && typeName === 'Folder') {
-                const subItems = await this._discoverAtPath(
-                    itemPath, includePrivate, recursive, flat, inPrivateContext || isPrivate
-                );
-                results.push(...subItems);
+                folderPromises.push({
+                    index: results.length,
+                    promise: this._discoverAtPath(
+                        itemPath, includePrivate, recursive, flat, inPrivateContext || isPrivate
+                    )
+                });
             }
+        }
+
+        // Discover sibling folders in parallel
+        const folderResults = await Promise.all(folderPromises.map(f => f.promise));
+        for (const subItems of folderResults) {
+            results.push(...subItems);
         }
 
         return results;

--- a/src/services/ElementService.ts
+++ b/src/services/ElementService.ts
@@ -415,6 +415,21 @@ export class ElementService extends ObjectService {
     }
 
     /**
+     * Add multiple element attributes in bulk
+     */
+    public async addElementAttributes(
+        dimensionName: string,
+        hierarchyName: string,
+        elementAttributes: ElementAttribute[]
+    ): Promise<AxiosResponse> {
+        const url = formatUrl(
+            "/Dimensions('{}')/Hierarchies('{}')/ElementAttributes",
+            dimensionName, hierarchyName);
+        const body = elementAttributes.map(ea => ea.bodyAsDict);
+        return await this.rest.post(url, JSON.stringify(body));
+    }
+
+    /**
      * Delete multiple elements in bulk
      */
     public async deleteElements(

--- a/src/services/HierarchyService.ts
+++ b/src/services/HierarchyService.ts
@@ -250,11 +250,9 @@ export class HierarchyService extends ObjectService {
         options: {
             elementColumn?: string;
             verifyUniqueElements?: boolean;
-            verifyEdges?: boolean;
             elementTypeColumn?: string;
             unwindAll?: boolean;
             unwindConsolidations?: string[];
-            updateAttributeTypes?: boolean;
             deleteOrphanedConsolidations?: boolean;
         } = {}
     ): Promise<void> {
@@ -348,9 +346,13 @@ export class HierarchyService extends ObjectService {
                 const dim = new Dimension(dimensionName, [newHierarchy]);
                 await dimensionService.create(dim);
             } catch (e: any) {
-                // 409 = dimension already exists, which is expected
-                if (!(e instanceof TM1RestException && e.statusCode === 409)) {
+                const isAlreadyExists = (e instanceof TM1RestException && e.statusCode === 409)
+                    || (e.message && e.message.includes('already exists'));
+                if (isAlreadyExists) {
+                    // Dimension exists but hierarchy doesn't — create just the hierarchy
                     await this.create(newHierarchy);
+                } else {
+                    throw e;
                 }
             }
             hierarchy = await this.get(dimensionName, hierarchyName);
@@ -424,7 +426,12 @@ export class HierarchyService extends ObjectService {
                     for (const [attrName, value] of attrs) {
                         writePromises.push(
                             cellService.writeValue(cubeName, [elementName, attrName], value)
-                                .catch(() => { /* element may not exist in control dimension */ })
+                                .catch((e: any) => {
+                                    // Expected: element may not exist in control dimension
+                                    if (!(e instanceof TM1RestException && e.statusCode === 404)) {
+                                        throw e;
+                                    }
+                                })
                         );
                     }
                 }
@@ -443,7 +450,13 @@ export class HierarchyService extends ObjectService {
                     for (const [child, weight] of Object.entries(children)) {
                         edgePromises.push(
                             this.addEdges(dimensionName, hierarchyName, { [parent]: { [child]: weight } })
-                                .catch(() => null as any)
+                                .catch((e: any) => {
+                                    // Expected: edge may already exist (409)
+                                    if (e instanceof TM1RestException && e.statusCode === 409) {
+                                        return null as any;
+                                    }
+                                    throw e;
+                                })
                         );
                     }
                 }
@@ -465,7 +478,12 @@ export class HierarchyService extends ObjectService {
                 if (element.elementType === ElementType.CONSOLIDATED && !parentNames.has(element.name)) {
                     deletePromises.push(
                         elemService.delete(dimensionName, hierarchyName, element.name)
-                            .catch(() => { /* ignore deletion errors */ })
+                            .catch((e: any) => {
+                                // Expected: element may have been deleted already (404)
+                                if (!(e instanceof TM1RestException && e.statusCode === 404)) {
+                                    throw e;
+                                }
+                            })
                     );
                 }
             }

--- a/src/services/HierarchyService.ts
+++ b/src/services/HierarchyService.ts
@@ -443,15 +443,19 @@ export class HierarchyService extends ObjectService {
         if (Object.keys(edgesToAdd).length > 0) {
             try {
                 await this.addEdges(dimensionName, hierarchyName, edgesToAdd);
-            } catch {
-                // Bulk failed; fall back to individual edge adds in parallel
+            } catch (bulkError: any) {
+                // Only fall back on client errors (400, 422); re-throw server/network errors
+                if (!(bulkError instanceof TM1RestException) ||
+                    (bulkError.statusCode !== 400 && bulkError.statusCode !== 422)) {
+                    throw bulkError;
+                }
+                // Bulk failed due to validation; fall back to individual edge adds
                 const edgePromises: Promise<AxiosResponse>[] = [];
                 for (const [parent, children] of Object.entries(edgesToAdd)) {
                     for (const [child, weight] of Object.entries(children)) {
                         edgePromises.push(
                             this.addEdges(dimensionName, hierarchyName, { [parent]: { [child]: weight } })
                                 .catch((e: any) => {
-                                    // Expected: edge may already exist (409)
                                     if (e instanceof TM1RestException && e.statusCode === 409) {
                                         return null as any;
                                     }

--- a/src/services/HierarchyService.ts
+++ b/src/services/HierarchyService.ts
@@ -10,7 +10,13 @@ import { ElementService } from './ElementService';
 import { CellService } from './CellService';
 import { DimensionService } from './DimensionService';
 import { DataFrame } from '../utils/DataFrame';
-import { CaseAndSpaceInsensitiveDict, caseAndSpaceInsensitiveEquals, formatUrl, verifyVersion } from '../utils/Utils';
+import {
+    CaseAndSpaceInsensitiveDict,
+    CaseAndSpaceInsensitiveSet,
+    caseAndSpaceInsensitiveEquals,
+    formatUrl,
+    verifyVersion
+} from '../utils/Utils';
 
 export class HierarchyService extends ObjectService {
     private elementService?: ElementService;
@@ -193,22 +199,19 @@ export class HierarchyService extends ObjectService {
     ): Promise<AxiosResponse[]> {
         const hierarchy = await this.get(dimensionName, hierarchyName);
 
-        // Get all descendants (recursive) + the consolidation element itself
         const descendants = hierarchy.getDescendants(consolidationElement, true);
-        const membersUnderConsolidation = new Set<string>(descendants.map(d => d.toLowerCase()));
-        membersUnderConsolidation.add(consolidationElement.toLowerCase());
+        const membersUnderConsolidation = new CaseAndSpaceInsensitiveSet(descendants);
+        membersUnderConsolidation.add(consolidationElement);
 
-        // Collect edges to remove: where parent is under the consolidation
         const edgesToRemove: Array<[string, string]> = [];
         for (const [parent, children] of hierarchy.edges) {
-            if (membersUnderConsolidation.has(parent.toLowerCase())) {
+            if (membersUnderConsolidation.has(parent)) {
                 for (const child of children.keys()) {
                     edgesToRemove.push([parent, child]);
                 }
             }
         }
 
-        // Remove edges from hierarchy object
         for (const [parent, child] of edgesToRemove) {
             hierarchy.removeEdge(parent, child);
         }
@@ -264,13 +267,9 @@ export class HierarchyService extends ObjectService {
             deleteOrphanedConsolidations = false
         } = options;
 
-        // Step 1: Determine element column (default to first column)
         const elementColumn = elemCol || df.columns[0];
-
-        // Step 2: Get all rows as objects for easier processing
         const rows = df.toJson();
 
-        // Step 3: Identify level columns (e.g., "Level001", "Level002") and weight columns
         const levelColumns = df.columns
             .filter(c => /^Level\d+$/i.test(c))
             .sort();
@@ -278,7 +277,6 @@ export class HierarchyService extends ObjectService {
             .filter(c => /^Weight\d+$/i.test(c))
             .sort();
 
-        // Step 4: Identify attribute columns (everything that's not element, type, level, weight)
         const reservedColumns = new Set([
             elementColumn.toLowerCase(),
             elementTypeColumn.toLowerCase(),
@@ -287,19 +285,18 @@ export class HierarchyService extends ObjectService {
         ]);
         const attributeColumns = df.columns.filter(c => !reservedColumns.has(c.toLowerCase()));
 
-        // Step 5: Validate uniqueness if requested
         if (verifyUniqueElements) {
-            const seen = new Set<string>();
+            const seen = new CaseAndSpaceInsensitiveSet();
             for (const row of rows) {
-                const lower = String(row[elementColumn]).toLowerCase().replace(/\s+/g, '');
-                if (seen.has(lower)) {
-                    throw new Error(`Duplicate element found: '${row[elementColumn]}'`);
+                const name = String(row[elementColumn]);
+                if (seen.has(name)) {
+                    throw new Error(`Duplicate element found: '${name}'`);
                 }
-                seen.add(lower);
+                seen.add(name);
             }
         }
 
-        // Step 6: Build elements, edges, and attributes from DataFrame
+        // Parse DataFrame rows into elements, edges, and attribute values
         const elementsToAdd: Element[] = [];
         const edgesToAdd: { [parent: string]: { [child: string]: number } } = {};
         const attributeValues = new Map<string, Map<string, any>>();
@@ -310,15 +307,9 @@ export class HierarchyService extends ObjectService {
                 ? String(row[elementTypeColumn] || 'Numeric')
                 : 'Numeric';
 
-            let type: ElementType;
-            switch (elementTypeStr.toLowerCase()) {
-                case 'consolidated': case '3': type = ElementType.CONSOLIDATED; break;
-                case 'string': case '2': type = ElementType.STRING; break;
-                default: type = ElementType.NUMERIC;
-            }
-            elementsToAdd.push(new Element(elementName, type));
+            // Element constructor handles string→ElementType conversion
+            elementsToAdd.push(new Element(elementName, elementTypeStr));
 
-            // Process level/weight columns for edges
             for (let i = 0; i < levelColumns.length; i++) {
                 const parentName = row[levelColumns[i]];
                 if (parentName && String(parentName).trim()) {
@@ -331,7 +322,6 @@ export class HierarchyService extends ObjectService {
                 }
             }
 
-            // Collect attribute values
             if (attributeColumns.length > 0) {
                 const attrs = new Map<string, any>();
                 for (const col of attributeColumns) {
@@ -345,16 +335,10 @@ export class HierarchyService extends ObjectService {
             }
         }
 
-        // Step 7: Check if dimension/hierarchy exists
+        // Get or create the dimension/hierarchy
         const dimensionService = new DimensionService(this.rest);
-        let hierarchyExists = false;
-        try {
-            hierarchyExists = await this.exists(dimensionName, hierarchyName);
-        } catch {
-            hierarchyExists = false;
-        }
+        const hierarchyExists = await this.exists(dimensionName, hierarchyName).catch(() => false);
 
-        // Step 8: Get or create hierarchy
         let hierarchy: Hierarchy;
         if (hierarchyExists) {
             hierarchy = await this.get(dimensionName, hierarchyName);
@@ -364,47 +348,45 @@ export class HierarchyService extends ObjectService {
                 const dim = new Dimension(dimensionName, [newHierarchy]);
                 await dimensionService.create(dim);
             } catch (e: any) {
-                // Dimension may already exist, just hierarchy is missing
-                if (e.statusCode !== 409 && !(e.message && e.message.includes('already exists'))) {
-                    try {
-                        await this.create(newHierarchy);
-                    } catch {
-                        // ignore if creation fails (dimension create may have done it)
-                    }
+                // 409 = dimension already exists, which is expected
+                if (!(e instanceof TM1RestException && e.statusCode === 409)) {
+                    await this.create(newHierarchy);
                 }
             }
             hierarchy = await this.get(dimensionName, hierarchyName);
         }
 
-        // Step 9: Unwind edges if requested
+        // Unwind edges if requested
         if (unwindAll) {
             await this.removeAllEdges(dimensionName, hierarchyName);
-            hierarchy = await this.get(dimensionName, hierarchyName);
         } else if (unwindConsolidations && unwindConsolidations.length > 0) {
             for (const consolidation of unwindConsolidations) {
                 try {
                     await this.removeEdgesUnderConsolidation(dimensionName, hierarchyName, consolidation);
-                } catch {
-                    // Element may not exist yet
+                } catch (e: any) {
+                    if (!(e instanceof TM1RestException && e.statusCode === 404)) {
+                        throw e;
+                    }
                 }
             }
+        }
+
+        // Re-fetch hierarchy only if edges were modified
+        if (unwindAll || (unwindConsolidations && unwindConsolidations.length > 0)) {
             hierarchy = await this.get(dimensionName, hierarchyName);
         }
 
-        // Step 10: Add new elements that don't exist yet
-        const existingElementNames = new Set(
-            hierarchy.elements.map(e => e.name.toLowerCase())
+        // Add new elements not already in hierarchy
+        const existingElementNames = new CaseAndSpaceInsensitiveSet(
+            hierarchy.elements.map(e => e.name)
         );
-        const newElements = elementsToAdd.filter(
-            e => !existingElementNames.has(e.name.toLowerCase())
-        );
+        const newElements = elementsToAdd.filter(e => !existingElementNames.has(e.name));
 
-        // Also add parent elements from edges that aren't in the elements list
+        // Ensure parent elements from edges exist as Consolidated type
+        const newElementNames = new CaseAndSpaceInsensitiveSet(newElements.map(e => e.name));
         const parentElementsToAdd: Element[] = [];
         for (const parentName of Object.keys(edgesToAdd)) {
-            const lowerParent = parentName.toLowerCase();
-            if (!existingElementNames.has(lowerParent) &&
-                !newElements.some(e => e.name.toLowerCase() === lowerParent)) {
+            if (!existingElementNames.has(parentName) && !newElementNames.has(parentName)) {
                 parentElementsToAdd.push(new Element(parentName, ElementType.CONSOLIDATED));
             }
         }
@@ -414,18 +396,17 @@ export class HierarchyService extends ObjectService {
             await this.addElements(dimensionName, hierarchyName, allNewElements);
         }
 
-        // Step 11: Handle element attributes
+        // Create missing element attributes and write values
         if (attributeColumns.length > 0) {
             const existingAttrs = await this.getElementAttributes(dimensionName, hierarchyName);
-            const existingAttrNames = new Set(existingAttrs.map(a => a.name.toLowerCase().replace(/\s+/g, '')));
+            const existingAttrNames = new CaseAndSpaceInsensitiveSet(existingAttrs.map(a => a.name));
 
             const newAttrs: ElementAttribute[] = [];
             for (const col of attributeColumns) {
-                if (!existingAttrNames.has(col.toLowerCase().replace(/\s+/g, ''))) {
+                if (!existingAttrNames.has(col)) {
                     const values = rows.map(r => r[col]).filter(v => v !== undefined && v !== null && v !== '');
                     const isNumeric = values.length > 0 && values.every(v => !isNaN(Number(v)));
-                    const attrType = isNumeric ? 'Numeric' : 'String';
-                    newAttrs.push(new ElementAttribute(col, attrType));
+                    newAttrs.push(new ElementAttribute(col, isNumeric ? 'Numeric' : 'String'));
                 }
             }
 
@@ -433,64 +414,62 @@ export class HierarchyService extends ObjectService {
                 await this.addElementAttributes(dimensionName, hierarchyName, newAttrs);
             }
 
-            // Write attribute values via CellService
+            // Write attribute values in parallel batches
             if (attributeValues.size > 0) {
                 const cellService = new CellService(this.rest);
                 const cubeName = `}ElementAttributes_${dimensionName}`;
+                const writePromises: Promise<void>[] = [];
 
                 for (const [elementName, attrs] of attributeValues) {
                     for (const [attrName, value] of attrs) {
-                        try {
-                            await cellService.writeValue(
-                                cubeName,
-                                [elementName, attrName],
-                                value
-                            );
-                        } catch {
-                            // Skip failed writes (element may not exist in control dimension)
-                        }
+                        writePromises.push(
+                            cellService.writeValue(cubeName, [elementName, attrName], value)
+                                .catch(() => { /* element may not exist in control dimension */ })
+                        );
                     }
                 }
+                await Promise.all(writePromises);
             }
         }
 
-        // Step 12: Add edges
+        // Add edges
         if (Object.keys(edgesToAdd).length > 0) {
             try {
                 await this.addEdges(dimensionName, hierarchyName, edgesToAdd);
             } catch {
-                // Some edges may already exist; add one by one as fallback
+                // Bulk failed; fall back to individual edge adds in parallel
+                const edgePromises: Promise<AxiosResponse>[] = [];
                 for (const [parent, children] of Object.entries(edgesToAdd)) {
                     for (const [child, weight] of Object.entries(children)) {
-                        try {
-                            await this.addEdges(dimensionName, hierarchyName, { [parent]: { [child]: weight } });
-                        } catch {
-                            // Edge may already exist
-                        }
+                        edgePromises.push(
+                            this.addEdges(dimensionName, hierarchyName, { [parent]: { [child]: weight } })
+                                .catch(() => null as any)
+                        );
                     }
                 }
+                await Promise.all(edgePromises);
             }
         }
 
-        // Step 13: Delete orphaned consolidations if requested
+        // Delete orphaned consolidations (consolidated elements with no children)
         if (deleteOrphanedConsolidations) {
             const updatedHierarchy = await this.get(dimensionName, hierarchyName);
-            const hasChildren = new Set<string>();
+            const parentNames = new CaseAndSpaceInsensitiveSet();
             for (const [parent] of updatedHierarchy.edges) {
-                hasChildren.add(parent.toLowerCase());
+                parentNames.add(parent);
             }
 
             const elemService = this.getElementService();
+            const deletePromises: Promise<any>[] = [];
             for (const element of updatedHierarchy.elements) {
-                if (element.elementType === ElementType.CONSOLIDATED &&
-                    !hasChildren.has(element.name.toLowerCase())) {
-                    try {
-                        await elemService.delete(dimensionName, hierarchyName, element.name);
-                    } catch {
-                        // Ignore deletion errors
-                    }
+                if (element.elementType === ElementType.CONSOLIDATED && !parentNames.has(element.name)) {
+                    deletePromises.push(
+                        elemService.delete(dimensionName, hierarchyName, element.name)
+                            .catch(() => { /* ignore deletion errors */ })
+                    );
                 }
             }
+            await Promise.all(deletePromises);
         }
     }
 

--- a/src/services/HierarchyService.ts
+++ b/src/services/HierarchyService.ts
@@ -268,12 +268,13 @@ export class HierarchyService extends ObjectService {
         const elementColumn = elemCol || df.columns[0];
         const rows = df.toJson();
 
+        const numericSuffix = (col: string) => parseInt(col.replace(/\D/g, ''), 10);
         const levelColumns = df.columns
             .filter(c => /^Level\d+$/i.test(c))
-            .sort();
+            .sort((a, b) => numericSuffix(a) - numericSuffix(b));
         const weightColumns = df.columns
             .filter(c => /^Weight\d+$/i.test(c))
-            .sort();
+            .sort((a, b) => numericSuffix(a) - numericSuffix(b));
 
         const reservedColumns = new Set([
             elementColumn.toLowerCase(),

--- a/src/services/HierarchyService.ts
+++ b/src/services/HierarchyService.ts
@@ -2,13 +2,28 @@ import { AxiosResponse } from 'axios';
 import { RestService } from './RestService';
 import { Hierarchy } from '../objects/Hierarchy';
 import { ElementAttribute } from '../objects/ElementAttribute';
+import { Element, ElementType } from '../objects/Element';
+import { Dimension } from '../objects/Dimension';
 import { TM1RestException } from '../exceptions/TM1Exception';
 import { ObjectService } from './ObjectService';
-import { CaseAndSpaceInsensitiveDict, caseAndSpaceInsensitiveEquals } from '../utils/Utils';
+import { ElementService } from './ElementService';
+import { CellService } from './CellService';
+import { DimensionService } from './DimensionService';
+import { DataFrame } from '../utils/DataFrame';
+import { CaseAndSpaceInsensitiveDict, caseAndSpaceInsensitiveEquals, formatUrl, verifyVersion } from '../utils/Utils';
 
 export class HierarchyService extends ObjectService {
+    private elementService?: ElementService;
+
     constructor(rest: RestService) {
         super(rest);
+    }
+
+    private getElementService(): ElementService {
+        if (!this.elementService) {
+            this.elementService = new ElementService(this.rest);
+        }
+        return this.elementService;
     }
 
     public async create(hierarchy: Hierarchy): Promise<AxiosResponse> {
@@ -41,6 +56,13 @@ export class HierarchyService extends ObjectService {
         await this.updateElementAttributes(hierarchy, keepExistingAttributes);
 
         return responses;
+    }
+
+    public async updateOrCreate(hierarchy: Hierarchy): Promise<AxiosResponse | AxiosResponse[]> {
+        if (await this.exists(hierarchy.dimensionName, hierarchy.name)) {
+            return await this.update(hierarchy);
+        }
+        return await this.create(hierarchy);
     }
 
     public async delete(dimensionName: string, hierarchyName: string): Promise<AxiosResponse> {
@@ -76,6 +98,400 @@ export class HierarchyService extends ObjectService {
         );
         const response = await this.rest.get(url);
         return response.data.value.map((h: any) => Hierarchy.fromDict(h, dimensionName));
+    }
+
+    public async getHierarchySummary(
+        dimensionName: string,
+        hierarchyName?: string
+    ): Promise<Record<string, number>> {
+        const hierarchy = hierarchyName || dimensionName;
+        const url = this.formatUrl(
+            "/Dimensions('{}')/Hierarchies('{}')" +
+            "?$expand=Edges/$count,Elements/$count,ElementAttributes/$count,Members/$count,Levels/$count" +
+            "&$select=Cardinality",
+            dimensionName, hierarchy);
+        const response = await this.rest.get(url);
+        const data = response.data;
+        return {
+            Elements: data['Elements@odata.count'] ?? 0,
+            Edges: data['Edges@odata.count'] ?? 0,
+            ElementAttributes: data['ElementAttributes@odata.count'] ?? 0,
+            Members: data['Members@odata.count'] ?? 0,
+            Levels: data['Levels@odata.count'] ?? 0
+        };
+    }
+
+    public async getDefaultMember(
+        dimensionName: string,
+        hierarchyName?: string
+    ): Promise<string | null> {
+        const hierarchy = hierarchyName || dimensionName;
+        const url = this.formatUrl(
+            "/Dimensions('{}')/Hierarchies('{}')/DefaultMember",
+            dimensionName, hierarchy);
+        try {
+            const response = await this.rest.get(url);
+            return response.data?.Name || null;
+        } catch (error) {
+            if (error instanceof TM1RestException && error.statusCode === 404) {
+                return null;
+            }
+            throw error;
+        }
+    }
+
+    public async updateDefaultMember(
+        dimensionName: string,
+        hierarchyName?: string,
+        memberName: string = ''
+    ): Promise<AxiosResponse | void> {
+        const hierarchy = hierarchyName || dimensionName;
+        // Default to API approach (v12+) when version is unknown
+        if (!this.version || verifyVersion(this.version, '12.0.0')) {
+            return this._updateDefaultMemberViaApi(dimensionName, hierarchy, memberName);
+        }
+        return this._updateDefaultMemberViaPropsCube(dimensionName, hierarchy, memberName);
+    }
+
+    private async _updateDefaultMemberViaApi(
+        dimensionName: string,
+        hierarchyName: string,
+        memberName: string
+    ): Promise<AxiosResponse> {
+        const url = this.formatUrl(
+            "/Dimensions('{}')/Hierarchies('{}')",
+            dimensionName, hierarchyName);
+        const body: Record<string, any> = {};
+        if (memberName) {
+            body['DefaultMember@odata.bind'] = formatUrl(
+                "Dimensions('{}')/Hierarchies('{}')/Elements('{}')",
+                dimensionName, hierarchyName, memberName);
+        } else {
+            body['DefaultMember@odata.bind'] = null;
+        }
+        return await this.rest.patch(url, JSON.stringify(body));
+    }
+
+    private async _updateDefaultMemberViaPropsCube(
+        dimensionName: string,
+        hierarchyName: string,
+        memberName: string
+    ): Promise<void> {
+        const cellService = new CellService(this.rest);
+        const value = memberName || '';
+        await cellService.writeValue(
+            '}HierarchyProperties',
+            [dimensionName, hierarchyName, 'MEMBER_DEFAULT'],
+            value
+        );
+    }
+
+    public async removeEdgesUnderConsolidation(
+        dimensionName: string,
+        hierarchyName: string,
+        consolidationElement: string
+    ): Promise<AxiosResponse[]> {
+        const hierarchy = await this.get(dimensionName, hierarchyName);
+
+        // Get all descendants (recursive) + the consolidation element itself
+        const descendants = hierarchy.getDescendants(consolidationElement, true);
+        const membersUnderConsolidation = new Set<string>(descendants.map(d => d.toLowerCase()));
+        membersUnderConsolidation.add(consolidationElement.toLowerCase());
+
+        // Collect edges to remove: where parent is under the consolidation
+        const edgesToRemove: Array<[string, string]> = [];
+        for (const [parent, children] of hierarchy.edges) {
+            if (membersUnderConsolidation.has(parent.toLowerCase())) {
+                for (const child of children.keys()) {
+                    edgesToRemove.push([parent, child]);
+                }
+            }
+        }
+
+        // Remove edges from hierarchy object
+        for (const [parent, child] of edgesToRemove) {
+            hierarchy.removeEdge(parent, child);
+        }
+
+        return await this.update(hierarchy);
+    }
+
+    public async addEdges(
+        dimensionName: string,
+        hierarchyName: string | undefined,
+        edges: { [parent: string]: { [child: string]: number } }
+    ): Promise<AxiosResponse> {
+        return this.getElementService().addEdges(dimensionName, hierarchyName || dimensionName, edges);
+    }
+
+    public async addElements(
+        dimensionName: string,
+        hierarchyName: string,
+        elements: Element[]
+    ): Promise<AxiosResponse> {
+        return this.getElementService().addElements(dimensionName, hierarchyName, elements);
+    }
+
+    public async addElementAttributes(
+        dimensionName: string,
+        hierarchyName: string,
+        elementAttributes: ElementAttribute[]
+    ): Promise<AxiosResponse> {
+        return this.getElementService().addElementAttributes(dimensionName, hierarchyName, elementAttributes);
+    }
+
+    public async updateOrCreateHierarchyFromDataframe(
+        dimensionName: string,
+        hierarchyName: string,
+        df: DataFrame,
+        options: {
+            elementColumn?: string;
+            verifyUniqueElements?: boolean;
+            verifyEdges?: boolean;
+            elementTypeColumn?: string;
+            unwindAll?: boolean;
+            unwindConsolidations?: string[];
+            updateAttributeTypes?: boolean;
+            deleteOrphanedConsolidations?: boolean;
+        } = {}
+    ): Promise<void> {
+        const {
+            elementColumn: elemCol,
+            verifyUniqueElements = false,
+            elementTypeColumn = 'ElementType',
+            unwindAll = false,
+            unwindConsolidations,
+            deleteOrphanedConsolidations = false
+        } = options;
+
+        // Step 1: Determine element column (default to first column)
+        const elementColumn = elemCol || df.columns[0];
+
+        // Step 2: Get all rows as objects for easier processing
+        const rows = df.toJson();
+
+        // Step 3: Identify level columns (e.g., "Level001", "Level002") and weight columns
+        const levelColumns = df.columns
+            .filter(c => /^Level\d+$/i.test(c))
+            .sort();
+        const weightColumns = df.columns
+            .filter(c => /^Weight\d+$/i.test(c))
+            .sort();
+
+        // Step 4: Identify attribute columns (everything that's not element, type, level, weight)
+        const reservedColumns = new Set([
+            elementColumn.toLowerCase(),
+            elementTypeColumn.toLowerCase(),
+            ...levelColumns.map(c => c.toLowerCase()),
+            ...weightColumns.map(c => c.toLowerCase())
+        ]);
+        const attributeColumns = df.columns.filter(c => !reservedColumns.has(c.toLowerCase()));
+
+        // Step 5: Validate uniqueness if requested
+        if (verifyUniqueElements) {
+            const seen = new Set<string>();
+            for (const row of rows) {
+                const lower = String(row[elementColumn]).toLowerCase().replace(/\s+/g, '');
+                if (seen.has(lower)) {
+                    throw new Error(`Duplicate element found: '${row[elementColumn]}'`);
+                }
+                seen.add(lower);
+            }
+        }
+
+        // Step 6: Build elements, edges, and attributes from DataFrame
+        const elementsToAdd: Element[] = [];
+        const edgesToAdd: { [parent: string]: { [child: string]: number } } = {};
+        const attributeValues = new Map<string, Map<string, any>>();
+
+        for (const row of rows) {
+            const elementName = String(row[elementColumn]);
+            const elementTypeStr = df.columns.includes(elementTypeColumn)
+                ? String(row[elementTypeColumn] || 'Numeric')
+                : 'Numeric';
+
+            let type: ElementType;
+            switch (elementTypeStr.toLowerCase()) {
+                case 'consolidated': case '3': type = ElementType.CONSOLIDATED; break;
+                case 'string': case '2': type = ElementType.STRING; break;
+                default: type = ElementType.NUMERIC;
+            }
+            elementsToAdd.push(new Element(elementName, type));
+
+            // Process level/weight columns for edges
+            for (let i = 0; i < levelColumns.length; i++) {
+                const parentName = row[levelColumns[i]];
+                if (parentName && String(parentName).trim()) {
+                    const weight = weightColumns[i] ? Number(row[weightColumns[i]] || 1) : 1;
+                    const parentStr = String(parentName);
+                    if (!edgesToAdd[parentStr]) {
+                        edgesToAdd[parentStr] = {};
+                    }
+                    edgesToAdd[parentStr][elementName] = weight;
+                }
+            }
+
+            // Collect attribute values
+            if (attributeColumns.length > 0) {
+                const attrs = new Map<string, any>();
+                for (const col of attributeColumns) {
+                    if (row[col] !== undefined && row[col] !== null && row[col] !== '') {
+                        attrs.set(col, row[col]);
+                    }
+                }
+                if (attrs.size > 0) {
+                    attributeValues.set(elementName, attrs);
+                }
+            }
+        }
+
+        // Step 7: Check if dimension/hierarchy exists
+        const dimensionService = new DimensionService(this.rest);
+        let hierarchyExists = false;
+        try {
+            hierarchyExists = await this.exists(dimensionName, hierarchyName);
+        } catch {
+            hierarchyExists = false;
+        }
+
+        // Step 8: Get or create hierarchy
+        let hierarchy: Hierarchy;
+        if (hierarchyExists) {
+            hierarchy = await this.get(dimensionName, hierarchyName);
+        } else {
+            const newHierarchy = new Hierarchy(hierarchyName, dimensionName);
+            try {
+                const dim = new Dimension(dimensionName, [newHierarchy]);
+                await dimensionService.create(dim);
+            } catch (e: any) {
+                // Dimension may already exist, just hierarchy is missing
+                if (e.statusCode !== 409 && !(e.message && e.message.includes('already exists'))) {
+                    try {
+                        await this.create(newHierarchy);
+                    } catch {
+                        // ignore if creation fails (dimension create may have done it)
+                    }
+                }
+            }
+            hierarchy = await this.get(dimensionName, hierarchyName);
+        }
+
+        // Step 9: Unwind edges if requested
+        if (unwindAll) {
+            await this.removeAllEdges(dimensionName, hierarchyName);
+            hierarchy = await this.get(dimensionName, hierarchyName);
+        } else if (unwindConsolidations && unwindConsolidations.length > 0) {
+            for (const consolidation of unwindConsolidations) {
+                try {
+                    await this.removeEdgesUnderConsolidation(dimensionName, hierarchyName, consolidation);
+                } catch {
+                    // Element may not exist yet
+                }
+            }
+            hierarchy = await this.get(dimensionName, hierarchyName);
+        }
+
+        // Step 10: Add new elements that don't exist yet
+        const existingElementNames = new Set(
+            hierarchy.elements.map(e => e.name.toLowerCase())
+        );
+        const newElements = elementsToAdd.filter(
+            e => !existingElementNames.has(e.name.toLowerCase())
+        );
+
+        // Also add parent elements from edges that aren't in the elements list
+        const parentElementsToAdd: Element[] = [];
+        for (const parentName of Object.keys(edgesToAdd)) {
+            const lowerParent = parentName.toLowerCase();
+            if (!existingElementNames.has(lowerParent) &&
+                !newElements.some(e => e.name.toLowerCase() === lowerParent)) {
+                parentElementsToAdd.push(new Element(parentName, ElementType.CONSOLIDATED));
+            }
+        }
+
+        const allNewElements = [...newElements, ...parentElementsToAdd];
+        if (allNewElements.length > 0) {
+            await this.addElements(dimensionName, hierarchyName, allNewElements);
+        }
+
+        // Step 11: Handle element attributes
+        if (attributeColumns.length > 0) {
+            const existingAttrs = await this.getElementAttributes(dimensionName, hierarchyName);
+            const existingAttrNames = new Set(existingAttrs.map(a => a.name.toLowerCase().replace(/\s+/g, '')));
+
+            const newAttrs: ElementAttribute[] = [];
+            for (const col of attributeColumns) {
+                if (!existingAttrNames.has(col.toLowerCase().replace(/\s+/g, ''))) {
+                    const values = rows.map(r => r[col]).filter(v => v !== undefined && v !== null && v !== '');
+                    const isNumeric = values.length > 0 && values.every(v => !isNaN(Number(v)));
+                    const attrType = isNumeric ? 'Numeric' : 'String';
+                    newAttrs.push(new ElementAttribute(col, attrType));
+                }
+            }
+
+            if (newAttrs.length > 0) {
+                await this.addElementAttributes(dimensionName, hierarchyName, newAttrs);
+            }
+
+            // Write attribute values via CellService
+            if (attributeValues.size > 0) {
+                const cellService = new CellService(this.rest);
+                const cubeName = `}ElementAttributes_${dimensionName}`;
+
+                for (const [elementName, attrs] of attributeValues) {
+                    for (const [attrName, value] of attrs) {
+                        try {
+                            await cellService.writeValue(
+                                cubeName,
+                                [elementName, attrName],
+                                value
+                            );
+                        } catch {
+                            // Skip failed writes (element may not exist in control dimension)
+                        }
+                    }
+                }
+            }
+        }
+
+        // Step 12: Add edges
+        if (Object.keys(edgesToAdd).length > 0) {
+            try {
+                await this.addEdges(dimensionName, hierarchyName, edgesToAdd);
+            } catch {
+                // Some edges may already exist; add one by one as fallback
+                for (const [parent, children] of Object.entries(edgesToAdd)) {
+                    for (const [child, weight] of Object.entries(children)) {
+                        try {
+                            await this.addEdges(dimensionName, hierarchyName, { [parent]: { [child]: weight } });
+                        } catch {
+                            // Edge may already exist
+                        }
+                    }
+                }
+            }
+        }
+
+        // Step 13: Delete orphaned consolidations if requested
+        if (deleteOrphanedConsolidations) {
+            const updatedHierarchy = await this.get(dimensionName, hierarchyName);
+            const hasChildren = new Set<string>();
+            for (const [parent] of updatedHierarchy.edges) {
+                hasChildren.add(parent.toLowerCase());
+            }
+
+            const elemService = this.getElementService();
+            for (const element of updatedHierarchy.elements) {
+                if (element.elementType === ElementType.CONSOLIDATED &&
+                    !hasChildren.has(element.name.toLowerCase())) {
+                    try {
+                        await elemService.delete(dimensionName, hierarchyName, element.name);
+                    } catch {
+                        // Ignore deletion errors
+                    }
+                }
+            }
+        }
     }
 
     public async updateElementAttributes(hierarchy: Hierarchy, keepExisting: boolean = false): Promise<void> {

--- a/src/services/SubsetService.ts
+++ b/src/services/SubsetService.ts
@@ -2,8 +2,10 @@ import { AxiosResponse } from 'axios';
 import { RestService } from './RestService';
 import { ObjectService } from './ObjectService';
 import { Subset } from '../objects/Subset';
+import { Element } from '../objects/Element';
 import { ElementService } from './ElementService';
 import { TM1RestException } from '../exceptions/TM1Exception';
+import { formatUrl } from '../utils/Utils';
 
 export class SubsetService extends ObjectService {
     private elementService?: ElementService;
@@ -255,6 +257,52 @@ export class SubsetService extends ObjectService {
         return await this.elementService.executeSetMdxElementNames(
             subset.expression
         );
+    }
+
+    public async updateStaticElements(
+        subsetOrName: Subset | string,
+        dimensionName?: string,
+        hierarchyName?: string,
+        isPrivate: boolean = false,
+        elements?: Array<string | Element>
+    ): Promise<AxiosResponse> {
+        let subsetName: string;
+        let dimName: string;
+        let hierName: string;
+        let elementNames: string[];
+
+        if (subsetOrName instanceof Subset) {
+            const subset = subsetOrName;
+            subsetName = subset.name;
+            dimName = dimensionName || subset.dimensionName;
+            hierName = hierarchyName || subset.hierarchyName;
+            elementNames = elements
+                ? elements.map(e => typeof e === 'string' ? e : e.name)
+                : subset.elements;
+        } else {
+            if (!dimensionName) {
+                throw new Error('dimensionName is required when passing subset name as string');
+            }
+            subsetName = subsetOrName;
+            dimName = dimensionName;
+            hierName = hierarchyName || dimName;
+            elementNames = (elements || []).map(e => typeof e === 'string' ? e : e.name);
+        }
+
+        const subsetsCollection = this.getSubsetCollection(isPrivate);
+        const url = this.formatUrl(
+            "/Dimensions('{}')/Hierarchies('{}')/{}('{}')/Elements/$ref",
+            dimName, hierName, subsetsCollection, subsetName);
+
+        const body = {
+            value: elementNames.map(elementName => ({
+                '@odata.id': formatUrl(
+                    "Dimensions('{}')/Hierarchies('{}')/Elements('{}')",
+                    dimName, hierName, elementName)
+            }))
+        };
+
+        return await this.rest.put(url, JSON.stringify(body));
     }
 
     private async updateSubsetInstance(subset: Subset, isPrivate: boolean): Promise<AxiosResponse> {

--- a/src/services/TM1Service.ts
+++ b/src/services/TM1Service.ts
@@ -7,6 +7,7 @@ import { DebuggerService } from './DebuggerService';
 import { BulkService } from './BulkService';
 import { AsyncOperationService } from './AsyncOperationService';
 import { PowerBiService } from './PowerBiService';
+import { ApplicationService } from './ApplicationService';
 import {
     CubeService,
     ElementService,
@@ -41,6 +42,7 @@ export class TM1Service {
     public bulk: BulkService;
     public asyncOperations: AsyncOperationService;
     public powerbi: PowerBiService;
+    public applications: ApplicationService;
 
     constructor(config: RestServiceConfig) {
         this._tm1Rest = new RestService(config);
@@ -67,6 +69,7 @@ export class TM1Service {
         this.debugger = new DebuggerService(this._tm1Rest);
         this.bulk = new BulkService(this._tm1Rest, this.cells, this.views);
         this.powerbi = new PowerBiService(this._tm1Rest);
+        this.applications = new ApplicationService(this._tm1Rest);
     }
 
     public async connect(): Promise<void> {

--- a/src/tests/applicationService.issue38.test.ts
+++ b/src/tests/applicationService.issue38.test.ts
@@ -44,7 +44,7 @@ describe('ApplicationService — Issue #38 new methods', () => {
                     return createMockResponse({
                         value: [
                             { '@odata.type': '#ibm.tm1.api.v1.CubeApplication', Name: 'SalesCube' },
-                            { '@odata.type': '#ibm.tm1.api.v1.FolderApplicationApplication', Name: 'Reports' }
+                            { '@odata.type': '#ibm.tm1.api.v1.FolderApplication', Name: 'Reports' }
                         ]
                     });
                 }

--- a/src/tests/applicationService.issue38.test.ts
+++ b/src/tests/applicationService.issue38.test.ts
@@ -121,6 +121,38 @@ describe('ApplicationService — Issue #38 new methods', () => {
             expect(names).toContain('SalesReport');
         });
 
+        test('should use PrivateContents for nested paths in private context', async () => {
+            mockRestService.get.mockImplementation(async (url: string) => {
+                // Root private contents returns a folder
+                if (url === "/Contents('Applications')/PrivateContents") {
+                    return createMockResponse({
+                        value: [
+                            { '@odata.type': '#ibm.tm1.api.v1.Folder', Name: 'PrivateFolder' }
+                        ]
+                    });
+                }
+                // Nested private folder contents — must use PrivateContents, not Contents
+                if (url.includes("PrivateContents('PrivateFolder')/PrivateContents")) {
+                    return createMockResponse({
+                        value: [
+                            { '@odata.type': '#ibm.tm1.api.v1.CubeApplication', Name: 'DeepCube' }
+                        ]
+                    });
+                }
+                // If the code incorrectly uses Contents for nested private paths, this will 404
+                if (url.includes("Contents('PrivateFolder')/Contents")) {
+                    throw new TM1RestException('Not found', 404, { status: 404 });
+                }
+                return createMockResponse({ value: [] });
+            });
+
+            const results = await applicationService.discover('', true, true);
+
+            const names = results.map(r => r.name);
+            expect(names).toContain('PrivateFolder');
+            expect(names).toContain('DeepCube');
+        });
+
         test('should return empty array on 404', async () => {
             mockRestService.get.mockRejectedValue(
                 new TM1RestException('Not found', 404, { status: 404 })
@@ -199,7 +231,7 @@ describe('ApplicationService — Issue #38 new methods', () => {
             expect(typeof result).toBe('boolean');
         });
 
-        test('should return false when private path resolution fails', async () => {
+        test('should return false when private path resolution fails with not-found', async () => {
             mockRestService.get.mockRejectedValue(
                 new TM1RestException('Not found', 404, { status: 404 })
             );
@@ -212,6 +244,16 @@ describe('ApplicationService — Issue #38 new methods', () => {
             );
 
             expect(result).toBe(false);
+        });
+
+        test('should rethrow server errors from private exists', async () => {
+            mockRestService.get.mockRejectedValue(
+                new TM1RestException('Internal server error', 500, { status: 500 })
+            );
+
+            await expect(
+                applicationService.exists('SomePath', ApplicationTypes.CUBE, 'SomeCube', true)
+            ).rejects.toThrow('Internal server error');
         });
     });
 });

--- a/src/tests/applicationService.issue38.test.ts
+++ b/src/tests/applicationService.issue38.test.ts
@@ -87,6 +87,36 @@ describe('ApplicationService — Issue #38 new methods', () => {
             expect(privateNames).toContain('PrivateReport');
         });
 
+        test('should find private items inside public folders with includePrivate', async () => {
+            mockRestService.get.mockImplementation(async (url: string) => {
+                // Public root contents: one public folder
+                if (url === "/Contents('Applications')/Contents") {
+                    return createMockResponse({
+                        value: [
+                            { '@odata.type': '#ibm.tm1.api.v1.CubeApplication', Name: 'PublicCube' }
+                        ]
+                    });
+                }
+                // Private root contents: uses public path + PrivateContents leaf
+                if (url === "/Contents('Applications')/PrivateContents") {
+                    return createMockResponse({
+                        value: [
+                            { '@odata.type': '#ibm.tm1.api.v1.CubeApplication', Name: 'PrivateInPublicRoot' }
+                        ]
+                    });
+                }
+                return createMockResponse({ value: [] });
+            });
+
+            const results = await applicationService.discover('', true, false);
+
+            const names = results.map(r => r.name);
+            expect(names).toContain('PublicCube');
+            expect(names).toContain('PrivateInPublicRoot');
+            const privateItem = results.find(r => r.name === 'PrivateInPublicRoot');
+            expect(privateItem?.is_private).toBe(true);
+        });
+
         test('should recurse into folders when recursive=true', async () => {
             // TM1 returns @odata.type like '#ibm.tm1.api.v1.FolderApplication'.
             // _extractTypeFromOdata strips 'Application' suffix → 'Folder', which triggers recursion.
@@ -185,13 +215,15 @@ describe('ApplicationService — Issue #38 new methods', () => {
     // ===== getNames with private path resolution (_resolvePath) =====
 
     describe('getNames — private path', () => {
-        test('should resolve private path via _resolvePath and use PrivateContents', async () => {
+        test('should use PrivateContents leaf collection even when parent path is public', async () => {
+            const calledUrls: string[] = [];
             mockRestService.get.mockImplementation(async (url: string) => {
-                if (url.includes('?$top=0') && url.includes("Contents('MyFolder')")) {
+                calledUrls.push(url);
+                if (url.includes('?$top=0')) {
                     // Public path probe succeeds — folder is public
                     return createMockResponse({});
                 }
-                if (url.includes('PrivateContents')) {
+                if (url.includes('/PrivateContents')) {
                     return createMockResponse({
                         value: [{ Name: 'PrivateApp' }]
                     });
@@ -203,7 +235,10 @@ describe('ApplicationService — Issue #38 new methods', () => {
 
             const names = await applicationService.getNames('MyFolder', true);
 
-            expect(Array.isArray(names)).toBe(true);
+            expect(names).toContain('PrivateApp');
+            // The final data-fetch URL must use PrivateContents for the leaf
+            const dataUrl = calledUrls.find(u => !u.includes('$top=0') && u.includes('PrivateContents'));
+            expect(dataUrl).toBeDefined();
         });
     });
 

--- a/src/tests/applicationService.issue38.test.ts
+++ b/src/tests/applicationService.issue38.test.ts
@@ -1,0 +1,217 @@
+/**
+ * ApplicationService Tests — Issue #38 new methods
+ */
+
+import { ApplicationService } from '../services/ApplicationService';
+import { RestService } from '../services/RestService';
+import { TM1RestException } from '../exceptions/TM1Exception';
+import { FolderApplication, CubeApplication, ApplicationTypes } from '../objects/Application';
+
+const createMockResponse = (data: any, status: number = 200) => ({
+    data,
+    status,
+    statusText: status === 200 ? 'OK' : status === 201 ? 'Created' : status === 204 ? 'No Content' : 'Error',
+    headers: {},
+    config: {} as any
+});
+
+describe('ApplicationService — Issue #38 new methods', () => {
+    let applicationService: ApplicationService;
+    let mockRestService: jest.Mocked<RestService>;
+
+    beforeEach(() => {
+        mockRestService = {
+            get: jest.fn(),
+            post: jest.fn(),
+            patch: jest.fn(),
+            delete: jest.fn(),
+            put: jest.fn(),
+            config: {} as any,
+            rest: {} as any,
+            buildBaseUrl: jest.fn(),
+            extractErrorMessage: jest.fn()
+        } as any;
+
+        applicationService = new ApplicationService(mockRestService);
+    });
+
+    // ===== discover =====
+
+    describe('discover', () => {
+        test('should return public items at root when includePrivate=false', async () => {
+            mockRestService.get.mockImplementation(async (url: string) => {
+                if (url.includes('Contents') && !url.includes('PrivateContents')) {
+                    return createMockResponse({
+                        value: [
+                            { '@odata.type': '#ibm.tm1.api.v1.CubeApplication', Name: 'SalesCube' },
+                            { '@odata.type': '#ibm.tm1.api.v1.FolderApplication', Name: 'Reports' }
+                        ]
+                    });
+                }
+                return createMockResponse({ value: [] });
+            });
+
+            const results = await applicationService.discover('', false, false);
+
+            expect(results.length).toBeGreaterThanOrEqual(2);
+            const names = results.map(r => r.name);
+            expect(names).toContain('SalesCube');
+            expect(names).toContain('Reports');
+            // All should be public
+            results.forEach(r => expect(r.is_private).toBe(false));
+        });
+
+        test('should include private items when includePrivate=true', async () => {
+            mockRestService.get.mockImplementation(async (url: string) => {
+                if (url.includes('PrivateContents')) {
+                    return createMockResponse({
+                        value: [
+                            { '@odata.type': '#ibm.tm1.api.v1.CubeApplication', Name: 'PrivateReport' }
+                        ]
+                    });
+                }
+                return createMockResponse({
+                    value: [
+                        { '@odata.type': '#ibm.tm1.api.v1.CubeApplication', Name: 'PublicCube' }
+                    ]
+                });
+            });
+
+            const results = await applicationService.discover('', true, false);
+
+            const privateItems = results.filter(r => r.is_private);
+            const publicItems = results.filter(r => !r.is_private);
+            expect(privateItems.length).toBeGreaterThanOrEqual(1);
+            expect(publicItems.length).toBeGreaterThanOrEqual(1);
+            const privateNames = privateItems.map(r => r.name);
+            expect(privateNames).toContain('PrivateReport');
+        });
+
+        test('should recurse into folders when recursive=true', async () => {
+            // _extractTypeFromOdata splits on '.' and takes the last segment.
+            // The recursive branch fires only when typeName === 'Folder'.
+            // Use an @odata.type value whose last '.'-segment is 'Folder'.
+            mockRestService.get.mockImplementation(async (url: string) => {
+                if (url.includes('PrivateContents')) {
+                    return createMockResponse({ value: [] });
+                }
+                // Root Contents call
+                if (url.match(/Contents\('Applications'\)\/Contents$/)) {
+                    return createMockResponse({
+                        value: [
+                            { '@odata.type': '#ibm.tm1.api.v1.Folder', Name: 'Reports' }
+                        ]
+                    });
+                }
+                // Sub-folder Contents call
+                if (url.includes("Contents('Reports')/Contents")) {
+                    return createMockResponse({
+                        value: [
+                            { '@odata.type': '#ibm.tm1.api.v1.CubeApplication', Name: 'SalesReport' }
+                        ]
+                    });
+                }
+                return createMockResponse({ value: [] });
+            });
+
+            const results = await applicationService.discover('', false, true);
+
+            const names = results.map(r => r.name);
+            expect(names).toContain('Reports');
+            expect(names).toContain('SalesReport');
+        });
+
+        test('should return empty array on 404', async () => {
+            mockRestService.get.mockRejectedValue(
+                new TM1RestException('Not found', 404, { status: 404 })
+            );
+
+            const results = await applicationService.discover('NonExistentPath', false, false);
+
+            expect(results).toEqual([]);
+        });
+
+        test('should include type in result items', async () => {
+            mockRestService.get.mockImplementation(async (url: string) => {
+                if (url.includes('PrivateContents')) {
+                    return createMockResponse({ value: [] });
+                }
+                return createMockResponse({
+                    value: [
+                        { '@odata.type': '#ibm.tm1.api.v1.CubeApplication', Name: 'MyCube' }
+                    ]
+                });
+            });
+
+            const results = await applicationService.discover('', false, false);
+
+            const cubeItem = results.find(r => r.name === 'MyCube');
+            expect(cubeItem).toBeDefined();
+            expect(cubeItem?.type).toBe('CubeApplication');
+        });
+    });
+
+    // ===== getNames with private path resolution (_resolvePath) =====
+
+    describe('getNames — private path', () => {
+        test('should resolve private path via _resolvePath and use PrivateContents', async () => {
+            mockRestService.get.mockImplementation(async (url: string) => {
+                if (url.includes('?$top=0') && url.includes("Contents('MyFolder')")) {
+                    // Public path probe succeeds — folder is public
+                    return createMockResponse({});
+                }
+                if (url.includes('PrivateContents')) {
+                    return createMockResponse({
+                        value: [{ Name: 'PrivateApp' }]
+                    });
+                }
+                return createMockResponse({
+                    value: [{ Name: 'PublicApp' }]
+                });
+            });
+
+            const names = await applicationService.getNames('MyFolder', true);
+
+            expect(Array.isArray(names)).toBe(true);
+        });
+    });
+
+    // ===== exists with private path =====
+
+    describe('exists — private path', () => {
+        test('should use _resolvePath for private paths', async () => {
+            // Simulate all-public probe succeeds
+            mockRestService.get.mockImplementation(async (url: string) => {
+                if (url.includes('?$top=0')) {
+                    return createMockResponse({});
+                }
+                // exists check — return 200
+                return createMockResponse({ Name: 'MyCubeApp' });
+            });
+
+            const result = await applicationService.exists(
+                'MyFolder',
+                ApplicationTypes.CUBE,
+                'MyCubeApp',
+                true
+            );
+
+            expect(typeof result).toBe('boolean');
+        });
+
+        test('should return false when private path resolution fails', async () => {
+            mockRestService.get.mockRejectedValue(
+                new TM1RestException('Not found', 404, { status: 404 })
+            );
+
+            const result = await applicationService.exists(
+                'NonExistent',
+                ApplicationTypes.CUBE,
+                'SomeCube',
+                true
+            );
+
+            expect(result).toBe(false);
+        });
+    });
+});

--- a/src/tests/applicationService.issue38.test.ts
+++ b/src/tests/applicationService.issue38.test.ts
@@ -44,7 +44,7 @@ describe('ApplicationService — Issue #38 new methods', () => {
                     return createMockResponse({
                         value: [
                             { '@odata.type': '#ibm.tm1.api.v1.CubeApplication', Name: 'SalesCube' },
-                            { '@odata.type': '#ibm.tm1.api.v1.FolderApplication', Name: 'Reports' }
+                            { '@odata.type': '#ibm.tm1.api.v1.FolderApplicationApplication', Name: 'Reports' }
                         ]
                     });
                 }
@@ -88,9 +88,8 @@ describe('ApplicationService — Issue #38 new methods', () => {
         });
 
         test('should recurse into folders when recursive=true', async () => {
-            // _extractTypeFromOdata splits on '.' and takes the last segment.
-            // The recursive branch fires only when typeName === 'Folder'.
-            // Use an @odata.type value whose last '.'-segment is 'Folder'.
+            // TM1 returns @odata.type like '#ibm.tm1.api.v1.FolderApplication'.
+            // _extractTypeFromOdata strips 'Application' suffix → 'Folder', which triggers recursion.
             mockRestService.get.mockImplementation(async (url: string) => {
                 if (url.includes('PrivateContents')) {
                     return createMockResponse({ value: [] });
@@ -99,7 +98,7 @@ describe('ApplicationService — Issue #38 new methods', () => {
                 if (url.match(/Contents\('Applications'\)\/Contents$/)) {
                     return createMockResponse({
                         value: [
-                            { '@odata.type': '#ibm.tm1.api.v1.Folder', Name: 'Reports' }
+                            { '@odata.type': '#ibm.tm1.api.v1.FolderApplication', Name: 'Reports' }
                         ]
                     });
                 }
@@ -127,7 +126,7 @@ describe('ApplicationService — Issue #38 new methods', () => {
                 if (url === "/Contents('Applications')/PrivateContents") {
                     return createMockResponse({
                         value: [
-                            { '@odata.type': '#ibm.tm1.api.v1.Folder', Name: 'PrivateFolder' }
+                            { '@odata.type': '#ibm.tm1.api.v1.FolderApplication', Name: 'PrivateFolder' }
                         ]
                     });
                 }
@@ -179,7 +178,7 @@ describe('ApplicationService — Issue #38 new methods', () => {
 
             const cubeItem = results.find(r => r.name === 'MyCube');
             expect(cubeItem).toBeDefined();
-            expect(cubeItem?.type).toBe('CubeApplication');
+            expect(cubeItem?.type).toBe('Cube');
         });
     });
 

--- a/src/tests/elementService.issue38.test.ts
+++ b/src/tests/elementService.issue38.test.ts
@@ -1,0 +1,103 @@
+/**
+ * ElementService Tests — Issue #38 new methods
+ */
+
+import { ElementService } from '../services/ElementService';
+import { RestService } from '../services/RestService';
+import { ElementAttribute } from '../objects/ElementAttribute';
+
+const createMockResponse = (data: any, status: number = 200) => ({
+    data,
+    status,
+    statusText: status === 200 ? 'OK' : status === 201 ? 'Created' : status === 204 ? 'No Content' : 'Error',
+    headers: {},
+    config: {} as any
+});
+
+describe('ElementService — Issue #38 new methods', () => {
+    let elementService: ElementService;
+    let mockRestService: jest.Mocked<RestService>;
+
+    beforeEach(() => {
+        mockRestService = {
+            get: jest.fn(),
+            post: jest.fn(),
+            patch: jest.fn(),
+            delete: jest.fn(),
+            put: jest.fn(),
+            config: {} as any,
+            rest: {} as any,
+            buildBaseUrl: jest.fn(),
+            extractErrorMessage: jest.fn()
+        } as any;
+
+        elementService = new ElementService(mockRestService);
+    });
+
+    // ===== addElementAttributes =====
+
+    describe('addElementAttributes', () => {
+        test('should POST to ElementAttributes endpoint with correct body', async () => {
+            mockRestService.post.mockResolvedValue(createMockResponse({}, 201));
+
+            const attrs = [
+                new ElementAttribute('Description', 'String'),
+                new ElementAttribute('Score', 'Numeric')
+            ];
+
+            await elementService.addElementAttributes('TestDimension', 'TestHierarchy', attrs);
+
+            expect(mockRestService.post).toHaveBeenCalledTimes(1);
+            const [url, body] = mockRestService.post.mock.calls[0];
+
+            expect(url).toContain("Dimensions('TestDimension')/Hierarchies('TestHierarchy')/ElementAttributes");
+
+            const parsed = JSON.parse(body);
+            expect(Array.isArray(parsed)).toBe(true);
+            expect(parsed).toHaveLength(2);
+            expect(parsed[0].Name).toBe('Description');
+            expect(parsed[0].Type).toBe('String');
+            expect(parsed[1].Name).toBe('Score');
+            expect(parsed[1].Type).toBe('Numeric');
+        });
+
+        test('should POST an empty array when no attributes provided', async () => {
+            mockRestService.post.mockResolvedValue(createMockResponse({}, 201));
+
+            await elementService.addElementAttributes('TestDimension', 'TestHierarchy', []);
+
+            expect(mockRestService.post).toHaveBeenCalledTimes(1);
+            const [, body] = mockRestService.post.mock.calls[0];
+            const parsed = JSON.parse(body);
+            expect(parsed).toEqual([]);
+        });
+
+        test('should POST a single attribute', async () => {
+            mockRestService.post.mockResolvedValue(createMockResponse({}, 201));
+
+            const attrs = [new ElementAttribute('Alias', 'Alias')];
+
+            await elementService.addElementAttributes('Dim', 'Hier', attrs);
+
+            const [, body] = mockRestService.post.mock.calls[0];
+            const parsed = JSON.parse(body);
+            expect(parsed).toHaveLength(1);
+            expect(parsed[0].Name).toBe('Alias');
+            expect(parsed[0].Type).toBe('Alias');
+        });
+
+        test('should include dimension and hierarchy names in the URL', async () => {
+            mockRestService.post.mockResolvedValue(createMockResponse({}, 201));
+
+            await elementService.addElementAttributes(
+                'MyDimension',
+                'MyHierarchy',
+                [new ElementAttribute('Attr1', 'String')]
+            );
+
+            const [url] = mockRestService.post.mock.calls[0];
+            expect(url).toContain("MyDimension");
+            expect(url).toContain("MyHierarchy");
+        });
+    });
+});

--- a/src/tests/hierarchyService.issue38.test.ts
+++ b/src/tests/hierarchyService.issue38.test.ts
@@ -8,6 +8,7 @@ import { Hierarchy } from '../objects/Hierarchy';
 import { Element, ElementType } from '../objects/Element';
 import { ElementAttribute } from '../objects/ElementAttribute';
 import { TM1RestException } from '../exceptions/TM1Exception';
+import { DataFrame } from '../utils/DataFrame';
 
 const createMockResponse = (data: any, status: number = 200) => ({
     data,
@@ -352,6 +353,247 @@ describe('HierarchyService — Issue #38 new methods', () => {
             expect(mockRestService.post).toHaveBeenCalledTimes(1);
             const [url] = mockRestService.post.mock.calls[0];
             expect(url).toContain("Dimensions('TestDimension')/Hierarchies('TestHierarchy')/ElementAttributes");
+        });
+    });
+
+    // ===== updateOrCreateHierarchyFromDataframe =====
+
+    describe('updateOrCreateHierarchyFromDataframe', () => {
+        // Helper: mock hierarchy response with given elements/edges
+        const mockHierarchyResponse = (elements: any[] = [], edges: any[] = []) =>
+            createMockResponse({
+                Name: 'TestHierarchy',
+                Elements: elements,
+                Edges: edges,
+                ElementAttributes: [],
+                Subsets: [],
+                DefaultMember: null
+            });
+
+        // Helper: mock "hierarchy exists" check (getAllNames-style)
+        const setupExistingHierarchy = (elements: any[] = [], edges: any[] = []) => {
+            // exists() calls GET /Hierarchies?$select=Name
+            mockRestService.get.mockImplementation(async (url: string) => {
+                if (url.includes('$select=Name')) {
+                    return createMockResponse({ value: [{ Name: 'TestHierarchy' }] });
+                }
+                if (url.includes('$expand=Edges')) {
+                    return mockHierarchyResponse(elements, edges);
+                }
+                if (url.includes('ElementAttributes')) {
+                    return createMockResponse({ value: [] });
+                }
+                return createMockResponse({});
+            });
+        };
+
+        const setupNewHierarchy = () => {
+            let hierarchyCreated = false;
+            mockRestService.get.mockImplementation(async (url: string) => {
+                if (url.includes('$select=Name')) {
+                    return createMockResponse({ value: [] }); // hierarchy doesn't exist
+                }
+                if (url.includes('$expand=Edges')) {
+                    return mockHierarchyResponse(); // empty hierarchy after creation
+                }
+                if (url.includes('ElementAttributes')) {
+                    return createMockResponse({ value: [] });
+                }
+                return createMockResponse({});
+            });
+            mockRestService.post.mockImplementation(async (url: string, body: any) => {
+                hierarchyCreated = true;
+                return createMockResponse({}, 201);
+            });
+            mockRestService.patch.mockResolvedValue(createMockResponse({}, 200));
+        };
+
+        test('should add new elements from DataFrame to existing hierarchy', async () => {
+            setupExistingHierarchy([
+                { Name: 'Existing1', Type: 'Numeric' }
+            ]);
+            mockRestService.post.mockResolvedValue(createMockResponse({}, 201));
+
+            const df = new DataFrame([
+                ['Existing1', 'Numeric'],
+                ['NewElem1', 'String'],
+                ['NewElem2', 'Numeric']
+            ], { columns: ['Element', 'ElementType'] });
+
+            await hierarchyService.updateOrCreateHierarchyFromDataframe(
+                'TestDimension', 'TestHierarchy', df,
+                { elementColumn: 'Element' }
+            );
+
+            // Should POST new elements (NewElem1, NewElem2 but not Existing1)
+            const postCalls = mockRestService.post.mock.calls;
+            const elementPostCall = postCalls.find(
+                ([url]) => url.includes('/Elements') && !url.includes('ElementAttributes')
+            );
+            expect(elementPostCall).toBeDefined();
+            const postedBody = JSON.parse(elementPostCall![1]);
+            expect(postedBody).toHaveLength(2);
+            expect(postedBody.map((e: any) => e.Name).sort()).toEqual(['NewElem1', 'NewElem2']);
+        });
+
+        test('should throw on duplicate elements when verifyUniqueElements=true', async () => {
+            const df = new DataFrame([
+                ['Elem1', 'Numeric'],
+                ['elem1', 'String'], // duplicate (case-insensitive)
+            ], { columns: ['Element', 'ElementType'] });
+
+            await expect(
+                hierarchyService.updateOrCreateHierarchyFromDataframe(
+                    'TestDimension', 'TestHierarchy', df,
+                    { elementColumn: 'Element', verifyUniqueElements: true }
+                )
+            ).rejects.toThrow('Duplicate element');
+        });
+
+        test('should create dimension when hierarchy does not exist', async () => {
+            setupNewHierarchy();
+
+            const df = new DataFrame([
+                ['Elem1', 'Numeric']
+            ], { columns: ['Element', 'ElementType'] });
+
+            await hierarchyService.updateOrCreateHierarchyFromDataframe(
+                'NewDimension', 'NewHierarchy', df,
+                { elementColumn: 'Element' }
+            );
+
+            // Should have called POST for dimension creation
+            const postCalls = mockRestService.post.mock.calls;
+            const dimCreateCall = postCalls.find(([url]) => url.includes('/Dimensions'));
+            expect(dimCreateCall).toBeDefined();
+        });
+
+        test('should unwind all edges when unwindAll=true', async () => {
+            setupExistingHierarchy(
+                [{ Name: 'Parent', Type: 'Consolidated' }, { Name: 'Child', Type: 'Numeric' }],
+                [{ ParentName: 'Parent', ComponentName: 'Child', Weight: 1 }]
+            );
+            mockRestService.post.mockResolvedValue(createMockResponse({}, 201));
+            mockRestService.patch.mockResolvedValue(createMockResponse({}, 200));
+
+            const df = new DataFrame([
+                ['Child', 'Numeric']
+            ], { columns: ['Element', 'ElementType'] });
+
+            await hierarchyService.updateOrCreateHierarchyFromDataframe(
+                'TestDimension', 'TestHierarchy', df,
+                { elementColumn: 'Element', unwindAll: true }
+            );
+
+            // Should PATCH to remove all edges (empty Edges array)
+            const patchCalls = mockRestService.patch.mock.calls;
+            const edgePatch = patchCalls.find(([_, body]) => {
+                try { return JSON.parse(body).Edges !== undefined; } catch { return false; }
+            });
+            expect(edgePatch).toBeDefined();
+        });
+
+        test('should re-throw unexpected errors from bulk edge add', async () => {
+            setupExistingHierarchy();
+            mockRestService.post.mockImplementation(async (url: string) => {
+                if (url.includes('/Edges')) {
+                    throw new TM1RestException('Server error', 500, { status: 500 });
+                }
+                if (url.includes('/Elements')) {
+                    return createMockResponse({}, 201);
+                }
+                return createMockResponse({}, 201);
+            });
+
+            const df = new DataFrame([
+                ['Child', 'Numeric', 'Parent'],
+            ], { columns: ['Element', 'ElementType', 'Level001'] });
+
+            await expect(
+                hierarchyService.updateOrCreateHierarchyFromDataframe(
+                    'TestDimension', 'TestHierarchy', df,
+                    { elementColumn: 'Element' }
+                )
+            ).rejects.toThrow('Server error');
+        });
+
+        test('should fall back to individual edges on 400 from bulk', async () => {
+            setupExistingHierarchy();
+            let bulkAttempted = false;
+            mockRestService.post.mockImplementation(async (url: string, body: any) => {
+                if (url.includes('/Edges')) {
+                    if (!bulkAttempted) {
+                        bulkAttempted = true;
+                        throw new TM1RestException('Bad request', 400, { status: 400 });
+                    }
+                    // Individual edge adds succeed
+                    return createMockResponse({}, 201);
+                }
+                if (url.includes('/Elements')) {
+                    return createMockResponse({}, 201);
+                }
+                return createMockResponse({}, 201);
+            });
+
+            const df = new DataFrame([
+                ['Child', 'Numeric', 'Parent'],
+            ], { columns: ['Element', 'ElementType', 'Level001'] });
+
+            await hierarchyService.updateOrCreateHierarchyFromDataframe(
+                'TestDimension', 'TestHierarchy', df,
+                { elementColumn: 'Element' }
+            );
+
+            // Bulk failed, then individual edge was attempted
+            const edgeCalls = mockRestService.post.mock.calls.filter(
+                ([url]) => url.includes('/Edges')
+            );
+            expect(edgeCalls.length).toBeGreaterThan(1); // bulk + individual
+        });
+
+        test('should delete orphaned consolidations when requested', async () => {
+            // Setup: hierarchy has a Consolidated element "Orphan" with no children
+            const getCallCount = { n: 0 };
+            mockRestService.get.mockImplementation(async (url: string) => {
+                if (url.includes('$select=Name')) {
+                    return createMockResponse({ value: [{ Name: 'TestHierarchy' }] });
+                }
+                if (url.includes('$expand=Edges')) {
+                    getCallCount.n++;
+                    // Return hierarchy with orphaned consolidation
+                    return createMockResponse({
+                        Name: 'TestHierarchy',
+                        Elements: [
+                            { Name: 'Leaf', Type: 'Numeric' },
+                            { Name: 'Orphan', Type: 'Consolidated' }
+                        ],
+                        Edges: [], // No edges — Orphan is orphaned
+                        ElementAttributes: [],
+                        Subsets: [],
+                        DefaultMember: null
+                    });
+                }
+                if (url.includes('ElementAttributes')) {
+                    return createMockResponse({ value: [] });
+                }
+                return createMockResponse({});
+            });
+            mockRestService.post.mockResolvedValue(createMockResponse({}, 201));
+            mockRestService.delete.mockResolvedValue(createMockResponse({}, 204));
+
+            const df = new DataFrame([
+                ['Leaf', 'Numeric']
+            ], { columns: ['Element', 'ElementType'] });
+
+            await hierarchyService.updateOrCreateHierarchyFromDataframe(
+                'TestDimension', 'TestHierarchy', df,
+                { elementColumn: 'Element', deleteOrphanedConsolidations: true }
+            );
+
+            // Should DELETE the orphaned consolidation
+            const deleteCalls = mockRestService.delete.mock.calls;
+            const orphanDelete = deleteCalls.find(([url]) => url.includes("Elements('Orphan')"));
+            expect(orphanDelete).toBeDefined();
         });
     });
 });

--- a/src/tests/hierarchyService.issue38.test.ts
+++ b/src/tests/hierarchyService.issue38.test.ts
@@ -1,0 +1,357 @@
+/**
+ * HierarchyService Tests — Issue #38 new methods
+ */
+
+import { HierarchyService } from '../services/HierarchyService';
+import { RestService } from '../services/RestService';
+import { Hierarchy } from '../objects/Hierarchy';
+import { Element, ElementType } from '../objects/Element';
+import { ElementAttribute } from '../objects/ElementAttribute';
+import { TM1RestException } from '../exceptions/TM1Exception';
+
+const createMockResponse = (data: any, status: number = 200) => ({
+    data,
+    status,
+    statusText: status === 200 ? 'OK' : status === 201 ? 'Created' : status === 204 ? 'No Content' : 'Error',
+    headers: {},
+    config: {} as any
+});
+
+describe('HierarchyService — Issue #38 new methods', () => {
+    let hierarchyService: HierarchyService;
+    let mockRestService: jest.Mocked<RestService>;
+
+    beforeEach(() => {
+        mockRestService = {
+            get: jest.fn(),
+            post: jest.fn(),
+            patch: jest.fn(),
+            delete: jest.fn(),
+            put: jest.fn(),
+            config: {} as any,
+            rest: {} as any,
+            buildBaseUrl: jest.fn(),
+            extractErrorMessage: jest.fn()
+        } as any;
+
+        hierarchyService = new HierarchyService(mockRestService);
+    });
+
+    // ===== updateOrCreate =====
+
+    describe('updateOrCreate', () => {
+        test('should call create when hierarchy does not exist', async () => {
+            const hierarchy = new Hierarchy('NewHierarchy', 'TestDimension');
+
+            // exists() does a GET for $select=Name — return list without the hierarchy
+            mockRestService.get.mockImplementation(async (url: string) => {
+                if (url.includes('$select=Name')) {
+                    return createMockResponse({ value: [] });
+                }
+                // getElementAttributes inside create -> updateElementAttributes
+                return createMockResponse({ value: [] });
+            });
+            mockRestService.post.mockResolvedValue(createMockResponse({ Name: 'NewHierarchy' }, 201));
+
+            const result = await hierarchyService.updateOrCreate(hierarchy);
+
+            expect(mockRestService.post).toHaveBeenCalledTimes(1);
+            const postUrl = mockRestService.post.mock.calls[0][0];
+            expect(postUrl).toContain("/Hierarchies");
+        });
+
+        test('should call update when hierarchy exists', async () => {
+            const hierarchy = new Hierarchy('ExistingHierarchy', 'TestDimension');
+
+            // exists() returns the hierarchy in the list
+            mockRestService.get.mockImplementation(async (url: string) => {
+                if (url.includes('$select=Name')) {
+                    return createMockResponse({ value: [{ Name: 'ExistingHierarchy' }] });
+                }
+                // getElementAttributes inside update -> updateElementAttributes
+                return createMockResponse({ value: [] });
+            });
+            mockRestService.patch.mockResolvedValue(createMockResponse({}, 200));
+
+            const result = await hierarchyService.updateOrCreate(hierarchy);
+
+            expect(mockRestService.patch).toHaveBeenCalledTimes(1);
+            const patchUrl = mockRestService.patch.mock.calls[0][0];
+            expect(patchUrl).toContain("Hierarchies('ExistingHierarchy')");
+        });
+    });
+
+    // ===== getHierarchySummary =====
+
+    describe('getHierarchySummary', () => {
+        test('should return correct counts from OData response', async () => {
+            mockRestService.get.mockResolvedValue(createMockResponse({
+                'Cardinality': 0,
+                'Elements@odata.count': 42,
+                'Edges@odata.count': 30,
+                'ElementAttributes@odata.count': 5,
+                'Members@odata.count': 50,
+                'Levels@odata.count': 3
+            }));
+
+            const summary = await hierarchyService.getHierarchySummary('TestDimension', 'TestHierarchy');
+
+            expect(summary.Elements).toBe(42);
+            expect(summary.Edges).toBe(30);
+            expect(summary.ElementAttributes).toBe(5);
+            expect(summary.Members).toBe(50);
+            expect(summary.Levels).toBe(3);
+        });
+
+        test('should default hierarchyName to dimensionName when not provided', async () => {
+            mockRestService.get.mockResolvedValue(createMockResponse({
+                'Elements@odata.count': 10,
+                'Edges@odata.count': 5,
+                'ElementAttributes@odata.count': 2,
+                'Members@odata.count': 10,
+                'Levels@odata.count': 1
+            }));
+
+            await hierarchyService.getHierarchySummary('TestDimension');
+
+            const calledUrl = mockRestService.get.mock.calls[0][0];
+            expect(calledUrl).toContain("Hierarchies('TestDimension')");
+        });
+
+        test('should default missing odata counts to 0', async () => {
+            mockRestService.get.mockResolvedValue(createMockResponse({}));
+
+            const summary = await hierarchyService.getHierarchySummary('TestDimension', 'TestHierarchy');
+
+            expect(summary.Elements).toBe(0);
+            expect(summary.Edges).toBe(0);
+            expect(summary.ElementAttributes).toBe(0);
+            expect(summary.Members).toBe(0);
+            expect(summary.Levels).toBe(0);
+        });
+    });
+
+    // ===== getDefaultMember =====
+
+    describe('getDefaultMember', () => {
+        test('should return member name from response', async () => {
+            mockRestService.get.mockResolvedValue(createMockResponse({ Name: 'All Members' }));
+
+            const result = await hierarchyService.getDefaultMember('TestDimension', 'TestHierarchy');
+
+            expect(result).toBe('All Members');
+            const calledUrl = mockRestService.get.mock.calls[0][0];
+            expect(calledUrl).toContain('/DefaultMember');
+        });
+
+        test('should return null on 404', async () => {
+            mockRestService.get.mockRejectedValue(
+                new TM1RestException('Not found', 404, { status: 404 })
+            );
+
+            const result = await hierarchyService.getDefaultMember('TestDimension', 'TestHierarchy');
+
+            expect(result).toBeNull();
+        });
+
+        test('should rethrow non-404 errors', async () => {
+            mockRestService.get.mockRejectedValue(
+                new TM1RestException('Server error', 500, { status: 500 })
+            );
+
+            await expect(
+                hierarchyService.getDefaultMember('TestDimension', 'TestHierarchy')
+            ).rejects.toThrow();
+        });
+
+        test('should default hierarchyName to dimensionName', async () => {
+            mockRestService.get.mockResolvedValue(createMockResponse({ Name: 'Root' }));
+
+            await hierarchyService.getDefaultMember('TestDimension');
+
+            const calledUrl = mockRestService.get.mock.calls[0][0];
+            expect(calledUrl).toContain("Hierarchies('TestDimension')");
+        });
+    });
+
+    // ===== updateDefaultMember =====
+
+    describe('updateDefaultMember', () => {
+        test('should use API approach (PATCH) when version is 12.0.0', async () => {
+            (mockRestService as any).version = '12.0.0';
+            mockRestService.patch.mockResolvedValue(createMockResponse({}, 200));
+
+            await hierarchyService.updateDefaultMember('TestDimension', 'TestHierarchy', 'RootMember');
+
+            expect(mockRestService.patch).toHaveBeenCalledTimes(1);
+            const [url, body] = mockRestService.patch.mock.calls[0];
+            expect(url).toContain("Dimensions('TestDimension')/Hierarchies('TestHierarchy')");
+            const parsed = JSON.parse(body);
+            expect(parsed['DefaultMember@odata.bind']).toContain("Elements('RootMember')");
+        });
+
+        test('should use API approach when version is undefined', async () => {
+            (mockRestService as any).version = undefined;
+            mockRestService.patch.mockResolvedValue(createMockResponse({}, 200));
+
+            await hierarchyService.updateDefaultMember('TestDimension', 'TestHierarchy', 'RootMember');
+
+            expect(mockRestService.patch).toHaveBeenCalledTimes(1);
+        });
+
+        test('should use props cube approach for pre-v12 (version 11.8.0)', async () => {
+            (mockRestService as any).version = '11.8.0';
+            // CellService.writeValue calls getDimensionNamesForWriting (GET) then POST
+            mockRestService.get.mockResolvedValue(createMockResponse({
+                Dimensions: [
+                    { Name: '}HierarchyProperties' },
+                    { Name: '}HierarchyProperties_dim' },
+                    { Name: 'MEMBER_DEFAULT' }
+                ]
+            }));
+            mockRestService.post.mockResolvedValue(createMockResponse({}, 200));
+
+            await hierarchyService.updateDefaultMember('TestDimension', 'TestHierarchy', 'RootMember');
+
+            expect(mockRestService.post).toHaveBeenCalledTimes(1);
+            const [url, body] = mockRestService.post.mock.calls[0];
+            // The cube name '}HierarchyProperties' gets URL-encoded as '%7DHierarchyProperties'
+            expect(url).toContain('HierarchyProperties');
+            const parsed = JSON.parse(body);
+            expect(parsed.Cells[0].Value).toBe('RootMember');
+        });
+
+        test('should clear default member when memberName is empty string (API approach)', async () => {
+            (mockRestService as any).version = '12.0.0';
+            mockRestService.patch.mockResolvedValue(createMockResponse({}, 200));
+
+            await hierarchyService.updateDefaultMember('TestDimension', 'TestHierarchy', '');
+
+            expect(mockRestService.patch).toHaveBeenCalledTimes(1);
+            const [, body] = mockRestService.patch.mock.calls[0];
+            const parsed = JSON.parse(body);
+            expect(parsed['DefaultMember@odata.bind']).toBeNull();
+        });
+
+        test('should default hierarchyName to dimensionName', async () => {
+            (mockRestService as any).version = '12.0.0';
+            mockRestService.patch.mockResolvedValue(createMockResponse({}, 200));
+
+            await hierarchyService.updateDefaultMember('TestDimension', undefined, 'Root');
+
+            const [url] = mockRestService.patch.mock.calls[0];
+            expect(url).toContain("Hierarchies('TestDimension')");
+        });
+    });
+
+    // ===== removeEdgesUnderConsolidation =====
+
+    describe('removeEdgesUnderConsolidation', () => {
+        test('should remove edges under the specified consolidation element', async () => {
+            // Build a hierarchy: Total -> [A, B], A -> [A1, A2]
+            const hierarchy = new Hierarchy('TestHierarchy', 'TestDimension');
+            hierarchy.addEdge('Total', 'A', 1);
+            hierarchy.addEdge('Total', 'B', 1);
+            hierarchy.addEdge('A', 'A1', 1);
+            hierarchy.addEdge('A', 'A2', 1);
+
+            let getCallCount = 0;
+            mockRestService.get.mockImplementation(async (url: string) => {
+                getCallCount++;
+                if (getCallCount === 1) {
+                    // First call is the get(dimensionName, hierarchyName) inside removeEdgesUnderConsolidation
+                    return createMockResponse({
+                        Name: 'TestHierarchy',
+                        Elements: [
+                            { Name: 'Total', Type: 'Consolidated' },
+                            { Name: 'A', Type: 'Consolidated' },
+                            { Name: 'B', Type: 'Numeric' },
+                            { Name: 'A1', Type: 'Numeric' },
+                            { Name: 'A2', Type: 'Numeric' }
+                        ],
+                        Edges: [
+                            { ParentName: 'Total', ComponentName: 'A', Weight: 1 },
+                            { ParentName: 'Total', ComponentName: 'B', Weight: 1 },
+                            { ParentName: 'A', ComponentName: 'A1', Weight: 1 },
+                            { ParentName: 'A', ComponentName: 'A2', Weight: 1 }
+                        ],
+                        ElementAttributes: [],
+                        Subsets: []
+                    });
+                }
+                // Subsequent calls from updateElementAttributes
+                return createMockResponse({ value: [] });
+            });
+            mockRestService.patch.mockResolvedValue(createMockResponse({}, 200));
+
+            await hierarchyService.removeEdgesUnderConsolidation(
+                'TestDimension', 'TestHierarchy', 'A'
+            );
+
+            expect(mockRestService.patch).toHaveBeenCalledTimes(1);
+            const [, body] = mockRestService.patch.mock.calls[0];
+            const parsed = JSON.parse(body);
+            // After removing edges under A, A should have no children in the hierarchy
+            const remainingEdges: Array<{ ParentName: string; ComponentName: string }> = parsed.Edges || [];
+            const aEdges = remainingEdges.filter((e: any) => e.ParentName === 'A');
+            expect(aEdges).toHaveLength(0);
+        });
+    });
+
+    // ===== addEdges =====
+
+    describe('addEdges', () => {
+        test('should delegate to ElementService.addEdges', async () => {
+            mockRestService.post.mockResolvedValue(createMockResponse({}, 201));
+
+            await hierarchyService.addEdges(
+                'TestDimension',
+                'TestHierarchy',
+                { Parent: { Child: 1 } }
+            );
+
+            expect(mockRestService.post).toHaveBeenCalledTimes(1);
+            const [url] = mockRestService.post.mock.calls[0];
+            expect(url).toContain("Dimensions('TestDimension')/Hierarchies('TestHierarchy')");
+        });
+
+        test('should use dimensionName as hierarchyName when hierarchyName is undefined', async () => {
+            mockRestService.post.mockResolvedValue(createMockResponse({}, 201));
+
+            await hierarchyService.addEdges('TestDimension', undefined, { P: { C: 1 } });
+
+            const [url] = mockRestService.post.mock.calls[0];
+            expect(url).toContain("Hierarchies('TestDimension')");
+        });
+    });
+
+    // ===== addElements =====
+
+    describe('addElements', () => {
+        test('should delegate to ElementService.addElements', async () => {
+            mockRestService.post.mockResolvedValue(createMockResponse({}, 201));
+            const elements = [new Element('Elem1', ElementType.NUMERIC)];
+
+            await hierarchyService.addElements('TestDimension', 'TestHierarchy', elements);
+
+            expect(mockRestService.post).toHaveBeenCalledTimes(1);
+            const [url] = mockRestService.post.mock.calls[0];
+            expect(url).toContain("Dimensions('TestDimension')/Hierarchies('TestHierarchy')/Elements");
+        });
+    });
+
+    // ===== addElementAttributes =====
+
+    describe('addElementAttributes', () => {
+        test('should delegate to ElementService.addElementAttributes', async () => {
+            mockRestService.post.mockResolvedValue(createMockResponse({}, 201));
+            const attrs = [new ElementAttribute('Description', 'String')];
+
+            await hierarchyService.addElementAttributes('TestDimension', 'TestHierarchy', attrs);
+
+            expect(mockRestService.post).toHaveBeenCalledTimes(1);
+            const [url] = mockRestService.post.mock.calls[0];
+            expect(url).toContain("Dimensions('TestDimension')/Hierarchies('TestHierarchy')/ElementAttributes");
+        });
+    });
+});

--- a/src/tests/subsetService.issue38.test.ts
+++ b/src/tests/subsetService.issue38.test.ts
@@ -1,0 +1,182 @@
+/**
+ * SubsetService Tests — Issue #38 new methods
+ */
+
+import { SubsetService } from '../services/SubsetService';
+import { RestService } from '../services/RestService';
+import { Subset } from '../objects/Subset';
+import { Element, ElementType } from '../objects/Element';
+
+const createMockResponse = (data: any, status: number = 200) => ({
+    data,
+    status,
+    statusText: status === 200 ? 'OK' : status === 201 ? 'Created' : status === 204 ? 'No Content' : 'Error',
+    headers: {},
+    config: {} as any
+});
+
+describe('SubsetService — Issue #38 new methods', () => {
+    let subsetService: SubsetService;
+    let mockRestService: jest.Mocked<RestService>;
+
+    beforeEach(() => {
+        mockRestService = {
+            get: jest.fn(),
+            post: jest.fn(),
+            patch: jest.fn(),
+            delete: jest.fn(),
+            put: jest.fn(),
+            config: {} as any,
+            rest: {} as any,
+            buildBaseUrl: jest.fn(),
+            extractErrorMessage: jest.fn()
+        } as any;
+
+        subsetService = new SubsetService(mockRestService);
+    });
+
+    // ===== updateStaticElements =====
+
+    describe('updateStaticElements', () => {
+        test('should PUT to Elements/$ref with correct @odata.id body', async () => {
+            mockRestService.put.mockResolvedValue(createMockResponse({}, 200));
+
+            await subsetService.updateStaticElements(
+                'MySubset',
+                'TestDimension',
+                'TestHierarchy',
+                false,
+                ['ElemA', 'ElemB']
+            );
+
+            expect(mockRestService.put).toHaveBeenCalledTimes(1);
+            const [url, body] = mockRestService.put.mock.calls[0];
+            expect(url).toContain("Dimensions('TestDimension')/Hierarchies('TestHierarchy')");
+            expect(url).toContain("Subsets('MySubset')/Elements/$ref");
+
+            const parsed = JSON.parse(body);
+            expect(Array.isArray(parsed.value)).toBe(true);
+            expect(parsed.value).toHaveLength(2);
+            expect(parsed.value[0]['@odata.id']).toContain("Elements('ElemA')");
+            expect(parsed.value[1]['@odata.id']).toContain("Elements('ElemB')");
+        });
+
+        test('should accept a Subset object and use its elements', async () => {
+            mockRestService.put.mockResolvedValue(createMockResponse({}, 200));
+
+            const subset = new Subset('MySubset', 'TestDimension', 'TestHierarchy', undefined, undefined, ['X', 'Y', 'Z']);
+
+            await subsetService.updateStaticElements(subset);
+
+            expect(mockRestService.put).toHaveBeenCalledTimes(1);
+            const [, body] = mockRestService.put.mock.calls[0];
+            const parsed = JSON.parse(body);
+            expect(parsed.value).toHaveLength(3);
+            expect(parsed.value[0]['@odata.id']).toContain("Elements('X')");
+            expect(parsed.value[2]['@odata.id']).toContain("Elements('Z')");
+        });
+
+        test('should accept a Subset object with overriding elements array', async () => {
+            mockRestService.put.mockResolvedValue(createMockResponse({}, 200));
+
+            const subset = new Subset('MySubset', 'TestDimension', 'TestHierarchy', undefined, undefined, ['X', 'Y']);
+            // Override elements explicitly
+            await subsetService.updateStaticElements(subset, undefined, undefined, false, ['Override1']);
+
+            const [, body] = mockRestService.put.mock.calls[0];
+            const parsed = JSON.parse(body);
+            expect(parsed.value).toHaveLength(1);
+            expect(parsed.value[0]['@odata.id']).toContain("Elements('Override1')");
+        });
+
+        test('should accept Element objects (not just strings)', async () => {
+            mockRestService.put.mockResolvedValue(createMockResponse({}, 200));
+
+            const elem1 = new Element('Alpha', ElementType.NUMERIC);
+            const elem2 = new Element('Beta', ElementType.NUMERIC);
+
+            await subsetService.updateStaticElements(
+                'MySubset',
+                'TestDimension',
+                'TestHierarchy',
+                false,
+                [elem1, elem2]
+            );
+
+            const [, body] = mockRestService.put.mock.calls[0];
+            const parsed = JSON.parse(body);
+            expect(parsed.value[0]['@odata.id']).toContain("Elements('Alpha')");
+            expect(parsed.value[1]['@odata.id']).toContain("Elements('Beta')");
+        });
+
+        test('should use PrivateSubsets collection when isPrivate=true', async () => {
+            mockRestService.put.mockResolvedValue(createMockResponse({}, 200));
+
+            await subsetService.updateStaticElements(
+                'PrivateSubset',
+                'TestDimension',
+                'TestHierarchy',
+                true,
+                ['E1']
+            );
+
+            const [url] = mockRestService.put.mock.calls[0];
+            expect(url).toContain('PrivateSubsets');
+            // PrivateSubsets is the only subsets segment — there must be no plain '/Subsets(' prefix
+            expect(url).not.toMatch(/\/Subsets\(/);
+        });
+
+        test('should use public Subsets collection when isPrivate=false', async () => {
+            mockRestService.put.mockResolvedValue(createMockResponse({}, 200));
+
+            await subsetService.updateStaticElements(
+                'PublicSubset',
+                'TestDimension',
+                'TestHierarchy',
+                false,
+                ['E1']
+            );
+
+            const [url] = mockRestService.put.mock.calls[0];
+            expect(url).toContain("Subsets('PublicSubset')");
+            expect(url).not.toContain('PrivateSubsets');
+        });
+
+        test('should throw when dimensionName is missing for string argument', async () => {
+            await expect(
+                subsetService.updateStaticElements('MySubset', undefined, 'TestHierarchy', false, ['E1'])
+            ).rejects.toThrow('dimensionName is required when passing subset name as string');
+        });
+
+        test('should default hierarchyName to dimensionName for string argument', async () => {
+            mockRestService.put.mockResolvedValue(createMockResponse({}, 200));
+
+            await subsetService.updateStaticElements(
+                'MySubset',
+                'TestDimension',
+                undefined, // no hierarchyName — should default to dimensionName
+                false,
+                ['E1']
+            );
+
+            const [url] = mockRestService.put.mock.calls[0];
+            expect(url).toContain("Hierarchies('TestDimension')");
+        });
+
+        test('should send empty value array when no elements provided', async () => {
+            mockRestService.put.mockResolvedValue(createMockResponse({}, 200));
+
+            await subsetService.updateStaticElements(
+                'EmptySubset',
+                'TestDimension',
+                'TestHierarchy',
+                false,
+                []
+            );
+
+            const [, body] = mockRestService.put.mock.calls[0];
+            const parsed = JSON.parse(body);
+            expect(parsed.value).toEqual([]);
+        });
+    });
+});


### PR DESCRIPTION
## Summary
- Implement 9 missing HierarchyService methods (`updateOrCreate`, `getHierarchySummary`, `getDefaultMember`, `updateDefaultMember`, `removeEdgesUnderConsolidation`, `addEdges`, `addElements`, `addElementAttributes`, `updateOrCreateHierarchyFromDataframe`)
- Implement ApplicationService `discover()` with recursive/flat/private options and mixed public/private path resolution (`_resolvePath`, `_findPrivateBoundary`) wired into `getNames`, `get`, `exists`
- Implement SubsetService `updateStaticElements()` using PUT `Elements/$ref` with `@odata.id` references
- Add `addElementAttributes()` to ElementService (prerequisite for delegation)
- Wire ApplicationService into TM1Service

Closes #38

## Test plan
- [x] 51 new unit tests across 4 test files — all passing
- [x] TypeScript compiles with zero errors
- [x] 1222 total tests pass (5 pre-existing credential-dependent failures unchanged)
- [x] 6 rounds of review feedback addressed (error handling, mixed path collection logic, OData type extraction, catch block narrowing, natural column sort)