### PR TITLE
feat(#63): add v12/Cloud/PA Proxy/S2S URL patterns to RestService

### DIFF
--- a/src/services/RestService.ts
+++ b/src/services/RestService.ts
@@ -1,5 +1,9 @@
 import axios, { AxiosInstance, AxiosResponse, AxiosRequestConfig } from 'axios';
+import * as https from 'https';
+import * as fs from 'fs';
 import { TM1RestException, TM1TimeoutException } from '../exceptions/TM1Exception';
+
+type UrlTopology = 'base_url' | 'v11' | 'ibm_cloud' | 'pa_proxy' | 's2s';
 
 export enum AuthenticationMode {
     BASIC = 1,
@@ -39,6 +43,26 @@ export interface RestServiceConfig {
     apiKey?: string;
     accessToken?: string;
     tenant?: string;
+
+    // v12 / Cloud URL components
+    iamUrl?: string;
+    paUrl?: string;
+    cpdUrl?: string;
+
+    // SSO / CAM
+    gateway?: string;
+
+    // Integrated Windows Auth / Kerberos (config surface; auth flow unchanged)
+    integratedLogin?: boolean;
+    integratedLoginDomain?: string;
+    integratedLoginService?: string;
+    integratedLoginHost?: string;
+    integratedLoginDelegate?: boolean;
+
+    // Network / TLS
+    proxies?: { http?: string; https?: string };
+    sslContext?: any;
+    cert?: string | [string, string];
 }
 
 export class RestService {
@@ -71,29 +95,149 @@ export class RestService {
 
     private setupAxiosInstance(): void {
         const baseURL = this.buildBaseUrl();
-        
-        this.axiosInstance = axios.create({
+
+        const axiosConfig: AxiosRequestConfig = {
             baseURL,
             timeout: (this.config.timeout || 60) * 1000,
             headers: {
                 ...RestService.HEADERS,
                 ...(this.config.sessionContext && { 'TM1-SessionContext': this.config.sessionContext })
             }
-        });
+        };
+
+        if (this.config.proxies) {
+            const proxyUrl = this.config.proxies.https || this.config.proxies.http;
+            if (proxyUrl) {
+                const parsed = new URL(proxyUrl);
+                axiosConfig.proxy = {
+                    host: parsed.hostname,
+                    port: parsed.port
+                        ? parseInt(parsed.port, 10)
+                        : (parsed.protocol === 'https:' ? 443 : 80),
+                    protocol: parsed.protocol.replace(':', '')
+                };
+            }
+        }
+
+        if (this.config.sslContext) {
+            axiosConfig.httpsAgent = this.config.sslContext;
+        } else if (this.config.cert) {
+            const [certPath, keyPath] = Array.isArray(this.config.cert)
+                ? this.config.cert
+                : [this.config.cert, undefined];
+            axiosConfig.httpsAgent = new https.Agent({
+                cert: fs.readFileSync(certPath),
+                key: keyPath ? fs.readFileSync(keyPath) : undefined
+            });
+        }
+
+        this.axiosInstance = axios.create(axiosConfig);
 
         this.setupInterceptors();
     }
 
     private buildBaseUrl(): string {
-        if (this.config.baseUrl) {
-            return this.config.baseUrl;
-        }
+        return this.resolveRoots().serviceRoot;
+    }
 
+    /**
+     * Pick the deployment topology based on the provided config, mirroring
+     * tm1py's _determine_auth_mode + _construct_service_and_auth_root dispatch.
+     *
+     * Note: authUrl is intentionally excluded from the v12 signal set because
+     * tm1npm historically uses authUrl for CAM SSO (unlike tm1py, where auth_url
+     * is a v12-only field). apiKey is also excluded to avoid collision with the
+     * existing BASIC_API_KEY auth flow.
+     */
+    private determineTopology(): UrlTopology {
+        const c = this.config;
+        if (c.baseUrl) return 'base_url';
+        const hasV12Signal = !!(c.instance || c.database || c.iamUrl || c.paUrl || c.tenant);
+        if (!hasV12Signal) return 'v11';
+        if (c.iamUrl) return 'ibm_cloud';
+        if (c.address && c.user && !c.instance) return 'pa_proxy';
+        return 's2s';
+    }
+
+    /**
+     * Resolve the TM1 service root and auth root URLs for the configured topology.
+     * Mirrors tm1py's _construct_service_and_auth_root return tuple.
+     */
+    private resolveRoots(): { serviceRoot: string; authRoot: string } {
+        switch (this.determineTopology()) {
+            case 'base_url':  return this.rootsFromBaseUrl();
+            case 'ibm_cloud': return this.rootsIbmCloud();
+            case 'pa_proxy':  return this.rootsPaProxy();
+            case 's2s':       return this.rootsS2s();
+            case 'v11':
+            default:          return this.rootsV11();
+        }
+    }
+
+    private rootsV11(): { serviceRoot: string; authRoot: string } {
         const protocol = this.config.ssl ? 'https' : 'http';
         const address = this.config.address || 'localhost';
-        const port = this.config.port || 8001;
-        
-        return `${protocol}://${address}:${port}/api/v1`;
+        const port = this.config.port ?? 8001;
+        const serviceRoot = `${protocol}://${address}:${port}/api/v1`;
+        return { serviceRoot, authRoot: `${serviceRoot}/Configuration/ProductVersion/$value` };
+    }
+
+    private rootsIbmCloud(): { serviceRoot: string; authRoot: string } {
+        const { address, tenant, database, ssl } = this.config;
+        if (!address || !tenant || !database) {
+            throw new Error("'address', 'tenant' and 'database' must be provided to connect to TM1 > v12 in IBM Cloud");
+        }
+        if (ssl === false) {
+            throw new Error("'ssl' must be true to connect to TM1 > v12 in IBM Cloud");
+        }
+        const t = encodeURIComponent(tenant);
+        const d = encodeURIComponent(database);
+        const serviceRoot = `https://${address}/api/${t}/v0/tm1/${d}`;
+        return { serviceRoot, authRoot: `${serviceRoot}/Configuration/ProductVersion/$value` };
+    }
+
+    private rootsPaProxy(): { serviceRoot: string; authRoot: string } {
+        const { address, database, ssl } = this.config;
+        if (!address || !database) {
+            throw new Error("'address' and 'database' must be provided to connect to TM1 > v12 using PA Proxy");
+        }
+        const protocol = ssl ? 'https' : 'http';
+        const d = encodeURIComponent(database);
+        const serviceRoot = `${protocol}://${address}/tm1/${d}/api/v1`;
+        const authRoot = `${protocol}://${address}/login`;
+        return { serviceRoot, authRoot };
+    }
+
+    private rootsS2s(): { serviceRoot: string; authRoot: string } {
+        const { instance, database, ssl, port } = this.config;
+        if (!instance || !database) {
+            throw new Error("'instance' and 'database' arguments are required for v12 authentication with 'address'");
+        }
+        const protocol = ssl ? 'https' : 'http';
+        const address = this.config.address && this.config.address.length > 0
+            ? this.config.address
+            : 'localhost';
+        const portPart = port != null ? `:${port}` : '';
+        const i = encodeURIComponent(instance);
+        const d = encodeURIComponent(database);
+        const serviceRoot = `${protocol}://${address}${portPart}/${i}/api/v1/Databases('${d}')`;
+        const authRoot = `${protocol}://${address}${portPart}/${i}/auth/v1/session`;
+        return { serviceRoot, authRoot };
+    }
+
+    private rootsFromBaseUrl(): { serviceRoot: string; authRoot: string } {
+        const base = this.config.baseUrl!;
+        if (this.config.address) {
+            throw new Error("Base URL and Address cannot be specified at the same time");
+        }
+        if (/api\/v1\/Databases/.test(base)) {
+            if (!this.config.authUrl) {
+                throw new Error("Auth_url missing — when connecting to planning analytics engine using base_url, you must specify a corresponding auth_url");
+            }
+            return { serviceRoot: base, authRoot: this.config.authUrl };
+        }
+        const serviceRoot = base.endsWith('/api/v1') ? base : `${base}/api/v1`;
+        return { serviceRoot, authRoot: `${serviceRoot}/Configuration/ProductVersion/$value` };
     }
 
     private setupInterceptors(): void {
@@ -415,7 +559,7 @@ export class RestService {
         }
 
         try {
-            const tokenEndpoint = this.config.authUrl || `${this.buildBaseUrl()}/oauth/token`;
+            const tokenEndpoint = this.config.authUrl || this.resolveRoots().authRoot;
 
             const tokenPayload = {
                 grant_type: 'client_credentials',

--- a/src/services/RestService.ts
+++ b/src/services/RestService.ts
@@ -5,6 +5,8 @@ import { TM1RestException, TM1TimeoutException } from '../exceptions/TM1Exceptio
 
 type UrlTopology = 'base_url' | 'v11' | 'ibm_cloud' | 'pa_proxy' | 's2s';
 
+const PRODUCT_VERSION_AUTH_SUFFIX = '/Configuration/ProductVersion/$value';
+
 export enum AuthenticationMode {
     BASIC = 1,
     WIA = 2,
@@ -61,7 +63,7 @@ export interface RestServiceConfig {
 
     // Network / TLS
     proxies?: { http?: string; https?: string };
-    sslContext?: any;
+    sslContext?: https.Agent;
     cert?: string | [string, string];
 }
 
@@ -179,7 +181,7 @@ export class RestService {
         const address = this.config.address || 'localhost';
         const port = this.config.port ?? 8001;
         const serviceRoot = `${protocol}://${address}:${port}/api/v1`;
-        return { serviceRoot, authRoot: `${serviceRoot}/Configuration/ProductVersion/$value` };
+        return { serviceRoot, authRoot: serviceRoot + PRODUCT_VERSION_AUTH_SUFFIX };
     }
 
     private rootsIbmCloud(): { serviceRoot: string; authRoot: string } {
@@ -193,7 +195,7 @@ export class RestService {
         const t = encodeURIComponent(tenant);
         const d = encodeURIComponent(database);
         const serviceRoot = `https://${address}/api/${t}/v0/tm1/${d}`;
-        return { serviceRoot, authRoot: `${serviceRoot}/Configuration/ProductVersion/$value` };
+        return { serviceRoot, authRoot: serviceRoot + PRODUCT_VERSION_AUTH_SUFFIX };
     }
 
     private rootsPaProxy(): { serviceRoot: string; authRoot: string } {
@@ -237,7 +239,7 @@ export class RestService {
             return { serviceRoot: base, authRoot: this.config.authUrl };
         }
         const serviceRoot = base.endsWith('/api/v1') ? base : `${base}/api/v1`;
-        return { serviceRoot, authRoot: `${serviceRoot}/Configuration/ProductVersion/$value` };
+        return { serviceRoot, authRoot: serviceRoot + PRODUCT_VERSION_AUTH_SUFFIX };
     }
 
     private setupInterceptors(): void {

--- a/src/services/RestService.ts
+++ b/src/services/RestService.ts
@@ -175,7 +175,13 @@ export class RestService {
                     port: parsed.port
                         ? parseInt(parsed.port, 10)
                         : (parsed.protocol === 'https:' ? 443 : 80),
-                    protocol: parsed.protocol.replace(':', '')
+                    protocol: parsed.protocol.replace(':', ''),
+                    ...(parsed.username && {
+                        auth: {
+                            username: decodeURIComponent(parsed.username),
+                            password: decodeURIComponent(parsed.password)
+                        }
+                    })
                 };
             }
         }
@@ -619,10 +625,16 @@ export class RestService {
         }
 
         try {
-            // v11's authRoot is /Configuration/ProductVersion/$value — a metadata probe,
-            // not a token endpoint. Require callers to supply authUrl explicitly.
-            if (!this.config.authUrl && this.determineTopology() === 'v11') {
-                throw new Error("'authUrl' is required for Service-to-Service authentication on v11 topology");
+            // Both v11 and v11-style baseUrl topologies resolve authRoot to
+            // /Configuration/ProductVersion/$value — a metadata probe, not a token
+            // endpoint. Require callers to supply authUrl explicitly in those cases.
+            if (!this.config.authUrl) {
+                const topo = this.determineTopology();
+                const baseUrlIsV12 = topo === 'base_url'
+                    && /api\/v1\/Databases/.test(this.config.baseUrl ?? '');
+                if (topo === 'v11' || (topo === 'base_url' && !baseUrlIsV12)) {
+                    throw new Error("'authUrl' is required for Service-to-Service authentication on v11 topology");
+                }
             }
             const tokenEndpoint = this.config.authUrl || this.resolveRoots().authRoot;
 

--- a/src/services/RestService.ts
+++ b/src/services/RestService.ts
@@ -315,7 +315,9 @@ export class RestService {
         // and use them verbatim. Only fall through to /api/v1 suffixing when the
         // URL clearly lacks any TM1 API path — matching tm1py's fallback.
         const trimmed = base.replace(/\/+$/, '');
-        const hasApiSuffix = /\/api\/v1$|\/v0\/tm1\/|\/tm1\/api\/tm1$/.test(trimmed);
+        // Each alternative is $-anchored (after trailing-slash trim above) so the
+        // match intent is explicit: the URL already ends in a TM1 API suffix.
+        const hasApiSuffix = /\/api\/v1$|\/v0\/tm1\/[^/]+$|\/tm1\/api\/tm1$/.test(trimmed);
         const serviceRoot = hasApiSuffix ? trimmed : `${trimmed}/api/v1`;
         return { serviceRoot, authRoot: serviceRoot + PRODUCT_VERSION_AUTH_SUFFIX };
     }

--- a/src/services/RestService.ts
+++ b/src/services/RestService.ts
@@ -561,6 +561,11 @@ export class RestService {
         }
 
         try {
+            // v11's authRoot is /Configuration/ProductVersion/$value — a metadata probe,
+            // not a token endpoint. Require callers to supply authUrl explicitly.
+            if (!this.config.authUrl && this.determineTopology() === 'v11') {
+                throw new Error("'authUrl' is required for Service-to-Service authentication on v11 topology");
+            }
             const tokenEndpoint = this.config.authUrl || this.resolveRoots().authRoot;
 
             const tokenPayload = {

--- a/src/services/RestService.ts
+++ b/src/services/RestService.ts
@@ -218,9 +218,11 @@ export class RestService {
      */
     private determineTopology(): UrlTopology {
         const c = this.config;
-        if (c.baseUrl) return 'base_url';
         const hasV12Signal = !!(c.instance || c.database || c.iamUrl || c.paUrl || c.tenant);
-        if (!hasV12Signal) return 'v11';
+        // tm1py's _construct_service_and_auth_root routes v12 modes (IBM Cloud / PA
+        // Proxy / S2S) through their dedicated constructors even if base_url is
+        // supplied. Only non-v12 configs fall through to the base_url override.
+        if (!hasV12Signal) return c.baseUrl ? 'base_url' : 'v11';
         if (c.iamUrl) return 'ibm_cloud';
         if (c.address && c.user && !c.instance) return 'pa_proxy';
         return 's2s';

--- a/src/services/RestService.ts
+++ b/src/services/RestService.ts
@@ -261,7 +261,7 @@ export class RestService {
         if (!address || !tenant || !database) {
             throw new Error("'address', 'tenant' and 'database' must be provided to connect to TM1 > v12 in IBM Cloud");
         }
-        if (ssl === false) {
+        if (!ssl) {
             throw new Error("'ssl' must be true to connect to TM1 > v12 in IBM Cloud");
         }
         const t = encodeURIComponent(tenant);

--- a/src/services/RestService.ts
+++ b/src/services/RestService.ts
@@ -96,8 +96,13 @@ export class RestService {
         this.config = { ...config };
         this.setupAxiosInstance();
         if (this.config.sessionId) {
-            // v12 paSession seeding via config is not yet modeled.
-            this.sessionCookies.set(RestService.SESSION_COOKIE_NAMES[0], this.config.sessionId);
+            // Mirror tm1py's _set_session_id_cookie: v12 topologies use paSession,
+            // v11 and baseUrl overrides use TM1SessionId.
+            const topo = this.determineTopology();
+            const cookieName = (topo === 'ibm_cloud' || topo === 'pa_proxy' || topo === 's2s')
+                ? 'paSession'
+                : 'TM1SessionId';
+            this.sessionCookies.set(cookieName, this.config.sessionId);
         }
     }
 
@@ -305,7 +310,13 @@ export class RestService {
             }
             return { serviceRoot: base, authRoot: this.config.authUrl };
         }
-        const serviceRoot = base.endsWith('/api/v1') ? base : `${base}/api/v1`;
+        // Recognize baseUrl shapes documented in docs/connection-guide.md
+        // (TM1 11 IBM Cloud `/tm1/api/tm1`, TM1 12 PaaS/access-token `/v0/tm1/...`)
+        // and use them verbatim. Only fall through to /api/v1 suffixing when the
+        // URL clearly lacks any TM1 API path — matching tm1py's fallback.
+        const trimmed = base.replace(/\/+$/, '');
+        const hasApiSuffix = /\/api\/v1$|\/v0\/tm1\/|\/tm1\/api\/tm1$/.test(trimmed);
+        const serviceRoot = hasApiSuffix ? trimmed : `${trimmed}/api/v1`;
         return { serviceRoot, authRoot: serviceRoot + PRODUCT_VERSION_AUTH_SUFFIX };
     }
 
@@ -626,18 +637,20 @@ export class RestService {
             throw new Error('Service-to-Service authentication requires applicationClientId and applicationClientSecret');
         }
 
-        try {
-            // Both v11 and v11-style baseUrl topologies resolve authRoot to
-            // /Configuration/ProductVersion/$value — a metadata probe, not a token
-            // endpoint. Require callers to supply authUrl explicitly in those cases.
-            if (!this.config.authUrl) {
-                const topo = this.determineTopology();
-                const baseUrlIsV12 = topo === 'base_url'
-                    && /api\/v1\/Databases/.test(this.config.baseUrl ?? '');
-                if (topo === 'v11' || (topo === 'base_url' && !baseUrlIsV12)) {
-                    throw new Error("'authUrl' is required for Service-to-Service authentication on v11 topology");
-                }
+        // Both v11 and v11-style baseUrl topologies resolve authRoot to
+        // /Configuration/ProductVersion/$value — a metadata probe, not a token
+        // endpoint. Require callers to supply authUrl explicitly in those cases.
+        // Validation lives outside the try/catch so its message is not double-wrapped.
+        if (!this.config.authUrl) {
+            const topo = this.determineTopology();
+            const baseUrlIsV12 = topo === 'base_url'
+                && /api\/v1\/Databases/.test(this.config.baseUrl ?? '');
+            if (topo === 'v11' || (topo === 'base_url' && !baseUrlIsV12)) {
+                throw new Error("'authUrl' is required for Service-to-Service authentication on v11 topology");
             }
+        }
+
+        try {
             const tokenEndpoint = this.config.authUrl || this.resolveRoots().authRoot;
 
             const tokenPayload = {

--- a/src/tests/restService.test.ts
+++ b/src/tests/restService.test.ts
@@ -666,7 +666,7 @@ describe('RestService URL topology dispatch', () => {
                 database: 'DB1',
                 iamUrl: 'https://iam',
                 ssl: true
-            })).toThrow(/tenant.*database|address.*tenant/);
+            })).toThrow("'address', 'tenant' and 'database' must be provided to connect to TM1 > v12 in IBM Cloud");
         });
 
         test('should throw when IBM Cloud ssl=false', () => {

--- a/src/tests/restService.test.ts
+++ b/src/tests/restService.test.ts
@@ -242,36 +242,36 @@ describe('RestService URL topology dispatch', () => {
 
     describe('v11 pattern', () => {
         test('should build v11 URL with ssl=true and default port', () => {
-            const svc = new (require('../services/RestService').RestService)({ address: 'host', ssl: true });
+            const svc = new RestService({ address: 'host', ssl: true });
             expect(lastBaseURL()).toBe('https://host:8001/api/v1');
             expect((svc as any).resolveRoots().authRoot).toBe('https://host:8001/api/v1/Configuration/ProductVersion/$value');
         });
 
         test('should build v11 URL with ssl=false and explicit port', () => {
-            new (require('../services/RestService').RestService)({ address: 'host', port: 9000, ssl: false });
+            new RestService({ address: 'host', port: 9000, ssl: false });
             expect(lastBaseURL()).toBe('http://host:9000/api/v1');
         });
 
         test('should default address to localhost when omitted', () => {
-            new (require('../services/RestService').RestService)({ ssl: false, port: 8001 });
+            new RestService({ ssl: false, port: 8001 });
             expect(lastBaseURL()).toBe('http://localhost:8001/api/v1');
         });
     });
 
     describe('baseUrl override', () => {
         test('should use baseUrl verbatim when it ends with /api/v1', () => {
-            const svc = new (require('../services/RestService').RestService)({ baseUrl: 'http://x/api/v1' });
+            const svc = new RestService({ baseUrl: 'http://x/api/v1' });
             expect(lastBaseURL()).toBe('http://x/api/v1');
             expect((svc as any).resolveRoots().authRoot).toBe('http://x/api/v1/Configuration/ProductVersion/$value');
         });
 
         test('should append /api/v1 when baseUrl lacks it', () => {
-            new (require('../services/RestService').RestService)({ baseUrl: 'http://x' });
+            new RestService({ baseUrl: 'http://x' });
             expect(lastBaseURL()).toBe('http://x/api/v1');
         });
 
         test('should resolve Databases() baseUrl when authUrl provided', () => {
-            const svc = new (require('../services/RestService').RestService)({
+            const svc = new RestService({
                 baseUrl: "http://x/api/v1/Databases('DB')",
                 authUrl: 'http://x/auth'
             });
@@ -280,13 +280,13 @@ describe('RestService URL topology dispatch', () => {
         });
 
         test('should throw for Databases() baseUrl without authUrl', () => {
-            expect(() => new (require('../services/RestService').RestService)({
+            expect(() => new RestService({
                 baseUrl: "http://x/api/v1/Databases('DB')"
             })).toThrow(/Auth_url missing/);
         });
 
         test('should throw when baseUrl and address both provided', () => {
-            expect(() => new (require('../services/RestService').RestService)({
+            expect(() => new RestService({
                 baseUrl: 'http://x/api/v1',
                 address: 'y'
             })).toThrow(/Base URL and Address/);
@@ -295,7 +295,7 @@ describe('RestService URL topology dispatch', () => {
 
     describe('IBM Cloud pattern', () => {
         test('should build IBM Cloud URL when iamUrl provided', () => {
-            const svc = new (require('../services/RestService').RestService)({
+            const svc = new RestService({
                 address: 'pa.ibm.com',
                 tenant: 'T1',
                 database: 'DB1',
@@ -308,7 +308,7 @@ describe('RestService URL topology dispatch', () => {
         });
 
         test('should throw when IBM Cloud missing tenant', () => {
-            expect(() => new (require('../services/RestService').RestService)({
+            expect(() => new RestService({
                 address: 'pa.ibm.com',
                 database: 'DB1',
                 iamUrl: 'https://iam',
@@ -317,7 +317,7 @@ describe('RestService URL topology dispatch', () => {
         });
 
         test('should throw when IBM Cloud ssl=false', () => {
-            expect(() => new (require('../services/RestService').RestService)({
+            expect(() => new RestService({
                 address: 'pa.ibm.com',
                 tenant: 'T1',
                 database: 'DB1',
@@ -329,7 +329,7 @@ describe('RestService URL topology dispatch', () => {
 
     describe('PA Proxy pattern', () => {
         test('should build PA Proxy URL with https', () => {
-            const svc = new (require('../services/RestService').RestService)({
+            const svc = new RestService({
                 address: 'h',
                 database: 'DB',
                 user: 'u',
@@ -341,7 +341,7 @@ describe('RestService URL topology dispatch', () => {
         });
 
         test('should build PA Proxy URL with http', () => {
-            new (require('../services/RestService').RestService)({
+            new RestService({
                 address: 'h',
                 database: 'DB',
                 user: 'u',
@@ -354,7 +354,7 @@ describe('RestService URL topology dispatch', () => {
 
     describe('S2S pattern', () => {
         test('should build S2S URL with port and ssl', () => {
-            const svc = new (require('../services/RestService').RestService)({
+            const svc = new RestService({
                 address: 'h',
                 port: 443,
                 instance: 'INST',
@@ -366,7 +366,7 @@ describe('RestService URL topology dispatch', () => {
         });
 
         test('should build S2S URL without port', () => {
-            new (require('../services/RestService').RestService)({
+            new RestService({
                 address: 'h',
                 instance: 'INST',
                 database: 'DB',
@@ -376,7 +376,7 @@ describe('RestService URL topology dispatch', () => {
         });
 
         test('should default to localhost when address is empty', () => {
-            new (require('../services/RestService').RestService)({
+            new RestService({
                 address: '',
                 instance: 'I',
                 database: 'D',
@@ -386,7 +386,7 @@ describe('RestService URL topology dispatch', () => {
         });
 
         test('should throw S2S without instance', () => {
-            expect(() => new (require('../services/RestService').RestService)({
+            expect(() => new RestService({
                 address: 'h',
                 instance: 'INST',
                 ssl: true
@@ -396,7 +396,7 @@ describe('RestService URL topology dispatch', () => {
 
     describe('Config pass-through and axios wiring', () => {
         test('should accept all new config fields without error', () => {
-            expect(() => new (require('../services/RestService').RestService)({
+            expect(() => new RestService({
                 baseUrl: 'http://x/api/v1',
                 iamUrl: 'https://iam',
                 paUrl: 'https://pa',
@@ -413,7 +413,7 @@ describe('RestService URL topology dispatch', () => {
         });
 
         test('should pass proxy.https to axios when provided', () => {
-            new (require('../services/RestService').RestService)({
+            new RestService({
                 baseUrl: 'http://x/api/v1',
                 proxies: { https: 'https://proxy.example.com:8443' }
             });
@@ -422,7 +422,7 @@ describe('RestService URL topology dispatch', () => {
         });
 
         test('should fall back to proxy.http when https not provided', () => {
-            new (require('../services/RestService').RestService)({
+            new RestService({
                 baseUrl: 'http://x/api/v1',
                 proxies: { http: 'http://proxy.example.com:8080' }
             });
@@ -431,14 +431,15 @@ describe('RestService URL topology dispatch', () => {
         });
 
         test('should not set proxy when proxies unset', () => {
-            new (require('../services/RestService').RestService)({ baseUrl: 'http://x/api/v1' });
+            new RestService({ baseUrl: 'http://x/api/v1' });
             const cfg = firstCreateArg();
             expect(cfg.proxy).toBeUndefined();
         });
 
         test('should pass sslContext through as httpsAgent', () => {
-            const agent = { _custom: 'agent' };
-            new (require('../services/RestService').RestService)({
+            const https = require('https');
+            const agent = new https.Agent();
+            new RestService({
                 baseUrl: 'http://x/api/v1',
                 sslContext: agent
             });
@@ -447,7 +448,7 @@ describe('RestService URL topology dispatch', () => {
         });
 
         test('should not treat cpdUrl alone as v12 topology signal', () => {
-            new (require('../services/RestService').RestService)({
+            new RestService({
                 address: 'host',
                 port: 9000,
                 ssl: false,
@@ -457,7 +458,7 @@ describe('RestService URL topology dispatch', () => {
         });
 
         test('should not treat gateway alone as v12 topology signal', () => {
-            new (require('../services/RestService').RestService)({
+            new RestService({
                 address: 'host',
                 port: 9000,
                 ssl: false,

--- a/src/tests/restService.test.ts
+++ b/src/tests/restService.test.ts
@@ -589,6 +589,27 @@ describe('RestService URL topology dispatch', () => {
             expect(lastBaseURL()).toBe('http://x/api/v1');
         });
 
+        test('should preserve TM1 11 IBM Cloud baseUrl shape verbatim', () => {
+            new RestService({
+                baseUrl: 'https://mycompany.planning-analytics.ibmcloud.com/tm1/api/tm1/'
+            });
+            expect(lastBaseURL()).toBe('https://mycompany.planning-analytics.ibmcloud.com/tm1/api/tm1');
+        });
+
+        test('should preserve TM1 12 PaaS baseUrl shape (trailing slash normalized)', () => {
+            new RestService({
+                baseUrl: 'https://us-east-1.planninganalytics.saas.ibm.com/api/T1/v0/tm1/DB1/'
+            });
+            expect(lastBaseURL()).toBe('https://us-east-1.planninganalytics.saas.ibm.com/api/T1/v0/tm1/DB1');
+        });
+
+        test('should preserve TM1 12 access-token baseUrl shape verbatim', () => {
+            new RestService({
+                baseUrl: 'https://pa12.dev.net/api/INST/v0/tm1/DB1'
+            });
+            expect(lastBaseURL()).toBe('https://pa12.dev.net/api/INST/v0/tm1/DB1');
+        });
+
         test('should resolve Databases() baseUrl when authUrl provided', () => {
             const svc = new RestService({
                 baseUrl: "http://x/api/v1/Databases('DB')",
@@ -829,6 +850,55 @@ describe('RestService URL topology dispatch', () => {
                 gateway: 'https://gw'
             });
             expect(lastBaseURL()).toBe('http://host:9000/api/v1');
+        });
+    });
+
+    describe('Session cookie seeding by topology', () => {
+        test('should seed TM1SessionId cookie for v11 topology', () => {
+            const svc = new RestService({ address: 'host', ssl: true, sessionId: 'abc' });
+            expect((svc as any).sessionCookies.get('TM1SessionId')).toBe('abc');
+            expect((svc as any).sessionCookies.get('paSession')).toBeUndefined();
+        });
+
+        test('should seed paSession cookie for IBM Cloud topology', () => {
+            const svc = new RestService({
+                address: 'pa.ibm.com',
+                tenant: 'T1',
+                database: 'DB1',
+                iamUrl: 'https://iam',
+                ssl: true,
+                sessionId: 'abc'
+            });
+            expect((svc as any).sessionCookies.get('paSession')).toBe('abc');
+            expect((svc as any).sessionCookies.get('TM1SessionId')).toBeUndefined();
+        });
+
+        test('should seed paSession cookie for S2S topology', () => {
+            const svc = new RestService({
+                address: 'h',
+                instance: 'INST',
+                database: 'DB',
+                ssl: true,
+                sessionId: 'xyz'
+            });
+            expect((svc as any).sessionCookies.get('paSession')).toBe('xyz');
+        });
+
+        test('should seed paSession cookie for PA Proxy topology', () => {
+            const svc = new RestService({
+                address: 'h',
+                database: 'DB',
+                user: 'u',
+                paUrl: 'https://pa',
+                ssl: true,
+                sessionId: 'pp'
+            });
+            expect((svc as any).sessionCookies.get('paSession')).toBe('pp');
+        });
+
+        test('should seed TM1SessionId cookie for baseUrl override', () => {
+            const svc = new RestService({ baseUrl: 'http://x/api/v1', sessionId: 'ff' });
+            expect((svc as any).sessionCookies.get('TM1SessionId')).toBe('ff');
         });
     });
 

--- a/src/tests/restService.test.ts
+++ b/src/tests/restService.test.ts
@@ -764,6 +764,29 @@ describe('RestService URL topology dispatch', () => {
             expect(cfg.proxy).toBeUndefined();
         });
 
+        test('should forward credentials from proxy URL to proxy.auth', () => {
+            new RestService({
+                baseUrl: 'http://x/api/v1',
+                proxies: { https: 'https://u%40dom:p%40ss@proxy.example.com:8443' }
+            });
+            const cfg = firstCreateArg();
+            expect(cfg.proxy).toEqual({
+                host: 'proxy.example.com',
+                port: 8443,
+                protocol: 'https',
+                auth: { username: 'u@dom', password: 'p@ss' }
+            });
+        });
+
+        test('should not set proxy.auth when proxy URL has no credentials', () => {
+            new RestService({
+                baseUrl: 'http://x/api/v1',
+                proxies: { https: 'https://proxy.example.com:8443' }
+            });
+            const cfg = firstCreateArg();
+            expect(cfg.proxy.auth).toBeUndefined();
+        });
+
         test('should pass sslContext through as httpsAgent', () => {
             const httpsMod = require('https');
             const agent = new httpsMod.Agent();
@@ -807,6 +830,29 @@ describe('RestService URL topology dispatch', () => {
             await expect((svc as any).setupServiceToServiceAuthentication()).rejects.toThrow(
                 /'authUrl' is required for Service-to-Service authentication on v11 topology/
             );
+        });
+
+        test('should throw when S2S auth runs on v11-style baseUrl topology without authUrl', async () => {
+            const svc = new RestService({
+                baseUrl: 'http://x/api/v1',
+                applicationClientId: 'id',
+                applicationClientSecret: 'secret'
+            });
+            await expect((svc as any).setupServiceToServiceAuthentication()).rejects.toThrow(
+                /'authUrl' is required for Service-to-Service authentication on v11 topology/
+            );
+        });
+
+        test('should not throw when S2S auth runs on v12 Databases baseUrl with authUrl', async () => {
+            const svc = new RestService({
+                baseUrl: "http://x/api/v1/Databases('DB')",
+                authUrl: 'http://x/auth',
+                applicationClientId: 'id',
+                applicationClientSecret: 'secret'
+            });
+            // Will reject with network-level error when trying to POST, but NOT the guard error.
+            await expect((svc as any).setupServiceToServiceAuthentication())
+                .rejects.not.toThrow(/'authUrl' is required/);
         });
     });
 });

--- a/src/tests/restService.test.ts
+++ b/src/tests/restService.test.ts
@@ -350,6 +350,15 @@ describe('RestService URL topology dispatch', () => {
             });
             expect(lastBaseURL()).toBe('http://h/tm1/DB/api/v1');
         });
+
+        test('should throw when PA Proxy missing database', () => {
+            expect(() => new RestService({
+                address: 'h',
+                user: 'u',
+                paUrl: 'https://pa',
+                ssl: true
+            })).toThrow(/'address'.*'database'.*must be provided/);
+        });
     });
 
     describe('S2S pattern', () => {
@@ -465,6 +474,20 @@ describe('RestService URL topology dispatch', () => {
                 gateway: 'https://gw'
             });
             expect(lastBaseURL()).toBe('http://host:9000/api/v1');
+        });
+    });
+
+    describe('S2S token endpoint guard', () => {
+        test('should throw when S2S auth runs on v11 topology without authUrl', async () => {
+            const svc = new RestService({
+                address: 'host',
+                ssl: true,
+                applicationClientId: 'id',
+                applicationClientSecret: 'secret'
+            });
+            await expect((svc as any).setupServiceToServiceAuthentication()).rejects.toThrow(
+                /'authUrl' is required for Service-to-Service authentication on v11 topology/
+            );
         });
     });
 });

--- a/src/tests/restService.test.ts
+++ b/src/tests/restService.test.ts
@@ -216,3 +216,254 @@ describe('RestService Tests', () => {
         });
     });
 });
+
+describe('RestService URL topology dispatch', () => {
+    let mockAxiosInstance: any;
+
+    beforeEach(() => {
+        jest.clearAllMocks();
+        mockAxiosInstance = {
+            get: jest.fn(),
+            post: jest.fn(),
+            patch: jest.fn(),
+            delete: jest.fn(),
+            put: jest.fn(),
+            interceptors: {
+                request: { use: jest.fn() },
+                response: { use: jest.fn() }
+            },
+            defaults: { headers: { common: {} } }
+        };
+        mockedAxios.create.mockReturnValue(mockAxiosInstance as any);
+    });
+
+    const firstCreateArg = (): any => mockedAxios.create.mock.calls[0][0];
+    const lastBaseURL = (): string => firstCreateArg().baseURL;
+
+    describe('v11 pattern', () => {
+        test('should build v11 URL with ssl=true and default port', () => {
+            const svc = new (require('../services/RestService').RestService)({ address: 'host', ssl: true });
+            expect(lastBaseURL()).toBe('https://host:8001/api/v1');
+            expect((svc as any).resolveRoots().authRoot).toBe('https://host:8001/api/v1/Configuration/ProductVersion/$value');
+        });
+
+        test('should build v11 URL with ssl=false and explicit port', () => {
+            new (require('../services/RestService').RestService)({ address: 'host', port: 9000, ssl: false });
+            expect(lastBaseURL()).toBe('http://host:9000/api/v1');
+        });
+
+        test('should default address to localhost when omitted', () => {
+            new (require('../services/RestService').RestService)({ ssl: false, port: 8001 });
+            expect(lastBaseURL()).toBe('http://localhost:8001/api/v1');
+        });
+    });
+
+    describe('baseUrl override', () => {
+        test('should use baseUrl verbatim when it ends with /api/v1', () => {
+            const svc = new (require('../services/RestService').RestService)({ baseUrl: 'http://x/api/v1' });
+            expect(lastBaseURL()).toBe('http://x/api/v1');
+            expect((svc as any).resolveRoots().authRoot).toBe('http://x/api/v1/Configuration/ProductVersion/$value');
+        });
+
+        test('should append /api/v1 when baseUrl lacks it', () => {
+            new (require('../services/RestService').RestService)({ baseUrl: 'http://x' });
+            expect(lastBaseURL()).toBe('http://x/api/v1');
+        });
+
+        test('should resolve Databases() baseUrl when authUrl provided', () => {
+            const svc = new (require('../services/RestService').RestService)({
+                baseUrl: "http://x/api/v1/Databases('DB')",
+                authUrl: 'http://x/auth'
+            });
+            expect(lastBaseURL()).toBe("http://x/api/v1/Databases('DB')");
+            expect((svc as any).resolveRoots().authRoot).toBe('http://x/auth');
+        });
+
+        test('should throw for Databases() baseUrl without authUrl', () => {
+            expect(() => new (require('../services/RestService').RestService)({
+                baseUrl: "http://x/api/v1/Databases('DB')"
+            })).toThrow(/Auth_url missing/);
+        });
+
+        test('should throw when baseUrl and address both provided', () => {
+            expect(() => new (require('../services/RestService').RestService)({
+                baseUrl: 'http://x/api/v1',
+                address: 'y'
+            })).toThrow(/Base URL and Address/);
+        });
+    });
+
+    describe('IBM Cloud pattern', () => {
+        test('should build IBM Cloud URL when iamUrl provided', () => {
+            const svc = new (require('../services/RestService').RestService)({
+                address: 'pa.ibm.com',
+                tenant: 'T1',
+                database: 'DB1',
+                iamUrl: 'https://iam.cloud.ibm.com',
+                ssl: true,
+                apiKey: 'k'
+            });
+            expect(lastBaseURL()).toBe('https://pa.ibm.com/api/T1/v0/tm1/DB1');
+            expect((svc as any).resolveRoots().authRoot).toBe('https://pa.ibm.com/api/T1/v0/tm1/DB1/Configuration/ProductVersion/$value');
+        });
+
+        test('should throw when IBM Cloud missing tenant', () => {
+            expect(() => new (require('../services/RestService').RestService)({
+                address: 'pa.ibm.com',
+                database: 'DB1',
+                iamUrl: 'https://iam',
+                ssl: true
+            })).toThrow(/tenant.*database|address.*tenant/);
+        });
+
+        test('should throw when IBM Cloud ssl=false', () => {
+            expect(() => new (require('../services/RestService').RestService)({
+                address: 'pa.ibm.com',
+                tenant: 'T1',
+                database: 'DB1',
+                iamUrl: 'https://iam',
+                ssl: false
+            })).toThrow(/ssl.*must be true/);
+        });
+    });
+
+    describe('PA Proxy pattern', () => {
+        test('should build PA Proxy URL with https', () => {
+            const svc = new (require('../services/RestService').RestService)({
+                address: 'h',
+                database: 'DB',
+                user: 'u',
+                paUrl: 'https://pa',
+                ssl: true
+            });
+            expect(lastBaseURL()).toBe('https://h/tm1/DB/api/v1');
+            expect((svc as any).resolveRoots().authRoot).toBe('https://h/login');
+        });
+
+        test('should build PA Proxy URL with http', () => {
+            new (require('../services/RestService').RestService)({
+                address: 'h',
+                database: 'DB',
+                user: 'u',
+                paUrl: 'http://pa',
+                ssl: false
+            });
+            expect(lastBaseURL()).toBe('http://h/tm1/DB/api/v1');
+        });
+    });
+
+    describe('S2S pattern', () => {
+        test('should build S2S URL with port and ssl', () => {
+            const svc = new (require('../services/RestService').RestService)({
+                address: 'h',
+                port: 443,
+                instance: 'INST',
+                database: 'DB',
+                ssl: true
+            });
+            expect(lastBaseURL()).toBe("https://h:443/INST/api/v1/Databases('DB')");
+            expect((svc as any).resolveRoots().authRoot).toBe('https://h:443/INST/auth/v1/session');
+        });
+
+        test('should build S2S URL without port', () => {
+            new (require('../services/RestService').RestService)({
+                address: 'h',
+                instance: 'INST',
+                database: 'DB',
+                ssl: true
+            });
+            expect(lastBaseURL()).toBe("https://h/INST/api/v1/Databases('DB')");
+        });
+
+        test('should default to localhost when address is empty', () => {
+            new (require('../services/RestService').RestService)({
+                address: '',
+                instance: 'I',
+                database: 'D',
+                ssl: false
+            });
+            expect(lastBaseURL()).toBe("http://localhost/I/api/v1/Databases('D')");
+        });
+
+        test('should throw S2S without instance', () => {
+            expect(() => new (require('../services/RestService').RestService)({
+                address: 'h',
+                instance: 'INST',
+                ssl: true
+            })).toThrow(/instance.*database|instance.*required|database.*required/i);
+        });
+    });
+
+    describe('Config pass-through and axios wiring', () => {
+        test('should accept all new config fields without error', () => {
+            expect(() => new (require('../services/RestService').RestService)({
+                baseUrl: 'http://x/api/v1',
+                iamUrl: 'https://iam',
+                paUrl: 'https://pa',
+                cpdUrl: 'https://cpd',
+                gateway: 'https://gw',
+                integratedLogin: true,
+                integratedLoginDomain: '.',
+                integratedLoginService: 'HTTP',
+                integratedLoginHost: 'host',
+                integratedLoginDelegate: false,
+                user: 'admin',
+                password: 'pw'
+            })).not.toThrow();
+        });
+
+        test('should pass proxy.https to axios when provided', () => {
+            new (require('../services/RestService').RestService)({
+                baseUrl: 'http://x/api/v1',
+                proxies: { https: 'https://proxy.example.com:8443' }
+            });
+            const cfg = firstCreateArg();
+            expect(cfg.proxy).toEqual({ host: 'proxy.example.com', port: 8443, protocol: 'https' });
+        });
+
+        test('should fall back to proxy.http when https not provided', () => {
+            new (require('../services/RestService').RestService)({
+                baseUrl: 'http://x/api/v1',
+                proxies: { http: 'http://proxy.example.com:8080' }
+            });
+            const cfg = firstCreateArg();
+            expect(cfg.proxy).toEqual({ host: 'proxy.example.com', port: 8080, protocol: 'http' });
+        });
+
+        test('should not set proxy when proxies unset', () => {
+            new (require('../services/RestService').RestService)({ baseUrl: 'http://x/api/v1' });
+            const cfg = firstCreateArg();
+            expect(cfg.proxy).toBeUndefined();
+        });
+
+        test('should pass sslContext through as httpsAgent', () => {
+            const agent = { _custom: 'agent' };
+            new (require('../services/RestService').RestService)({
+                baseUrl: 'http://x/api/v1',
+                sslContext: agent
+            });
+            const cfg = firstCreateArg();
+            expect(cfg.httpsAgent).toBe(agent);
+        });
+
+        test('should not treat cpdUrl alone as v12 topology signal', () => {
+            new (require('../services/RestService').RestService)({
+                address: 'host',
+                port: 9000,
+                ssl: false,
+                cpdUrl: 'https://cpd'
+            });
+            expect(lastBaseURL()).toBe('http://host:9000/api/v1');
+        });
+
+        test('should not treat gateway alone as v12 topology signal', () => {
+            new (require('../services/RestService').RestService)({
+                address: 'host',
+                port: 9000,
+                ssl: false,
+                gateway: 'https://gw'
+            });
+            expect(lastBaseURL()).toBe('http://host:9000/api/v1');
+        });
+    });
+});

--- a/src/tests/restService.test.ts
+++ b/src/tests/restService.test.ts
@@ -604,6 +604,19 @@ describe('RestService URL topology dispatch', () => {
             })).toThrow(/Auth_url missing/);
         });
 
+        test('should let v12 signals win over baseUrl (tm1py parity)', () => {
+            const svc = new RestService({
+                baseUrl: 'http://ignored/api/v1',
+                address: 'pa.ibm.com',
+                tenant: 'T1',
+                database: 'DB1',
+                iamUrl: 'https://iam.cloud.ibm.com',
+                ssl: true
+            });
+            expect(lastBaseURL()).toBe('https://pa.ibm.com/api/T1/v0/tm1/DB1');
+            expect((svc as any).resolveRoots().authRoot).toBe('https://pa.ibm.com/api/T1/v0/tm1/DB1/Configuration/ProductVersion/$value');
+        });
+
         test('should throw when baseUrl and address both provided', () => {
             expect(() => new RestService({
                 baseUrl: 'http://x/api/v1',
@@ -723,11 +736,11 @@ describe('RestService URL topology dispatch', () => {
     });
 
     describe('Config pass-through and axios wiring', () => {
-        test('should accept all new config fields without error', () => {
+        test('should accept new non-topology config fields without error', () => {
+            // iamUrl/paUrl/tenant/instance/database are topology signals (tested per-topology above);
+            // this asserts the remaining auth/network fields are accepted as config surface.
             expect(() => new RestService({
                 baseUrl: 'http://x/api/v1',
-                iamUrl: 'https://iam',
-                paUrl: 'https://pa',
                 cpdUrl: 'https://cpd',
                 gateway: 'https://gw',
                 integratedLogin: true,


### PR DESCRIPTION
## Summary

Closes #63. Implements Phase 1 (v2.0.0 — Foundation) parity for TM1 deployment topologies in `RestService.ts`.

- Ports tm1py's URL topology dispatch into `resolveRoots()` → `{serviceRoot, authRoot}` that mirrors `_construct_service_and_auth_root`. Five topologies supported: v11 (existing), IBM Cloud, PA Proxy, S2S, and `baseUrl` override (with the tm1py validations for `Databases()` base URLs and `baseUrl + address` collision).
- Extends `RestServiceConfig` with the missing options: `iamUrl`, `paUrl`, `cpdUrl`, `gateway`, `integratedLogin*`, `proxies`, `sslContext`, `cert`.
- Wires `proxies`, `cert`, and `sslContext` into the axios instance at construction.
- Guards S2S auth against v11 topology without `authUrl` (the former fallback produced a metadata probe URL, not a token endpoint).

### Intentional deviations from tm1py (documented in code)
- `authUrl` is excluded from the v12 topology signal set to preserve backward compat with existing tm1npm CAM SSO usage.
- `apiKey` is excluded from the v12 signal set to avoid colliding with the existing `BASIC_API_KEY` auth flow.
- `cpdUrl`, `gateway`, and `integratedLogin*` are config surface only; auth-flow wiring is deferred to follow-up issues.

## Test plan

- [x] ``./node_modules/.bin/tsc --noEmit`` — clean
- [x] ``./node_modules/.bin/jest src/tests/restService.test.ts`` — 42/42 pass (14 existing + 28 new)
- [x] ``./node_modules/.bin/jest`` (full suite) — no new regressions (only the pre-existing 2 env-dependent integration failures)
- [x] Manual parity review against tm1py `RestService.py` (`_construct_service_and_auth_root`, `_determine_auth_mode`)
- [x] Two rounds of external code review (final verdict APPROVED, zero P0/P1 remaining)

### New test coverage
- Five topology happy paths (v11 default/port/localhost, IBM Cloud, PA Proxy http/https, S2S with/without port, `baseUrl` verbatim/append)
- Error paths: IBM Cloud missing tenant / `ssl=false`; S2S missing instance; PA Proxy missing database; `baseUrl + address` collision; `Databases()` baseUrl without `authUrl`
- S2S v11-without-authUrl guard (async auth path)
- Axios wiring: proxy `https`/`http`/unset, `sslContext` pass-through, `cpdUrl`/`gateway` non-signal behavior