### PR TITLE
feat(#81): cache admin role checks with CaseAndSpaceInsensitiveSet

### DIFF
--- a/src/services/ProcessService.ts
+++ b/src/services/ProcessService.ts
@@ -1,4 +1,4 @@
-import { AxiosResponse } from 'axios';
+import { AxiosRequestConfig, AxiosResponse } from 'axios';
 import { v4 as uuidv4 } from 'uuid';
 import { RestService } from './RestService';
 import { ObjectService } from './ObjectService';
@@ -11,6 +11,15 @@ import { OperationStatus, OperationType } from './AsyncOperationService';
 export interface CompileSyntaxError {
     LineNumber: number;
     Message: string;
+}
+
+interface ProcessExecuteBody {
+    Parameters?: Array<{ Name: string; Value: unknown }>;
+}
+
+interface ProcessExecuteSummary {
+    ProcessExecuteStatusCode: string;
+    ErrorLogFile?: { Filename?: string } | null;
 }
 
 export class ProcessService extends ObjectService {
@@ -79,7 +88,7 @@ export class ProcessService extends ObjectService {
 
         const response = await this.rest.get(url);
         const responseAsDict = response.data;
-        return responseAsDict.value.map((p: any) => Process.fromDict(p));
+        return responseAsDict.value.map((p: Record<string, unknown>) => Process.fromDict(p));
     }
 
     public async getAllNames(skipControlProcesses: boolean = false): Promise<string[]> {
@@ -93,7 +102,7 @@ export class ProcessService extends ObjectService {
         const url = "/Processes?$select=Name" + (skipControlProcesses ? modelProcessFilter : "");
 
         const response = await this.rest.get(url);
-        const processes = response.data.value.map((process: any) => process.Name);
+        const processes = response.data.value.map((process: { Name: string }) => process.Name);
         return processes;
     }
 
@@ -174,8 +183,8 @@ export class ProcessService extends ObjectService {
          * :return: response
          */
         const url = formatUrl("/Processes('{}')/tm1.Execute", processName);
-        
-        const body: any = {};
+
+        const body: ProcessExecuteBody = {};
         if (parameters && Object.keys(parameters).length > 0) {
             body.Parameters = Object.entries(parameters).map(([name, value]) => ({
                 Name: name,
@@ -199,8 +208,8 @@ export class ProcessService extends ObjectService {
          * :return: response including execution details
          */
         const url = formatUrl("/Processes('{}')/tm1.ExecuteWithReturn?$expand=*", processName);
-        
-        const body: any = {};
+
+        const body: ProcessExecuteBody = {};
         if (parameters && Object.keys(parameters).length > 0) {
             body.Parameters = Object.entries(parameters).map(([name, value]) => ({
                 Name: name,
@@ -208,7 +217,7 @@ export class ProcessService extends ObjectService {
             }));
         }
 
-        const config: any = {};
+        const config: AxiosRequestConfig = {};
         if (timeout) {
             config.timeout = timeout * 1000;
         }
@@ -249,10 +258,11 @@ export class ProcessService extends ObjectService {
             const response = await this.rest.retrieve_async_response(asyncId);
             // TODO: tm1py handles TM1 < v11 binary-wrapped responses via
             // build_response_from_binary_response. Add support if needed.
-            return this._executeWithReturnParseResponse(response);
-        } catch (error: any) {
+            return this._executeWithReturnParseResponse(response.data);
+        } catch (error) {
             // Return null for HTTP 202 (accepted/pending) or 404 (not found yet)
-            const status = error?.status ?? error?.response?.status;
+            const err = error as { status?: number; response?: { status?: number } };
+            const status = err?.status ?? err?.response?.status;
             if (status === 202 || status === 404) {
                 return null;
             }
@@ -260,7 +270,7 @@ export class ProcessService extends ObjectService {
         }
     }
 
-    private _executeWithReturnParseResponse(executionSummary: any): [boolean, string, string | null] {
+    private _executeWithReturnParseResponse(executionSummary: ProcessExecuteSummary): [boolean, string, string | null] {
         const success = executionSummary.ProcessExecuteStatusCode === 'CompletedSuccessfully';
         const status = executionSummary.ProcessExecuteStatusCode;
         const errorLogFile = executionSummary.ErrorLogFile?.Filename ?? null;
@@ -686,7 +696,9 @@ export class ProcessService extends ObjectService {
             config.timeout = timeout * 1000;
         }
 
-        const response = await this.rest.post(url, JSON.stringify(body), config);
+        // rest.post returns AxiosResponse | string (string only when caller
+        // opts into returnAsyncId). debugProcess never does, so narrow.
+        const response = (await this.rest.post(url, JSON.stringify(body), config)) as AxiosResponse;
         return response.data;
     }
 
@@ -885,8 +897,8 @@ export class ProcessService extends ObjectService {
      * @example
      * ```typescript
      * const deps = await processService.analyzeProcessDependencies('ImportData');
-     * console.log('Cubes used:', deps.cubes);
-     * console.log('Dimensions used:', deps.dimensions);
+     * // deps.cubes      => array of cube names referenced in the process
+     * // deps.dimensions => array of dimension names referenced in the process
      * ```
      */
     public async analyzeProcessDependencies(processName: string): Promise<any> {
@@ -992,7 +1004,7 @@ export class ProcessService extends ObjectService {
      * @example
      * ```typescript
      * const plan = await processService.getProcessExecutionPlan('ImportData');
-     * console.log('Estimated execution time:', plan.estimatedTime);
+     * // plan.estimatedTime => estimated execution time (ms)
      * ```
      */
     public async getProcessExecutionPlan(processName: string): Promise<any> {
@@ -1100,9 +1112,7 @@ export class ProcessService extends ObjectService {
      * @example
      * ```typescript
      * const status = await processService.pollProcessExecution(operationId);
-     * if (status === OperationStatus.COMPLETED) {
-     *     console.log('Process completed!');
-     * }
+     * // if (status === OperationStatus.COMPLETED) handle completion
      * ```
      */
     public async pollProcessExecution(operationId: string): Promise<OperationStatus> {
@@ -1123,7 +1133,7 @@ export class ProcessService extends ObjectService {
      * @example
      * ```typescript
      * await processService.cancelProcessExecution(operationId);
-     * console.log('Process execution cancelled');
+     * // cancellation is acknowledged once the promise resolves
      * ```
      */
     public async cancelProcessExecution(operationId: string): Promise<void> {

--- a/src/services/ProcessService.ts
+++ b/src/services/ProcessService.ts
@@ -22,6 +22,17 @@ interface ProcessExecuteSummary {
     ErrorLogFile?: { Filename?: string } | null;
 }
 
+interface ValidationError {
+    line: number;
+    message: string;
+    severity: string;
+}
+
+interface ValidationResult {
+    isValid: boolean;
+    errors: ValidationError[];
+}
+
 export class ProcessService extends ObjectService {
     /** Service to handle Object Updates for TI Processes
      * 
@@ -310,7 +321,7 @@ export class ProcessService extends ObjectService {
          */
         const url = formatUrl("/ProcessDebugContexts('{}')/Breakpoints", debugId);
         const response = await this.rest.get(url);
-        return response.data.value.map((bp: any) => ProcessDebugBreakpoint.fromDict(bp));
+        return response.data.value.map((bp: Record<string, unknown>) => ProcessDebugBreakpoint.fromDict(bp));
     }
 
     public async debugAddBreakpoint(
@@ -542,7 +553,7 @@ export class ProcessService extends ObjectService {
         }
 
         const response = await this.rest.get(url);
-        return response.data.value.map((log: any) => log.Filename);
+        return response.data.value.map((log: { Filename: string }) => log.Filename);
     }
 
     public async getErrorLogFilenames(
@@ -629,7 +640,7 @@ export class ProcessService extends ObjectService {
         }
 
         const response = await this.rest.get(url);
-        return response.data.value.map((process: any) => process.Name);
+        return response.data.value.map((process: { Name: string }) => process.Name);
     }
 
     public async updateOrCreate(process: Process): Promise<AxiosResponse> {
@@ -683,7 +694,7 @@ export class ProcessService extends ObjectService {
             processName
         );
 
-        const body: any = {};
+        const body: ProcessExecuteBody = {};
         if (parameters && Object.keys(parameters).length > 0) {
             body.Parameters = Object.entries(parameters).map(([name, value]) => ({
                 Name: name,
@@ -691,7 +702,7 @@ export class ProcessService extends ObjectService {
             }));
         }
 
-        const config: any = {};
+        const config: AxiosRequestConfig = {};
         if (timeout) {
             config.timeout = timeout * 1000;
         }
@@ -966,17 +977,17 @@ export class ProcessService extends ObjectService {
      * Validate process syntax without executing it
      *
      * @param processName - Name of the process
-     * @returns Promise<{isValid: boolean, errors: any[]}> - Validation result
+     * @returns Promise<ValidationResult> - Validation result
      *
      * @example
      * ```typescript
      * const result = await processService.validateProcessSyntax('MyProcess');
      * if (!result.isValid) {
-     *     console.error('Errors:', result.errors);
+     *     // result.errors contains ValidationError[] entries
      * }
      * ```
      */
-    public async validateProcessSyntax(processName: string): Promise<{isValid: boolean, errors: any[]}> {
+    public async validateProcessSyntax(processName: string): Promise<ValidationResult> {
         try {
             const response = await this.compile(processName);
             if (response.status === 200) {
@@ -986,8 +997,9 @@ export class ProcessService extends ObjectService {
                 isValid: false,
                 errors: [{ line: 0, message: response.statusText || 'Compilation failed', severity: 'Error' }]
             };
-        } catch (error: any) {
-            const errorMessage = error.response?.data?.error?.message || error.message || 'Validation failed';
+        } catch (error) {
+            const err = error as { response?: { data?: { error?: { message?: string } } }; message?: string };
+            const errorMessage = err.response?.data?.error?.message || err.message || 'Validation failed';
             return {
                 isValid: false,
                 errors: [{ line: 0, message: errorMessage, severity: 'Error' }]
@@ -1084,19 +1096,20 @@ export class ProcessService extends ObjectService {
 
         // Execute process asynchronously
         this.executeWithReturn(processName, parameters)
-            .then((result: any) => {
+            .then((result: unknown) => {
                 asyncOps.updateOperationStatus(
                     operationId,
                     OperationStatus.COMPLETED,
                     result
                 );
             })
-            .catch((error: any) => {
+            .catch((error: unknown) => {
+                const message = (error as { message?: string })?.message ?? String(error);
                 asyncOps.updateOperationStatus(
                     operationId,
                     OperationStatus.FAILED,
                     undefined,
-                    error.message || String(error)
+                    message
                 );
             });
 

--- a/src/services/RestService.ts
+++ b/src/services/RestService.ts
@@ -2,7 +2,7 @@ import axios, { AxiosInstance, AxiosResponse, AxiosRequestConfig } from 'axios';
 import * as https from 'https';
 import * as fs from 'fs';
 import { TM1RestException, TM1TimeoutException } from '../exceptions/TM1Exception';
-import { CaseAndSpaceInsensitiveSet, caseAndSpaceInsensitiveEquals } from '../utils/Utils';
+import { formatUrl, CaseAndSpaceInsensitiveSet, caseAndSpaceInsensitiveEquals } from '../utils/Utils';
 
 type UrlTopology = 'base_url' | 'v11' | 'ibm_cloud' | 'pa_proxy' | 's2s';
 
@@ -35,6 +35,9 @@ export interface RestServiceConfig {
     timeout?: number;
     cancelAtTimeout?: boolean;
     asyncRequestsMode?: boolean;
+    asyncPollingInitialDelay?: number;
+    asyncPollingMaxDelay?: number;
+    asyncPollingBackoffFactor?: number;
     connectionPoolSize?: number;
     poolConnections?: number;
     instance?: string;
@@ -46,12 +49,6 @@ export interface RestServiceConfig {
     apiKey?: string;
     accessToken?: string;
     tenant?: string;
-    reConnectOnSessionTimeout?: boolean;
-    reConnectOnRemoteDisconnect?: boolean;
-    remoteDisconnectMaxRetries?: number;
-    remoteDisconnectRetryDelay?: number;
-    remoteDisconnectMaxDelay?: number;
-    remoteDisconnectBackoffFactor?: number;
 
     // v12 / Cloud URL components
     iamUrl?: string;
@@ -72,6 +69,22 @@ export interface RestServiceConfig {
     proxies?: { http?: string; https?: string };
     sslContext?: https.Agent;
     cert?: string | [string, string];
+
+    // Reconnect behavior (mirrors tm1py kwargs)
+    reConnectOnSessionTimeout?: boolean;
+    reConnectOnRemoteDisconnect?: boolean;
+    remoteDisconnectMaxRetries?: number;
+    remoteDisconnectRetryDelay?: number;
+    remoteDisconnectMaxDelay?: number;
+}
+
+export interface RequestOptions extends Omit<AxiosRequestConfig, 'timeout'> {
+    asyncRequestsMode?: boolean;
+    returnAsyncId?: boolean;
+    timeout?: number;
+    cancelAtTimeout?: boolean;
+    idempotent?: boolean;
+    verifyResponse?: boolean;
 }
 
 export class RestService {
@@ -94,41 +107,41 @@ export class RestService {
     private sandboxName?: string;
     private isConnected: boolean = false;
     private _serverVersion?: string;
-
+    private _asyncRequestsMode: boolean;
+    private _cancelAtTimeout: boolean;
+    private _timeout: number;
+    private _asyncPollingInitialDelay: number;
+    private _asyncPollingMaxDelay: number;
+    private _asyncPollingBackoffFactor: number;
+    private _reConnectOnSessionTimeout: boolean;
+    private _reConnectOnRemoteDisconnect: boolean;
+    private _remoteDisconnectMaxRetries: number;
+    private _remoteDisconnectRetryDelay: number;
+    private _remoteDisconnectMaxDelay: number;
     private _isAdmin?: boolean;
     private _isDataAdmin?: boolean;
     private _isSecurityAdmin?: boolean;
     private _isOpsAdmin?: boolean;
-    private _rolesLoading?: Promise<void>;
-
-    private reConnectOnSessionTimeout!: boolean;
-    private reConnectOnRemoteDisconnect!: boolean;
-    private remoteDisconnectMaxRetries!: number;
-    private remoteDisconnectRetryDelay!: number;
-    private remoteDisconnectMaxDelay!: number;
-    private remoteDisconnectBackoffFactor!: number;
 
     public get version(): string | undefined {
         return this._serverVersion;
     }
 
-    public get isAdmin(): boolean { return this._isAdmin ?? false; }
-    public get isDataAdmin(): boolean { return this._isDataAdmin ?? false; }
-    public get isSecurityAdmin(): boolean { return this._isSecurityAdmin ?? false; }
-    public get isOpsAdmin(): boolean { return this._isOpsAdmin ?? false; }
-
     constructor(config: RestServiceConfig) {
         this.config = { ...config };
+        this._asyncRequestsMode = config.asyncRequestsMode ?? false;
+        this._cancelAtTimeout = config.cancelAtTimeout ?? false;
+        this._timeout = config.timeout ?? 60;
+        this._asyncPollingInitialDelay = config.asyncPollingInitialDelay ?? 0.1;
+        this._asyncPollingMaxDelay = config.asyncPollingMaxDelay ?? 1.0;
+        this._asyncPollingBackoffFactor = config.asyncPollingBackoffFactor ?? 2.0;
+        this._reConnectOnSessionTimeout = config.reConnectOnSessionTimeout ?? true;
+        this._reConnectOnRemoteDisconnect = config.reConnectOnRemoteDisconnect ?? true;
+        this._remoteDisconnectMaxRetries = config.remoteDisconnectMaxRetries ?? 5;
+        this._remoteDisconnectRetryDelay = config.remoteDisconnectRetryDelay ?? 1;
+        this._remoteDisconnectMaxDelay = config.remoteDisconnectMaxDelay ?? 30;
 
-        // Reconnect knob defaults mirror tm1py RestService.__init__
-        this.reConnectOnSessionTimeout = config.reConnectOnSessionTimeout ?? true;
-        this.reConnectOnRemoteDisconnect = config.reConnectOnRemoteDisconnect ?? true;
-        this.remoteDisconnectMaxRetries = config.remoteDisconnectMaxRetries ?? 5;
-        this.remoteDisconnectRetryDelay = config.remoteDisconnectRetryDelay ?? 1;
-        this.remoteDisconnectMaxDelay = config.remoteDisconnectMaxDelay ?? 30;
-        this.remoteDisconnectBackoffFactor = config.remoteDisconnectBackoffFactor ?? 2;
-
-        // ADMIN username fast-path (tm1py RestService.__init__ — ADMIN short-circuit)
+        // Pre-populate admin flags for the built-in ADMIN user (mirrors tm1py)
         if (config.user && caseAndSpaceInsensitiveEquals(config.user, 'ADMIN')) {
             this._isAdmin = true;
             this._isDataAdmin = true;
@@ -167,7 +180,7 @@ export class RestService {
 
     private parseSetCookieHeaders(setCookie: string[] | string | undefined): void {
         if (!setCookie) return;
-        const list = Array.isArray(setCookie) ? setCookie : [setCookie];
+        const list = RestService.normaliseSetCookie(setCookie);
         for (const raw of list) {
             const firstSegment = raw.split(';')[0];
             const eqIdx = firstSegment.indexOf('=');
@@ -206,7 +219,7 @@ export class RestService {
 
         const axiosConfig: AxiosRequestConfig = {
             baseURL,
-            timeout: (this.config.timeout || 60) * 1000,
+            timeout: this._timeout * 1000,
             headers: {
                 ...RestService.HEADERS,
                 ...(this.config.sessionContext && { 'TM1-SessionContext': this.config.sessionContext })
@@ -393,14 +406,14 @@ export class RestService {
                 const originalRequest = error.config;
 
                 // Handle timeout errors
-                if (error.code === 'ECONNABORTED' || error.message.includes('timeout')) {
+                if (error.code === 'ECONNABORTED' || error.message?.includes?.('timeout')) {
                     throw new TM1TimeoutException(`Request timeout: ${error.message}`);
                 }
 
                 // Handle authentication errors with retry. Guarded by this.isConnected so a 401
                 // during disconnect()'s tm1.Close POST cannot recurse back into reAuthenticate().
-                if (this.reConnectOnSessionTimeout && error.response?.status === 401
-                    && !originalRequest._retry && this.isConnected) {
+                if (error.response?.status === 401 && originalRequest && !originalRequest._retry
+                    && this.isConnected && this._reConnectOnSessionTimeout) {
                     originalRequest._retry = true;
 
                     try {
@@ -417,9 +430,8 @@ export class RestService {
                     }
                 }
 
-                // Handle connection errors with retry (gated by reConnectOnRemoteDisconnect)
-                if (this.reConnectOnRemoteDisconnect
-                    && this.shouldRetryRequest(error) && this.canRetryRequest(originalRequest)) {
+                // Handle connection errors with retry
+                if (originalRequest && this.shouldRetryRequest(error) && this.canRetryRequest(originalRequest)) {
                     return this.retryRequest(originalRequest);
                 }
 
@@ -438,6 +450,7 @@ export class RestService {
      * Determine if a request should be retried
      */
     private shouldRetryRequest(error: any): boolean {
+        if (!this._reConnectOnRemoteDisconnect) return false;
         // Retry on network errors, timeouts, and 5xx server errors
         return !error.response ||
                error.code === 'ECONNRESET' ||
@@ -450,26 +463,38 @@ export class RestService {
      * Check if a request can be retried
      */
     private canRetryRequest(config: any): boolean {
+        if (config._idempotent === false) {
+            return false;
+        }
         // Don't retry if already retried maximum times
         config._retryCount = config._retryCount || 0;
-        return config._retryCount < this.remoteDisconnectMaxRetries;
+        return config._retryCount < this._remoteDisconnectMaxRetries;
     }
 
     /**
-     * Retry a failed request with exponential backoff, capped by remoteDisconnectMaxDelay
+     * Retry a failed request with exponential backoff, reconnecting the
+     * session before replay. Mirrors tm1py's _handle_remote_disconnect,
+     * which calls _manage_http_adapter() + connect() prior to retrying
+     * so a dropped session is re-established rather than replayed dead.
      */
     private async retryRequest(config: any): Promise<any> {
-        config._retryCount = (config._retryCount || 0) + 1;
+        config._retryCount = config._retryCount || 0;
+        config._retryCount++;
 
-        // Mirrors tm1py _handle_remote_disconnect:
-        //   min(retry_delay * (backoff_factor ** (attempt - 1)), max_delay)
-        const baseMs = this.remoteDisconnectRetryDelay * 1000;
-        const capMs = this.remoteDisconnectMaxDelay * 1000;
-        const delay = Math.min(
-            baseMs * Math.pow(this.remoteDisconnectBackoffFactor, config._retryCount - 1),
-            capMs
-        );
-        await new Promise(resolve => setTimeout(resolve, delay));
+        const baseDelay = this._remoteDisconnectRetryDelay * Math.pow(2, config._retryCount - 1);
+        const retryDelay = Math.min(baseDelay, this._remoteDisconnectMaxDelay) * 1000;
+        await new Promise(resolve => setTimeout(resolve, retryDelay));
+
+        // Re-establish session before replay. Flip isConnected=false first so
+        // connect()'s probe GET cannot recurse through the 401 re-auth branch,
+        // and so a fresh setupAuthentication runs when cookies were cleared.
+        this.isConnected = false;
+        await this.connect();
+
+        // Drop stale Cookie/Authorization on the original config — the request
+        // interceptor rebuilds Cookie from sessionCookies on replay.
+        this.deleteHeaderCaseInsensitive(config.headers, 'Cookie');
+        this.deleteHeaderCaseInsensitive(config.headers, 'Authorization');
 
         return this.axiosInstance(config);
     }
@@ -486,6 +511,177 @@ export class RestService {
         } catch {
             return `HTTP ${response.status}: ${response.statusText}`;
         }
+    }
+
+    private *waitTimeGenerator(timeout: number): Generator<number> {
+        let delay = this._asyncPollingInitialDelay;
+        let elapsed = 0;
+
+        if (timeout) {
+            while (elapsed < timeout) {
+                yield delay;
+                elapsed += delay;
+                delay = Math.min(delay * this._asyncPollingBackoffFactor, this._asyncPollingMaxDelay);
+            }
+        } else {
+            while (true) {
+                yield delay;
+                delay = Math.min(delay * this._asyncPollingBackoffFactor, this._asyncPollingMaxDelay);
+            }
+        }
+    }
+
+    private async _executeSyncRequest(
+        method: string,
+        url: string,
+        data?: any,
+        timeout?: number,
+        idempotent?: boolean,
+        axiosExtras?: Partial<AxiosRequestConfig>
+    ): Promise<AxiosResponse> {
+        const config: AxiosRequestConfig = {
+            method: method as AxiosRequestConfig['method'],
+            url,
+            data,
+            ...axiosExtras
+        };
+
+        if (timeout !== undefined) {
+            config.timeout = timeout * 1000;
+        }
+
+        (config as any)._idempotent = idempotent ?? false;
+
+        return this.axiosInstance.request(config);
+    }
+
+    private async _executeAsyncRequest(
+        method: string,
+        url: string,
+        data?: any,
+        timeout?: number,
+        cancelAtTimeout?: boolean,
+        returnAsyncId?: boolean,
+        idempotent?: boolean,
+        axiosExtras?: Partial<AxiosRequestConfig>
+    ): Promise<AxiosResponse | string> {
+        const preferValue = returnAsyncId ? 'respond-async' : 'respond-async,wait=55';
+        const config: AxiosRequestConfig = {
+            method: method as AxiosRequestConfig['method'],
+            url,
+            data,
+            ...axiosExtras,
+            headers: {
+                ...axiosExtras?.headers,
+                Prefer: preferValue
+            }
+        };
+
+        if (timeout !== undefined) {
+            config.timeout = timeout * 1000;
+        }
+
+        (config as any)._idempotent = idempotent ?? false;
+
+        const response = await this.axiosInstance.request(config);
+
+        if (response.status !== 202) {
+            // Server completed synchronously. If the caller asked for an async
+            // ID (returnAsyncId: true) there is none to return — hand back the
+            // full response so the caller can inspect the result directly.
+            return response;
+        }
+
+        const location = response.headers['location'] || '';
+        const match = typeof location === 'string' ? location.match(/\('([^']+)'\)/) : null;
+        const asyncId = match ? match[1] : undefined;
+
+        if (!asyncId) {
+            throw new TM1RestException(
+                `Async request returned 202 but no valid async ID in Location header: ${location}`
+            );
+        }
+
+        if (returnAsyncId) {
+            return asyncId;
+        }
+
+        return this._pollAsyncResponse(
+            asyncId,
+            timeout ?? this._timeout,
+            cancelAtTimeout ?? this._cancelAtTimeout
+        );
+    }
+
+    private async _pollAsyncResponse(
+        asyncId: string,
+        timeout: number,
+        cancelAtTimeout: boolean
+    ): Promise<AxiosResponse> {
+        for (const wait of this.waitTimeGenerator(timeout)) {
+            const response = await this.retrieve_async_response(asyncId);
+
+            if (response.status === 200 || response.status === 201) {
+                this.verifyAsyncResultHeader(response);
+                return response;
+            }
+
+            await new Promise(resolve => setTimeout(resolve, wait * 1000));
+        }
+
+        if (cancelAtTimeout) {
+            try {
+                await this.cancel_async_operation(asyncId);
+            } catch (cancelError) {
+                console.warn(`Failed to cancel async operation ${asyncId} at timeout:`, cancelError);
+            }
+        }
+
+        throw new TM1TimeoutException(
+            `Async operation ${asyncId} timed out after ${timeout} seconds`,
+            timeout
+        );
+    }
+
+    private async _request(
+        method: string,
+        url: string,
+        data?: any,
+        options?: RequestOptions
+    ): Promise<AxiosResponse | string> {
+        const timeout = options?.timeout ?? this._timeout;
+        const cancelAtTimeout = options?.cancelAtTimeout ?? this._cancelAtTimeout;
+        const asyncMode = options?.returnAsyncId || (options?.asyncRequestsMode ?? this._asyncRequestsMode);
+        const verifyResponse = options?.verifyResponse ?? true;
+        const idempotent = options?.idempotent ?? false;
+        const {
+            asyncRequestsMode: _asyncModeOpt,
+            returnAsyncId,
+            cancelAtTimeout: _cancelAtTimeoutOpt,
+            idempotent: _idempotentOpt,
+            verifyResponse: _verifyResponseOpt,
+            timeout: _timeoutOpt,
+            ...axiosExtras
+        } = options ?? {};
+
+        if (!verifyResponse && axiosExtras.validateStatus === undefined) {
+            axiosExtras.validateStatus = () => true;
+        }
+
+        if (asyncMode) {
+            return this._executeAsyncRequest(
+                method,
+                url,
+                data,
+                timeout,
+                cancelAtTimeout,
+                returnAsyncId,
+                idempotent,
+                axiosExtras
+            );
+        }
+
+        return this._executeSyncRequest(method, url, data, timeout, idempotent, axiosExtras);
     }
 
     public async connect(): Promise<void> {
@@ -509,7 +705,7 @@ export class RestService {
     }
 
     public async disconnect(): Promise<void> {
-        const shouldClose = this.isConnected && !!this.getSessionCookieValue();
+        const shouldClose = this.isConnected;
         // Flip isConnected first so a 401 on tm1.Close cannot trigger reAuthenticate recursion
         this.isConnected = false;
         if (shouldClose) {
@@ -522,24 +718,40 @@ export class RestService {
         this.sessionCookies.clear();
     }
 
-    public async get(url: string, config?: AxiosRequestConfig): Promise<AxiosResponse> {
-        return this.axiosInstance.get(url, config);
+    /**
+     * When `returnAsyncId: true`, the caller receives the async id string
+     * iff the server returns `202 Accepted`. If TM1 short-circuits with
+     * `200/201`, the full `AxiosResponse` is returned instead — the
+     * declared `Promise<string>` return type is a best-effort narrowing.
+     */
+    public async get(url: string, options: RequestOptions & { returnAsyncId: true }): Promise<string | AxiosResponse>;
+    public async get(url: string, options?: RequestOptions): Promise<AxiosResponse>;
+    public async get(url: string, options?: RequestOptions): Promise<AxiosResponse | string> {
+        return this._request('GET', url, undefined, { idempotent: true, ...options });
     }
 
-    public async post(url: string, data?: any, config?: AxiosRequestConfig): Promise<AxiosResponse> {
-        return this.axiosInstance.post(url, data, config);
+    public async post(url: string, data: any, options: RequestOptions & { returnAsyncId: true }): Promise<string | AxiosResponse>;
+    public async post(url: string, data?: any, options?: RequestOptions): Promise<AxiosResponse>;
+    public async post(url: string, data?: any, options?: RequestOptions): Promise<AxiosResponse | string> {
+        return this._request('POST', url, data, options);
     }
 
-    public async patch(url: string, data?: any, config?: AxiosRequestConfig): Promise<AxiosResponse> {
-        return this.axiosInstance.patch(url, data, config);
+    public async patch(url: string, data: any, options: RequestOptions & { returnAsyncId: true }): Promise<string | AxiosResponse>;
+    public async patch(url: string, data?: any, options?: RequestOptions): Promise<AxiosResponse>;
+    public async patch(url: string, data?: any, options?: RequestOptions): Promise<AxiosResponse | string> {
+        return this._request('PATCH', url, data, options);
     }
 
-    public async put(url: string, data?: any, config?: AxiosRequestConfig): Promise<AxiosResponse> {
-        return this.axiosInstance.put(url, data, config);
+    public async put(url: string, data: any, options: RequestOptions & { returnAsyncId: true }): Promise<string | AxiosResponse>;
+    public async put(url: string, data?: any, options?: RequestOptions): Promise<AxiosResponse>;
+    public async put(url: string, data?: any, options?: RequestOptions): Promise<AxiosResponse | string> {
+        return this._request('PUT', url, data, options);
     }
 
-    public async delete(url: string, config?: AxiosRequestConfig): Promise<AxiosResponse> {
-        return this.axiosInstance.delete(url, config);
+    public async delete(url: string, options: RequestOptions & { returnAsyncId: true }): Promise<string | AxiosResponse>;
+    public async delete(url: string, options?: RequestOptions): Promise<AxiosResponse>;
+    public async delete(url: string, options?: RequestOptions): Promise<AxiosResponse | string> {
+        return this._request('DELETE', url, undefined, options);
     }
 
     public getSessionId(): string | undefined {
@@ -555,7 +767,10 @@ export class RestService {
     }
 
     public isLoggedIn(): boolean {
-        return this.isConnected && !!this.getSessionCookieValue();
+        return this.isConnected && (
+            !!this.getSessionCookieValue() ||
+            !!this.axiosInstance.defaults.headers.common['Authorization']
+        );
     }
 
     public async getApiMetadata(): Promise<any> {
@@ -563,192 +778,347 @@ export class RestService {
         return response.data;
     }
 
+    // =========================================================================
+    // Authentication helpers — mirror tm1py's _build_authorization_token*,
+    // _generate_*_access_token, and _start_session flows
+    // =========================================================================
+
     /**
-     * Set up authentication based on configuration
+     * Build an httpsAgent option that skips TLS verification when verify is false.
      */
-    private async setupAuthentication(): Promise<void> {
-        // Access Token authentication (TM1 12+ with JWT tokens)
-        if (this.config.accessToken) {
-            this.axiosInstance.defaults.headers.common['Authorization'] = `Bearer ${this.config.accessToken}`;
-            return;
-        }
-
-        // API Key authentication (TM1 12+ PAaaS)
-        if (this.config.apiKey) {
-            if (this.config.user === 'apikey') {
-                // IBM Cloud API Key style
-                this.axiosInstance.defaults.headers.common['Authorization'] = `Basic ${Buffer.from(`apikey:${this.config.apiKey}`).toString('base64')}`;
-            } else {
-                // Basic API Key style
-                this.axiosInstance.defaults.headers.common['API-Key'] = this.config.apiKey;
-            }
-            return;
-        }
-
-        // CAM (Cognos Access Manager) authentication
-        if (this.config.authUrl && this.config.camPassport) {
-            await this.setupCamAuthentication();
-            return;
-        }
-
-        // CAM SSO authentication
-        if (this.config.authUrl && this.config.user && this.config.password && this.config.namespace) {
-            await this.setupCamSsoAuthentication();
-            return;
-        }
-
-        // Service-to-Service authentication
-        if (this.config.applicationClientId && this.config.applicationClientSecret) {
-            await this.setupServiceToServiceAuthentication();
-            return;
-        }
-
-        // Basic authentication (default)
-        if (this.config.user && this.config.password) {
-            const credentials = Buffer.from(`${this.config.user}:${this.config.password}`).toString('base64');
-            this.axiosInstance.defaults.headers.common['Authorization'] = `Basic ${credentials}`;
-
-            // Add namespace for TM1 Cloud
-            if (this.config.namespace) {
-                this.axiosInstance.defaults.headers.common['TM1-Namespace'] = this.config.namespace;
-            }
-            return;
-        }
-
-        throw new Error('No valid authentication configuration provided');
+    private static insecureAgentOption(
+        verify?: boolean | string
+    ): { httpsAgent: https.Agent } | Record<string, never> {
+        return verify === false
+            ? { httpsAgent: new https.Agent({ rejectUnauthorized: false }) }
+            : {};
     }
 
     /**
-     * Set up CAM (Cognos Access Manager) authentication
+     * Normalise a Set-Cookie header value (string | string[] | undefined) into a string[].
      */
-    private async setupCamAuthentication(): Promise<void> {
-        if (!this.config.authUrl || !this.config.camPassport) {
-            throw new Error('CAM authentication requires authUrl and camPassport');
-        }
-
-        try {
-            const authResponse = await axios.post(this.config.authUrl, {
-                parameters: [{
-                    name: 'CAMPassport',
-                    value: this.config.camPassport
-                }]
-            }, {
-                headers: {
-                    'Content-Type': 'application/json'
-                }
-            });
-
-            if (authResponse.data && authResponse.data.sessionId) {
-                this.sessionCookies.set(RestService.SESSION_COOKIE_NAMES[0], authResponse.data.sessionId);
-            } else {
-                throw new Error('CAM authentication failed: No session ID returned');
-            }
-        } catch (error) {
-            throw new Error(`CAM authentication failed: ${error}`);
-        }
+    private static normaliseSetCookie(raw: string | string[] | undefined): string[] {
+        if (!raw) return [];
+        return Array.isArray(raw) ? raw : [raw];
     }
 
     /**
-     * Set up CAM SSO authentication
+     * Extract a named cookie value from raw Set-Cookie headers.
      */
-    private async setupCamSsoAuthentication(): Promise<void> {
-        if (!this.config.authUrl || !this.config.user || !this.config.password || !this.config.namespace) {
-            throw new Error('CAM SSO authentication requires authUrl, user, password, and namespace');
-        }
-
-        try {
-            const authPayload = {
-                username: this.config.user,
-                password: this.config.password,
-                namespace: this.config.namespace
-            };
-
-            const authResponse = await axios.post(this.config.authUrl, authPayload, {
-                headers: {
-                    'Content-Type': 'application/json'
-                }
-            });
-
-            if (authResponse.data && authResponse.data.token) {
-                this.axiosInstance.defaults.headers.common['Authorization'] = `Bearer ${authResponse.data.token}`;
-            } else if (authResponse.data && authResponse.data.sessionId) {
-                this.sessionCookies.set(RestService.SESSION_COOKIE_NAMES[0], authResponse.data.sessionId);
-            } else {
-                throw new Error('CAM SSO authentication failed: No token or session ID returned');
+    private static extractCookieValue(
+        raw: string | string[] | undefined,
+        name: string
+    ): string | undefined {
+        const prefix = name + '=';
+        for (const header of RestService.normaliseSetCookie(raw)) {
+            const segment = header.split(';')[0];
+            if (segment.startsWith(prefix)) {
+                return segment.slice(prefix.length);
             }
-        } catch (error) {
-            throw new Error(`CAM SSO authentication failed: ${error}`);
         }
+        return undefined;
     }
 
     /**
-     * Set up Service-to-Service authentication
+     * Build Basic Authorization header.
+     * Mirrors tm1py's _build_authorization_token_basic.
      */
-    private async setupServiceToServiceAuthentication(): Promise<void> {
-        if (!this.config.applicationClientId || !this.config.applicationClientSecret) {
-            throw new Error('Service-to-Service authentication requires applicationClientId and applicationClientSecret');
+    private static _buildAuthorizationTokenBasic(user: string, password: string): string {
+        return 'Basic ' + Buffer.from(`${user}:${password}`).toString('base64');
+    }
+
+    /**
+     * Build CAMNamespace Authorization header.
+     * Mirrors tm1py's _build_authorization_token_cam (non-gateway path).
+     */
+    private static _buildAuthorizationTokenCam(
+        user: string,
+        password: string,
+        namespace: string
+    ): string {
+        return 'CAMNamespace ' + Buffer.from(`${user}:${password}:${namespace}`).toString('base64');
+    }
+
+    /**
+     * Build CAMPassport Authorization token via gateway SSO.
+     * Mirrors tm1py's _build_authorization_token_cam (gateway path).
+     * Makes a GET request to the gateway URL with CAMNamespace as a query
+     * parameter and extracts the cam_passport cookie from the response.
+     *
+     * Note: tm1py uses HttpNegotiateAuth (NTLM/Kerberos) for gateway requests,
+     * which is Windows-only. This implementation sends a plain GET and relies on
+     * the gateway being accessible without NTLM. For environments requiring NTLM,
+     * pass a pre-obtained cam_passport via config.camPassport instead.
+     */
+    private static async _buildAuthorizationTokenCamSso(
+        gateway: string,
+        namespace: string,
+        verify?: boolean | string
+    ): Promise<string> {
+        const response = await axios.get(gateway, {
+            params: { CAMNamespace: namespace },
+            ...RestService.insecureAgentOption(verify)
+        });
+        if (response.status !== 200) {
+            throw new Error(
+                'Failed to authenticate through CAM. Expected status_code 200, received status_code: ' +
+                response.status
+            );
+        }
+        const passport = RestService.extractCookieValue(
+            response.headers['set-cookie'], 'cam_passport'
+        );
+        if (!passport) {
+            throw new Error(
+                "Failed to authenticate through CAM. HTTP response does not contain 'cam_passport' cookie"
+            );
+        }
+        return 'CAMPassport ' + passport;
+    }
+
+    /**
+     * Generate IBM IAM Cloud access token.
+     * Mirrors tm1py's _generate_ibm_iam_cloud_access_token.
+     */
+    private async _generateIbmIamCloudAccessToken(): Promise<string> {
+        const { iamUrl, apiKey } = this.config;
+        if (!iamUrl || !apiKey) {
+            throw new Error("'iamUrl' and 'apiKey' must be provided to generate access token from IBM Cloud");
+        }
+        const payload = `grant_type=urn%3Aibm%3Aparams%3Aoauth%3Agrant-type%3Aapikey&apikey=${encodeURIComponent(apiKey)}`;
+        const headers = {
+            'Accept': 'application/json',
+            'Content-Type': 'application/x-www-form-urlencoded'
+        };
+        const response = await axios.post(iamUrl, payload, {
+            headers,
+            ...RestService.insecureAgentOption(this.config.verify)
+        });
+        if (!response.data?.access_token) {
+            throw new Error(`Failed to generate access_token from URL: '${iamUrl}'`);
+        }
+        return response.data.access_token;
+    }
+
+    /**
+     * Generate CPD (Cloud Pak for Data) access token.
+     * Mirrors tm1py's _generate_cpd_access_token.
+     */
+    private async _generateCpdAccessToken(
+        credentials: { username: string; password: string }
+    ): Promise<string> {
+        const { cpdUrl } = this.config;
+        if (!cpdUrl) {
+            throw new Error("'cpdUrl' must be provided to authenticate via CPD/Cloud Pak for Data");
+        }
+        const url = `${cpdUrl}/v1/preauth/signin`;
+        const headers = { 'Content-Type': 'application/json;charset=UTF-8' };
+        const response = await axios.post(url, credentials, {
+            headers,
+            ...RestService.insecureAgentOption(this.config.verify)
+        });
+        if (!response.data?.token) {
+            throw new Error(`Failed to generate CPD access token from URL: '${url}'`);
+        }
+        return response.data.token;
+    }
+
+    /**
+     * Authenticate with PA Proxy using a CPD JWT token.
+     * Mirrors tm1py's PA_PROXY flow in _start_session.
+     */
+    private async _authenticateWithPaProxy(jwt: string): Promise<void> {
+        const authRoot = this.resolveRoots().authRoot;
+        const headers = { 'Content-Type': 'application/x-www-form-urlencoded' };
+        const payload = `jwt=${jwt}`;
+        const response = await axios.post(authRoot, payload, {
+            headers,
+            ...RestService.insecureAgentOption(this.config.verify)
+        });
+        const setCookie = response.headers['set-cookie'];
+        const csrfValue = RestService.extractCookieValue(setCookie, 'ba-sso-csrf');
+        if (csrfValue) {
+            this.axiosInstance.defaults.headers.common['ba-sso-authenticity'] = csrfValue;
+        }
+        this.parseSetCookieHeaders(setCookie);
+    }
+
+    /**
+     * Authenticate Service-to-Service (v12).
+     * Mirrors tm1py's SERVICE_TO_SERVICE flow in _start_session:
+     * Uses Basic auth with applicationClientId:applicationClientSecret,
+     * then POSTs {"User": user} to the auth endpoint.
+     */
+    private async _authenticateServiceToService(): Promise<void> {
+        const { applicationClientId, applicationClientSecret, user } = this.config;
+        if (!applicationClientId || !applicationClientSecret) {
+            throw new Error(
+                'Service-to-Service authentication requires applicationClientId and applicationClientSecret'
+            );
         }
 
-        // Both v11 and v11-style baseUrl topologies resolve authRoot to
-        // /Configuration/ProductVersion/$value — a metadata probe, not a token
-        // endpoint. Require callers to supply authUrl explicitly in those cases.
-        // Validation lives outside the try/catch so its message is not double-wrapped.
+        // Guard: v11 and plain baseUrl topologies resolve authRoot to a metadata
+        // probe URL, not a token endpoint. Require explicit authUrl in those cases.
         if (!this.config.authUrl) {
             const topo = this.determineTopology();
             const baseUrlIsV12 = topo === 'base_url'
                 && /api\/v1\/Databases/.test(this.config.baseUrl ?? '');
             if (topo === 'v11' || (topo === 'base_url' && !baseUrlIsV12)) {
-                throw new Error("'authUrl' is required for Service-to-Service authentication on v11 topology");
+                throw new Error(
+                    "'authUrl' is required for Service-to-Service authentication on v11 topology"
+                );
             }
         }
 
-        try {
-            const tokenEndpoint = this.config.authUrl || this.resolveRoots().authRoot;
+        const authRoot = this.config.authUrl || this.resolveRoots().authRoot;
+        const basicAuth = Buffer.from(
+            `${applicationClientId}:${applicationClientSecret}`
+        ).toString('base64');
 
-            const tokenPayload = {
-                grant_type: 'client_credentials',
-                client_id: this.config.applicationClientId,
-                client_secret: this.config.applicationClientSecret
-            };
+        this.axiosInstance.defaults.headers.common['Authorization'] = `Basic ${basicAuth}`;
 
-            const tokenResponse = await axios.post(tokenEndpoint, tokenPayload, {
+        const response = await axios.post(
+            authRoot,
+            JSON.stringify({ User: user }),
+            {
                 headers: {
-                    'Content-Type': 'application/x-www-form-urlencoded'
-                }
-            });
-
-            if (tokenResponse.data && tokenResponse.data.access_token) {
-                this.axiosInstance.defaults.headers.common['Authorization'] = `Bearer ${tokenResponse.data.access_token}`;
-            } else {
-                throw new Error('Service-to-Service authentication failed: No access token returned');
+                    ...RestService.HEADERS,
+                    'Authorization': `Basic ${basicAuth}`
+                },
+                ...RestService.insecureAgentOption(this.config.verify)
             }
-        } catch (error) {
-            throw new Error(`Service-to-Service authentication failed: ${error}`);
+        );
+
+        this.parseSetCookieHeaders(response.headers['set-cookie']);
+    }
+
+    /**
+     * Determine the authentication mode from config.
+     * Mirrors tm1py's _determine_auth_mode, using the URL topology as the
+     * primary discriminator for v12 modes.
+     */
+    public getAuthenticationMode(): AuthenticationMode {
+        const topo = this.determineTopology();
+        const c = this.config;
+
+        switch (topo) {
+            case 'ibm_cloud':
+                return AuthenticationMode.IBM_CLOUD_API_KEY;
+            case 'pa_proxy':
+                return AuthenticationMode.PA_PROXY;
+            case 's2s':
+                return AuthenticationMode.SERVICE_TO_SERVICE;
+
+            case 'v11':
+            case 'base_url':
+            default: {
+                // v11 / base_url: check auth-specific config flags
+                if (c.accessToken) return AuthenticationMode.ACCESS_TOKEN;
+                if (c.apiKey) return AuthenticationMode.BASIC_API_KEY;
+                if (c.applicationClientId && c.applicationClientSecret) {
+                    return AuthenticationMode.SERVICE_TO_SERVICE;
+                }
+                if (c.camPassport) return AuthenticationMode.CAM;
+                if (c.gateway && c.namespace) return AuthenticationMode.CAM_SSO;
+                if (c.integratedLogin) return AuthenticationMode.WIA;
+                if (c.namespace) return AuthenticationMode.CAM;
+                return AuthenticationMode.BASIC;
+            }
         }
     }
 
     /**
-     * Get the authentication mode being used
+     * Set up authentication based on configuration.
+     * Mirrors tm1py's _start_session routing.
      */
-    public getAuthenticationMode(): AuthenticationMode {
-        if (this.config.accessToken) {
-            return AuthenticationMode.ACCESS_TOKEN;
+    private async setupAuthentication(): Promise<void> {
+        const authMode = this.getAuthenticationMode();
+        const password = this.config.decodeB64 && this.config.password
+            ? RestService.b64_decode_password(this.config.password)
+            : this.config.password;
+
+        switch (authMode) {
+            case AuthenticationMode.ACCESS_TOKEN:
+                this.axiosInstance.defaults.headers.common['Authorization'] =
+                    `Bearer ${this.config.accessToken}`;
+                break;
+
+            case AuthenticationMode.BASIC_API_KEY:
+                if (this.config.user === 'apikey') {
+                    this.axiosInstance.defaults.headers.common['Authorization'] =
+                        RestService._buildAuthorizationTokenBasic('apikey', this.config.apiKey!);
+                } else {
+                    this.axiosInstance.defaults.headers.common['API-Key'] = this.config.apiKey!;
+                }
+                break;
+
+            case AuthenticationMode.IBM_CLOUD_API_KEY: {
+                const accessToken = await this._generateIbmIamCloudAccessToken();
+                this.axiosInstance.defaults.headers.common['Authorization'] =
+                    `Bearer ${accessToken}`;
+                break;
+            }
+
+            case AuthenticationMode.PA_PROXY: {
+                if (!this.config.user || !password) {
+                    throw new Error('PA Proxy authentication requires user and password');
+                }
+                const jwt = await this._generateCpdAccessToken({
+                    username: this.config.user,
+                    password
+                });
+                await this._authenticateWithPaProxy(jwt);
+                break;
+            }
+
+            case AuthenticationMode.SERVICE_TO_SERVICE:
+                await this._authenticateServiceToService();
+                break;
+
+            case AuthenticationMode.CAM_SSO: {
+                // CAM_SSO is only reached when gateway is set (see getAuthenticationMode)
+                const token = await RestService._buildAuthorizationTokenCamSso(
+                    this.config.gateway!,
+                    this.config.namespace!,
+                    this.config.verify
+                );
+                this.axiosInstance.defaults.headers.common['Authorization'] = token;
+                break;
+            }
+
+            case AuthenticationMode.CAM: {
+                if (this.config.camPassport) {
+                    this.axiosInstance.defaults.headers.common['Authorization'] =
+                        'CAMPassport ' + this.config.camPassport;
+                } else if (this.config.namespace && this.config.user && password) {
+                    this.axiosInstance.defaults.headers.common['Authorization'] =
+                        RestService._buildAuthorizationTokenCam(
+                            this.config.user, password, this.config.namespace
+                        );
+                } else {
+                    throw new Error(
+                        'CAM authentication requires either camPassport or user/password/namespace'
+                    );
+                }
+                break;
+            }
+
+            case AuthenticationMode.WIA:
+                throw new Error(
+                    'Windows Integrated Authentication (WIA) is not supported in Node.js. ' +
+                    'Use CAM or Basic authentication instead.'
+                );
+
+            case AuthenticationMode.BASIC:
+            default: {
+                if (!this.config.user || !password) {
+                    throw new Error('No valid authentication configuration provided');
+                }
+                this.axiosInstance.defaults.headers.common['Authorization'] =
+                    RestService._buildAuthorizationTokenBasic(this.config.user, password);
+                break;
+            }
         }
-        if (this.config.apiKey) {
-            return this.config.user === 'apikey' ?
-                AuthenticationMode.IBM_CLOUD_API_KEY :
-                AuthenticationMode.BASIC_API_KEY;
-        }
-        if (this.config.authUrl && this.config.camPassport) {
-            return AuthenticationMode.CAM;
-        }
-        if (this.config.authUrl && this.config.user && this.config.password && this.config.namespace) {
-            return AuthenticationMode.CAM_SSO;
-        }
-        if (this.config.applicationClientId && this.config.applicationClientSecret) {
-            return AuthenticationMode.SERVICE_TO_SERVICE;
-        }
-        return AuthenticationMode.BASIC;
     }
 
     /**
@@ -804,7 +1174,7 @@ export class RestService {
             sessionId: this.getSessionCookieValue(),
             authMode: this.getAuthenticationMode(),
             baseUrl: this.buildBaseUrl(),
-            timeout: (this.config.timeout || 60) * 1000,
+            timeout: this._timeout,
             sandbox: this.sandboxName
         };
     }
@@ -906,7 +1276,10 @@ export class RestService {
      * Check if currently connected to TM1
      */
     public is_connected(): boolean {
-        return this.isConnected && !!this.getSessionCookieValue();
+        return this.isConnected && (
+            !!this.getSessionCookieValue() ||
+            !!this.axiosInstance.defaults.headers.common['Authorization']
+        );
     }
 
     /**
@@ -940,97 +1313,58 @@ export class RestService {
     }
 
     /**
-     * Load /ActiveUser/Groups once and populate all four admin role caches.
-     * Deduplicates concurrent callers via _rolesLoading so parallel is_*_admin()
-     * calls share a single HTTP request.
-     * Uses CaseAndSpaceInsensitiveSet to match group names (tm1py is_admin / is_*_admin).
+     * Fetch the active user's group names as a CaseAndSpaceInsensitiveSet so
+     * membership tests are case- and whitespace-insensitive (mirrors tm1py).
      */
-    private loadActiveUserRoles(): Promise<void> {
-        if (this._rolesLoading) return this._rolesLoading;
-        this._rolesLoading = (async () => {
-            try {
-                const response = await this.get('/ActiveUser/Groups');
-                const groups = new CaseAndSpaceInsensitiveSet();
-                for (const g of (response.data.value || [])) {
-                    if (g && typeof g.Name === 'string') groups.add(g.Name);
-                }
-                if (this._isAdmin === undefined)         this._isAdmin         = groups.has('ADMIN');
-                if (this._isDataAdmin === undefined)     this._isDataAdmin     = groups.has('ADMIN') || groups.has('DataAdmin');
-                if (this._isSecurityAdmin === undefined) this._isSecurityAdmin = groups.has('ADMIN') || groups.has('SecurityAdmin');
-                if (this._isOpsAdmin === undefined)      this._isOpsAdmin      = groups.has('ADMIN') || groups.has('OperationsAdmin');
-            } catch (err) {
-                // Transient errors must not poison the cache: leave _is*Admin undefined so the
-                // next call retries the fetch. Clear _rolesLoading so the next call doesn't
-                // await this same already-failed promise.
-                console.warn('Failed to load /ActiveUser/Groups; admin role flags will retry on next call:', err);
-                this._rolesLoading = undefined;
-                throw err;
-            }
-        })();
-        return this._rolesLoading;
+    private async fetchActiveUserGroupNames(): Promise<CaseAndSpaceInsensitiveSet> {
+        const response = await this.get('/ActiveUser/Groups');
+        const set = new CaseAndSpaceInsensitiveSet();
+        const value = response.data?.value ?? [];
+        for (const group of value) {
+            if (group?.Name) set.add(group.Name);
+        }
+        return set;
     }
 
-    private async tryLoadActiveUserRoles(): Promise<void> {
-        try { await this.loadActiveUserRoles(); } catch { /* transient — caller returns false */ }
-    }
-
-    /** Check if current user is admin (cached, case/space-insensitive). */
+    /**
+     * Check if current user is admin. Result is cached after the first
+     * computation, and pre-populated when the configured user is ADMIN.
+     */
     public async is_admin(): Promise<boolean> {
-        if (this._isAdmin === undefined) await this.tryLoadActiveUserRoles();
-        return this._isAdmin ?? false;
+        if (this._isAdmin !== undefined) return this._isAdmin;
+        const groups = await this.fetchActiveUserGroupNames();
+        this._isAdmin = groups.has('ADMIN');
+        return this._isAdmin;
     }
 
-    /** Check if current user is data admin (cached, case/space-insensitive). */
+    /**
+     * Check if current user is data admin (member of Admin or DataAdmin).
+     */
     public async is_data_admin(): Promise<boolean> {
-        if (this._isDataAdmin === undefined) await this.tryLoadActiveUserRoles();
-        return this._isDataAdmin ?? false;
+        if (this._isDataAdmin !== undefined) return this._isDataAdmin;
+        const groups = await this.fetchActiveUserGroupNames();
+        this._isDataAdmin = groups.has('Admin') || groups.has('DataAdmin');
+        return this._isDataAdmin;
     }
 
-    /** Check if current user is ops admin (cached, case/space-insensitive). */
+    /**
+     * Check if current user is ops admin (member of Admin or OperationsAdmin).
+     */
     public async is_ops_admin(): Promise<boolean> {
-        if (this._isOpsAdmin === undefined) await this.tryLoadActiveUserRoles();
-        return this._isOpsAdmin ?? false;
+        if (this._isOpsAdmin !== undefined) return this._isOpsAdmin;
+        const groups = await this.fetchActiveUserGroupNames();
+        this._isOpsAdmin = groups.has('Admin') || groups.has('OperationsAdmin');
+        return this._isOpsAdmin;
     }
 
-    /** Check if current user is security admin (cached, case/space-insensitive). */
+    /**
+     * Check if current user is security admin (member of Admin or SecurityAdmin).
+     */
     public async is_security_admin(): Promise<boolean> {
-        if (this._isSecurityAdmin === undefined) await this.tryLoadActiveUserRoles();
-        return this._isSecurityAdmin ?? false;
-    }
-
-    /**
-     * Base64-decode an encoded password (tm1py RestService.b64_decode_password).
-     */
-    public static b64_decode_password(encryptedPassword: string): string {
-        return Buffer.from(encryptedPassword, 'base64').toString('utf-8');
-    }
-
-    /**
-     * Convert bool/number/string to boolean (tm1py RestService.translate_to_boolean).
-     * Strings: whitespace stripped, lowercased, compared to 'true'.
-     */
-    public static translate_to_boolean(value: boolean | number | string): boolean {
-        if (typeof value === 'boolean') return value;
-        if (typeof value === 'number') return Boolean(value);
-        if (typeof value === 'string') return value.replace(/\s+/g, '').toLowerCase() === 'true';
-        const rendered = (() => { try { return JSON.stringify(value); } catch { return String(value); } })();
-        throw new Error(`Invalid argument: '${rendered}'. Must be of type 'bool', 'number', or 'str'`);
-    }
-
-    /**
-     * Insert 'tm1.compact=v0' into the Accept header at position 1 and return the prior value.
-     * Mirrors tm1py RestService.add_compact_json_header exactly (no idempotency guard).
-     */
-    public add_compact_json_header(): string {
-        const current = this.axiosInstance.defaults.headers.common['Accept'];
-        // axios headers may be string, string[], number, boolean, or null; only string is a
-        // meaningful Accept value. Anything else falls back to the class default.
-        const original = typeof current === 'string' ? current : RestService.HEADERS['Accept'];
-        const parts = original.split(';');
-        parts.splice(1, 0, 'tm1.compact=v0');
-        const modified = parts.join(';');
-        this.add_http_header('Accept', modified);
-        return original;
+        if (this._isSecurityAdmin !== undefined) return this._isSecurityAdmin;
+        const groups = await this.fetchActiveUserGroupNames();
+        this._isSecurityAdmin = groups.has('Admin') || groups.has('SecurityAdmin');
+        return this._isSecurityAdmin;
     }
 
     /**
@@ -1065,81 +1399,123 @@ export class RestService {
     }
 
     /**
+     * Insert `tm1.compact=v0` into the Accept header (after the
+     * `application/json` segment) and return the previous header value.
+     * Mirrors tm1py's add_compact_json_header.
+     */
+    public add_compact_json_header(): string {
+        const original = (this.axiosInstance.defaults.headers.common['Accept'] as string | undefined) ?? '';
+        const parts = original.split(';');
+        // Insertion point matters: must come immediately after `application/json`
+        parts.splice(1, 0, 'tm1.compact=v0');
+        this.axiosInstance.defaults.headers.common['Accept'] = parts.join(';');
+        return original;
+    }
+
+    /**
+     * Decode a Base64-encoded password to its UTF-8 plaintext form
+     * (mirrors tm1py's b64_decode_password).
+     */
+    public static b64_decode_password(encryptedPassword: string): string {
+        return Buffer.from(encryptedPassword, 'base64').toString('utf-8');
+    }
+
+    /**
+     * Coerce a boolean/number/string config value to a boolean. Strings
+     * are stripped of whitespace and lowercased before comparison with
+     * `'true'` (mirrors tm1py's translate_to_boolean).
+     */
+    public static translate_to_boolean(value: unknown): boolean {
+        if (typeof value === 'boolean') return value;
+        if (typeof value === 'number') return Boolean(value);
+        if (typeof value === 'string') {
+            return value.replace(/\s+/g, '').toLowerCase() === 'true';
+        }
+        throw new Error(
+            `Invalid argument: '${String(value)}'. Must be type 'boolean', 'number', or 'string'`
+        );
+    }
+
+    /**
      * Cancel an async operation by ID
      */
     public async cancel_async_operation(async_id: string): Promise<void> {
-        try {
-            await this.post(`/AsyncOperations('${async_id}')/tm1.Cancel`);
-        } catch (error) {
-            throw new TM1RestException(`Failed to cancel async operation ${async_id}: ${error}`);
-        }
+        await this.delete(formatUrl("/_async('{}')", async_id), { asyncRequestsMode: false });
     }
 
     /**
      * Retrieve async operation response
      */
-    public async retrieve_async_response(async_id: string): Promise<any> {
-        try {
-            const response = await this.get(`/AsyncOperations('${async_id}')`);
-            // Axios treats 2xx as success, but 202 means the operation is still running
-            if (response.status === 202) {
-                throw new TM1RestException('Async operation still running', 202, response);
-            }
-            return response.data;
-        } catch (error: any) {
-            if (error instanceof TM1RestException) {
-                throw error;
-            }
-            const status = error?.status ?? error?.response?.status;
-            throw new TM1RestException(
-                `Failed to retrieve async response ${async_id}: ${error}`,
-                status,
-                error?.response
-            );
-        }
+    public async retrieve_async_response(async_id: string): Promise<AxiosResponse> {
+        // tm1py's retrieve_async_response returns the raw response without
+        // raising on non-2xx because its caller (_poll_async_response) gates
+        // on status_code in [200, 201]. Mirror that: accept all statuses so
+        // transient 404s (resource not yet materialized) or 202s (still
+        // running) flow through to the polling loop rather than aborting it.
+        return this.get(formatUrl("/_async('{}')", async_id), {
+            asyncRequestsMode: false,
+            verifyResponse: false,
+            validateStatus: () => true
+        }) as Promise<AxiosResponse>;
     }
 
     /**
-     * Get async operation status
+     * TM1 v12 returns completed async results with HTTP 200 and encodes
+     * the true operation status in the `asyncresult` header (e.g.
+     * "500 Internal Server Error"). Mirror tm1py's
+     * `_transform_async_response` by throwing on any embedded non-2xx
+     * status so callers are not handed a 500 as "success".
      */
-    public async get_async_operation_status(async_id: string): Promise<string> {
-        try {
-            const response = await this.get(`/AsyncOperations('${async_id}')/Status/$value`);
-            return response.data;
-        } catch (error) {
-            throw new TM1RestException(`Failed to get async operation status ${async_id}: ${error}`);
-        }
+    private verifyAsyncResultHeader(response: AxiosResponse): void {
+        const headerValue = response.headers?.['asyncresult'];
+        if (typeof headerValue !== 'string') return;
+        const embeddedStatus = parseInt(headerValue.trim().split(/\s+/)[0], 10);
+        if (Number.isNaN(embeddedStatus)) return;
+        if (embeddedStatus >= 200 && embeddedStatus < 300) return;
+        throw new TM1RestException(
+            `Async operation failed with status ${headerValue}`,
+            embeddedStatus,
+            response
+        );
     }
 
     /**
-     * Wait for async operation to complete
+     * Wait for async operation to complete using a fixed polling cadence.
+     *
+     * Unlike the internal dispatcher's {@link waitTimeGenerator} (capped
+     * exponential backoff), this public helper polls every
+     * {@link poll_interval_seconds} seconds so existing callers who tuned
+     * the cadence keep their original behavior.
      */
     public async wait_for_async_operation(
         async_id: string,
         timeout_seconds: number = 300,
-        poll_interval_seconds: number = 1
+        poll_interval_seconds: number = 1,
+        cancel_at_timeout: boolean = false
     ): Promise<any> {
-        const start_time = Date.now();
-        const timeout_ms = timeout_seconds * 1000;
-        const poll_interval_ms = poll_interval_seconds * 1000;
+        const deadline = Date.now() + timeout_seconds * 1000;
 
-        while (Date.now() - start_time < timeout_ms) {
-            const status = await this.get_async_operation_status(async_id);
-
-            if (status === 'Completed' || status === 'CompletedSuccessfully') {
-                return await this.retrieve_async_response(async_id);
+        while (Date.now() < deadline) {
+            const response = await this.retrieve_async_response(async_id);
+            if (response.status === 200 || response.status === 201) {
+                this.verifyAsyncResultHeader(response);
+                return response.data;
             }
-
-            if (status === 'Failed' || status === 'CompletedWithError') {
-                const response = await this.retrieve_async_response(async_id);
-                throw new TM1RestException(`Async operation failed: ${JSON.stringify(response)}`);
-            }
-
-            // Wait before polling again
-            await new Promise(resolve => setTimeout(resolve, poll_interval_ms));
+            await new Promise(resolve => setTimeout(resolve, poll_interval_seconds * 1000));
         }
 
-        throw new TM1TimeoutException(`Async operation ${async_id} timed out after ${timeout_seconds} seconds`);
+        if (cancel_at_timeout) {
+            try {
+                await this.cancel_async_operation(async_id);
+            } catch (cancelError) {
+                console.warn(`Failed to cancel async operation ${async_id} at timeout:`, cancelError);
+            }
+        }
+
+        throw new TM1TimeoutException(
+            `Async operation ${async_id} timed out after ${timeout_seconds} seconds`,
+            timeout_seconds
+        );
     }
 
     /**

--- a/src/services/RestService.ts
+++ b/src/services/RestService.ts
@@ -122,10 +122,19 @@ export class RestService {
     private _isDataAdmin?: boolean;
     private _isSecurityAdmin?: boolean;
     private _isOpsAdmin?: boolean;
+    private _activeUserGroupsPromise?: Promise<CaseAndSpaceInsensitiveSet>;
 
     public get version(): string | undefined {
         return this._serverVersion;
     }
+
+    // Sync accessors for cached role flags. Return false before the first
+    // is_*_admin() call resolves — callers that need the real value must
+    // await is_admin() / is_data_admin() / etc. first.
+    public get isAdmin(): boolean { return this._isAdmin ?? false; }
+    public get isDataAdmin(): boolean { return this._isDataAdmin ?? false; }
+    public get isSecurityAdmin(): boolean { return this._isSecurityAdmin ?? false; }
+    public get isOpsAdmin(): boolean { return this._isOpsAdmin ?? false; }
 
     constructor(config: RestServiceConfig) {
         this.config = { ...config };
@@ -690,7 +699,15 @@ export class RestService {
                 await this.setupAuthentication();
             }
 
-            await this.axiosInstance.get('/Configuration/ServerName');
+            // Mark probe non-idempotent so the response interceptor's retry
+            // branch skips it. Without this, a retry-triggered connect() whose
+            // probe also fails would spawn another connect(), recursively,
+            // bypassing remoteDisconnectMaxRetries (each probe has its own
+            // fresh _retryCount).
+            await this.axiosInstance.get(
+                '/Configuration/ServerName',
+                { _idempotent: false } as AxiosRequestConfig
+            );
 
             // Strip Authorization only if the session cookie is established; Bearer/API-key
             // modes that never issue a cookie must keep Authorization to stay authenticated
@@ -1315,15 +1332,28 @@ export class RestService {
     /**
      * Fetch the active user's group names as a CaseAndSpaceInsensitiveSet so
      * membership tests are case- and whitespace-insensitive (mirrors tm1py).
+     * Concurrent callers (e.g. Promise.all([is_admin(), is_data_admin(), ...]))
+     * coalesce onto a single in-flight request.
      */
-    private async fetchActiveUserGroupNames(): Promise<CaseAndSpaceInsensitiveSet> {
-        const response = await this.get('/ActiveUser/Groups');
-        const set = new CaseAndSpaceInsensitiveSet();
-        const value = response.data?.value ?? [];
-        for (const group of value) {
-            if (group?.Name) set.add(group.Name);
-        }
-        return set;
+    private fetchActiveUserGroupNames(): Promise<CaseAndSpaceInsensitiveSet> {
+        if (this._activeUserGroupsPromise) return this._activeUserGroupsPromise;
+
+        const clear = () => { this._activeUserGroupsPromise = undefined; };
+        const fetch = this.get('/ActiveUser/Groups').then(
+            (response) => {
+                clear();
+                const set = new CaseAndSpaceInsensitiveSet();
+                const value = response.data?.value ?? [];
+                for (const group of value) {
+                    if (group?.Name) set.add(group.Name);
+                }
+                return set;
+            },
+            (err) => { clear(); throw err; }
+        );
+
+        this._activeUserGroupsPromise = fetch;
+        return fetch;
     }
 
     /**

--- a/src/services/RestService.ts
+++ b/src/services/RestService.ts
@@ -1,5 +1,6 @@
 import axios, { AxiosInstance, AxiosResponse, AxiosRequestConfig } from 'axios';
 import { TM1RestException, TM1TimeoutException } from '../exceptions/TM1Exception';
+import { CaseAndSpaceInsensitiveSet, caseAndSpaceInsensitiveEquals } from '../utils/Utils';
 
 export enum AuthenticationMode {
     BASIC = 1,
@@ -39,6 +40,11 @@ export interface RestServiceConfig {
     apiKey?: string;
     accessToken?: string;
     tenant?: string;
+    reConnectOnSessionTimeout?: boolean;
+    reConnectOnRemoteDisconnect?: boolean;
+    remoteDisconnectMaxRetries?: number;
+    remoteDisconnectDelay?: number;
+    remoteDisconnectMaxDelay?: number;
 }
 
 export class RestService {
@@ -62,12 +68,44 @@ export class RestService {
     private isConnected: boolean = false;
     private _serverVersion?: string;
 
+    private _isAdmin?: boolean;
+    private _isDataAdmin?: boolean;
+    private _isSecurityAdmin?: boolean;
+    private _isOpsAdmin?: boolean;
+    private _rolesLoading?: Promise<void>;
+
+    private reConnectOnSessionTimeout!: boolean;
+    private reConnectOnRemoteDisconnect!: boolean;
+    private remoteDisconnectMaxRetries!: number;
+    private remoteDisconnectDelay!: number;
+    private remoteDisconnectMaxDelay!: number;
+
     public get version(): string | undefined {
         return this._serverVersion;
     }
 
+    public get isAdmin(): boolean { return this._isAdmin ?? false; }
+    public get isDataAdmin(): boolean { return this._isDataAdmin ?? false; }
+    public get isSecurityAdmin(): boolean { return this._isSecurityAdmin ?? false; }
+    public get isOpsAdmin(): boolean { return this._isOpsAdmin ?? false; }
+
     constructor(config: RestServiceConfig) {
         this.config = { ...config };
+
+        this.reConnectOnSessionTimeout = config.reConnectOnSessionTimeout ?? true;
+        this.reConnectOnRemoteDisconnect = config.reConnectOnRemoteDisconnect ?? true;
+        this.remoteDisconnectMaxRetries = config.remoteDisconnectMaxRetries ?? 3;
+        this.remoteDisconnectDelay = config.remoteDisconnectDelay ?? 1;
+        this.remoteDisconnectMaxDelay = config.remoteDisconnectMaxDelay ?? 30;
+
+        // ADMIN username fast-path (tm1py RestService.py:173-177)
+        if (config.user && caseAndSpaceInsensitiveEquals(config.user, 'ADMIN')) {
+            this._isAdmin = true;
+            this._isDataAdmin = true;
+            this._isSecurityAdmin = true;
+            this._isOpsAdmin = true;
+        }
+
         this.setupAxiosInstance();
         if (this.config.sessionId) {
             // v12 paSession seeding via config is not yet modeled.
@@ -190,7 +228,8 @@ export class RestService {
 
                 // Handle authentication errors with retry. Guarded by this.isConnected so a 401
                 // during disconnect()'s tm1.Close POST cannot recurse back into reAuthenticate().
-                if (error.response?.status === 401 && !originalRequest._retry && this.isConnected) {
+                if (this.reConnectOnSessionTimeout && error.response?.status === 401
+                    && !originalRequest._retry && this.isConnected) {
                     originalRequest._retry = true;
 
                     try {
@@ -207,8 +246,9 @@ export class RestService {
                     }
                 }
 
-                // Handle connection errors with retry
-                if (this.shouldRetryRequest(error) && this.canRetryRequest(originalRequest)) {
+                // Handle connection errors with retry (gated by reConnectOnRemoteDisconnect)
+                if (this.reConnectOnRemoteDisconnect
+                    && this.shouldRetryRequest(error) && this.canRetryRequest(originalRequest)) {
                     return this.retryRequest(originalRequest);
                 }
 
@@ -241,18 +281,19 @@ export class RestService {
     private canRetryRequest(config: any): boolean {
         // Don't retry if already retried maximum times
         config._retryCount = config._retryCount || 0;
-        return config._retryCount < 3;
+        return config._retryCount < this.remoteDisconnectMaxRetries;
     }
 
     /**
-     * Retry a failed request with exponential backoff
+     * Retry a failed request with exponential backoff, capped by remoteDisconnectMaxDelay
      */
     private async retryRequest(config: any): Promise<any> {
-        config._retryCount = config._retryCount || 0;
-        config._retryCount++;
+        config._retryCount = (config._retryCount || 0) + 1;
 
-        const retryDelay = Math.pow(2, config._retryCount) * 1000; // Exponential backoff
-        await new Promise(resolve => setTimeout(resolve, retryDelay));
+        const baseMs = this.remoteDisconnectDelay * 1000;
+        const capMs = this.remoteDisconnectMaxDelay * 1000;
+        const delay = Math.min(baseMs * Math.pow(2, config._retryCount - 1), capMs);
+        await new Promise(resolve => setTimeout(resolve, delay));
 
         return this.axiosInstance(config);
     }
@@ -710,55 +751,88 @@ export class RestService {
     }
 
     /**
-     * Check if current user is admin
+     * Load /ActiveUser/Groups once and populate all four admin role caches.
+     * Deduplicates concurrent callers via _rolesLoading so parallel is_*_admin()
+     * calls share a single HTTP request.
+     * Uses CaseAndSpaceInsensitiveSet to match group names (tm1py RestService.py:961-994).
      */
+    private loadActiveUserRoles(): Promise<void> {
+        if (this._rolesLoading) return this._rolesLoading;
+        this._rolesLoading = (async () => {
+            try {
+                const response = await this.get('/ActiveUser/Groups');
+                const groups = new CaseAndSpaceInsensitiveSet();
+                for (const g of (response.data.value || [])) {
+                    if (g && typeof g.Name === 'string') groups.add(g.Name);
+                }
+                if (this._isAdmin === undefined)         this._isAdmin         = groups.has('ADMIN');
+                if (this._isDataAdmin === undefined)     this._isDataAdmin     = groups.has('ADMIN') || groups.has('DataAdmin');
+                if (this._isSecurityAdmin === undefined) this._isSecurityAdmin = groups.has('ADMIN') || groups.has('SecurityAdmin');
+                if (this._isOpsAdmin === undefined)      this._isOpsAdmin      = groups.has('ADMIN') || groups.has('OperationsAdmin');
+            } catch {
+                if (this._isAdmin === undefined)         this._isAdmin = false;
+                if (this._isDataAdmin === undefined)     this._isDataAdmin = false;
+                if (this._isSecurityAdmin === undefined) this._isSecurityAdmin = false;
+                if (this._isOpsAdmin === undefined)      this._isOpsAdmin = false;
+            }
+        })();
+        return this._rolesLoading;
+    }
+
+    /** Check if current user is admin (cached, case/space-insensitive). */
     public async is_admin(): Promise<boolean> {
-        try {
-            const response = await this.get('/ActiveUser/Groups');
-            const groups = response.data.value || [];
-            return groups.some((g: any) => g.Name === 'ADMIN');
-        } catch (error) {
-            return false;
-        }
+        if (this._isAdmin === undefined) await this.loadActiveUserRoles();
+        return this._isAdmin!;
     }
 
-    /**
-     * Check if current user is data admin
-     */
+    /** Check if current user is data admin (cached, case/space-insensitive). */
     public async is_data_admin(): Promise<boolean> {
-        try {
-            const response = await this.get('/ActiveUser/Groups');
-            const groups = response.data.value || [];
-            return groups.some((g: any) => g.Name === 'ADMIN' || g.Name === 'DataAdmin');
-        } catch (error) {
-            return false;
-        }
+        if (this._isDataAdmin === undefined) await this.loadActiveUserRoles();
+        return this._isDataAdmin!;
     }
 
-    /**
-     * Check if current user is ops admin
-     */
+    /** Check if current user is ops admin (cached, case/space-insensitive). */
     public async is_ops_admin(): Promise<boolean> {
-        try {
-            const response = await this.get('/ActiveUser/Groups');
-            const groups = response.data.value || [];
-            return groups.some((g: any) => g.Name === 'ADMIN' || g.Name === 'OperationsAdmin');
-        } catch (error) {
-            return false;
-        }
+        if (this._isOpsAdmin === undefined) await this.loadActiveUserRoles();
+        return this._isOpsAdmin!;
+    }
+
+    /** Check if current user is security admin (cached, case/space-insensitive). */
+    public async is_security_admin(): Promise<boolean> {
+        if (this._isSecurityAdmin === undefined) await this.loadActiveUserRoles();
+        return this._isSecurityAdmin!;
     }
 
     /**
-     * Check if current user is security admin
+     * Base64-decode an encoded password (tm1py RestService.py:1025-1031).
      */
-    public async is_security_admin(): Promise<boolean> {
-        try {
-            const response = await this.get('/ActiveUser/Groups');
-            const groups = response.data.value || [];
-            return groups.some((g: any) => g.Name === 'ADMIN' || g.Name === 'SecurityAdmin');
-        } catch (error) {
-            return false;
-        }
+    public static b64_decode_password(encryptedPassword: string): string {
+        return Buffer.from(encryptedPassword, 'base64').toString('utf-8');
+    }
+
+    /**
+     * Convert bool/number/string to boolean (tm1py RestService.py:1012-1023).
+     * Strings: whitespace stripped, lowercased, compared to 'true'.
+     */
+    public static translate_to_boolean(value: boolean | number | string): boolean {
+        if (typeof value === 'boolean') return value;
+        if (typeof value === 'number') return Boolean(value);
+        if (typeof value === 'string') return value.replace(/\s+/g, '').toLowerCase() === 'true';
+        throw new Error(`Invalid argument: '${value}'. Must be of type 'bool', 'number', or 'str'`);
+    }
+
+    /**
+     * Insert 'tm1.compact=v0' into the Accept header at position 1 and return the prior value.
+     * Mirrors tm1py RestService.py:1105-1114 exactly (no idempotency guard).
+     */
+    public add_compact_json_header(): string {
+        const original = (this.axiosInstance.defaults.headers.common['Accept'] as string | undefined)
+            ?? RestService.HEADERS['Accept'];
+        const parts = original.split(';');
+        parts.splice(1, 0, 'tm1.compact=v0');
+        const modified = parts.join(';');
+        this.add_http_header('Accept', modified);
+        return original;
     }
 
     /**

--- a/src/services/RestService.ts
+++ b/src/services/RestService.ts
@@ -769,38 +769,44 @@ export class RestService {
                 if (this._isDataAdmin === undefined)     this._isDataAdmin     = groups.has('ADMIN') || groups.has('DataAdmin');
                 if (this._isSecurityAdmin === undefined) this._isSecurityAdmin = groups.has('ADMIN') || groups.has('SecurityAdmin');
                 if (this._isOpsAdmin === undefined)      this._isOpsAdmin      = groups.has('ADMIN') || groups.has('OperationsAdmin');
-            } catch {
-                if (this._isAdmin === undefined)         this._isAdmin = false;
-                if (this._isDataAdmin === undefined)     this._isDataAdmin = false;
-                if (this._isSecurityAdmin === undefined) this._isSecurityAdmin = false;
-                if (this._isOpsAdmin === undefined)      this._isOpsAdmin = false;
+            } catch (err) {
+                // Transient errors must not poison the cache: leave _is*Admin undefined so the
+                // next call retries the fetch. Clear _rolesLoading so the next call doesn't
+                // await this same already-failed promise.
+                console.warn('Failed to load /ActiveUser/Groups; admin role flags will retry on next call:', err);
+                this._rolesLoading = undefined;
+                throw err;
             }
         })();
         return this._rolesLoading;
     }
 
+    private async tryLoadActiveUserRoles(): Promise<void> {
+        try { await this.loadActiveUserRoles(); } catch { /* transient — caller returns false */ }
+    }
+
     /** Check if current user is admin (cached, case/space-insensitive). */
     public async is_admin(): Promise<boolean> {
-        if (this._isAdmin === undefined) await this.loadActiveUserRoles();
-        return this._isAdmin!;
+        if (this._isAdmin === undefined) await this.tryLoadActiveUserRoles();
+        return this._isAdmin ?? false;
     }
 
     /** Check if current user is data admin (cached, case/space-insensitive). */
     public async is_data_admin(): Promise<boolean> {
-        if (this._isDataAdmin === undefined) await this.loadActiveUserRoles();
-        return this._isDataAdmin!;
+        if (this._isDataAdmin === undefined) await this.tryLoadActiveUserRoles();
+        return this._isDataAdmin ?? false;
     }
 
     /** Check if current user is ops admin (cached, case/space-insensitive). */
     public async is_ops_admin(): Promise<boolean> {
-        if (this._isOpsAdmin === undefined) await this.loadActiveUserRoles();
-        return this._isOpsAdmin!;
+        if (this._isOpsAdmin === undefined) await this.tryLoadActiveUserRoles();
+        return this._isOpsAdmin ?? false;
     }
 
     /** Check if current user is security admin (cached, case/space-insensitive). */
     public async is_security_admin(): Promise<boolean> {
-        if (this._isSecurityAdmin === undefined) await this.loadActiveUserRoles();
-        return this._isSecurityAdmin!;
+        if (this._isSecurityAdmin === undefined) await this.tryLoadActiveUserRoles();
+        return this._isSecurityAdmin ?? false;
     }
 
     /**
@@ -818,7 +824,8 @@ export class RestService {
         if (typeof value === 'boolean') return value;
         if (typeof value === 'number') return Boolean(value);
         if (typeof value === 'string') return value.replace(/\s+/g, '').toLowerCase() === 'true';
-        throw new Error(`Invalid argument: '${value}'. Must be of type 'bool', 'number', or 'str'`);
+        const rendered = (() => { try { return JSON.stringify(value); } catch { return String(value); } })();
+        throw new Error(`Invalid argument: '${rendered}'. Must be of type 'bool', 'number', or 'str'`);
     }
 
     /**

--- a/src/services/RestService.ts
+++ b/src/services/RestService.ts
@@ -494,9 +494,15 @@ export class RestService {
         const retryDelay = Math.min(baseDelay, this._remoteDisconnectMaxDelay) * 1000;
         await new Promise(resolve => setTimeout(resolve, retryDelay));
 
-        // Re-establish session before replay. Flip isConnected=false first so
-        // connect()'s probe GET cannot recurse through the 401 re-auth branch,
-        // and so a fresh setupAuthentication runs when cookies were cleared.
+        // Re-establish session before replay. Clear sessionCookies first so
+        // connect() runs a full setupAuthentication (mirrors tm1py, whose
+        // connect() always re-runs _start_session / _set_session_id_cookie
+        // regardless of prior cookie state). Without this, a stale cookie
+        // from a server-invalidated session would be reused, the probe GET
+        // would 401, and the whole retry path would silently fail.
+        // Flip isConnected=false so the 401 re-auth branch cannot recurse
+        // through the probe.
+        this.sessionCookies.clear();
         this.isConnected = false;
         await this.connect();
 

--- a/src/services/RestService.ts
+++ b/src/services/RestService.ts
@@ -43,8 +43,9 @@ export interface RestServiceConfig {
     reConnectOnSessionTimeout?: boolean;
     reConnectOnRemoteDisconnect?: boolean;
     remoteDisconnectMaxRetries?: number;
-    remoteDisconnectDelay?: number;
+    remoteDisconnectRetryDelay?: number;
     remoteDisconnectMaxDelay?: number;
+    remoteDisconnectBackoffFactor?: number;
 }
 
 export class RestService {
@@ -77,8 +78,9 @@ export class RestService {
     private reConnectOnSessionTimeout!: boolean;
     private reConnectOnRemoteDisconnect!: boolean;
     private remoteDisconnectMaxRetries!: number;
-    private remoteDisconnectDelay!: number;
+    private remoteDisconnectRetryDelay!: number;
     private remoteDisconnectMaxDelay!: number;
+    private remoteDisconnectBackoffFactor!: number;
 
     public get version(): string | undefined {
         return this._serverVersion;
@@ -92,13 +94,15 @@ export class RestService {
     constructor(config: RestServiceConfig) {
         this.config = { ...config };
 
+        // Reconnect knob defaults mirror tm1py RestService.__init__
         this.reConnectOnSessionTimeout = config.reConnectOnSessionTimeout ?? true;
         this.reConnectOnRemoteDisconnect = config.reConnectOnRemoteDisconnect ?? true;
-        this.remoteDisconnectMaxRetries = config.remoteDisconnectMaxRetries ?? 3;
-        this.remoteDisconnectDelay = config.remoteDisconnectDelay ?? 1;
+        this.remoteDisconnectMaxRetries = config.remoteDisconnectMaxRetries ?? 5;
+        this.remoteDisconnectRetryDelay = config.remoteDisconnectRetryDelay ?? 1;
         this.remoteDisconnectMaxDelay = config.remoteDisconnectMaxDelay ?? 30;
+        this.remoteDisconnectBackoffFactor = config.remoteDisconnectBackoffFactor ?? 2;
 
-        // ADMIN username fast-path (tm1py RestService.py:173-177)
+        // ADMIN username fast-path (tm1py RestService.__init__ — ADMIN short-circuit)
         if (config.user && caseAndSpaceInsensitiveEquals(config.user, 'ADMIN')) {
             this._isAdmin = true;
             this._isDataAdmin = true;
@@ -290,9 +294,14 @@ export class RestService {
     private async retryRequest(config: any): Promise<any> {
         config._retryCount = (config._retryCount || 0) + 1;
 
-        const baseMs = this.remoteDisconnectDelay * 1000;
+        // Mirrors tm1py _handle_remote_disconnect:
+        //   min(retry_delay * (backoff_factor ** (attempt - 1)), max_delay)
+        const baseMs = this.remoteDisconnectRetryDelay * 1000;
         const capMs = this.remoteDisconnectMaxDelay * 1000;
-        const delay = Math.min(baseMs * Math.pow(2, config._retryCount - 1), capMs);
+        const delay = Math.min(
+            baseMs * Math.pow(this.remoteDisconnectBackoffFactor, config._retryCount - 1),
+            capMs
+        );
         await new Promise(resolve => setTimeout(resolve, delay));
 
         return this.axiosInstance(config);
@@ -754,7 +763,7 @@ export class RestService {
      * Load /ActiveUser/Groups once and populate all four admin role caches.
      * Deduplicates concurrent callers via _rolesLoading so parallel is_*_admin()
      * calls share a single HTTP request.
-     * Uses CaseAndSpaceInsensitiveSet to match group names (tm1py RestService.py:961-994).
+     * Uses CaseAndSpaceInsensitiveSet to match group names (tm1py is_admin / is_*_admin).
      */
     private loadActiveUserRoles(): Promise<void> {
         if (this._rolesLoading) return this._rolesLoading;
@@ -810,14 +819,14 @@ export class RestService {
     }
 
     /**
-     * Base64-decode an encoded password (tm1py RestService.py:1025-1031).
+     * Base64-decode an encoded password (tm1py RestService.b64_decode_password).
      */
     public static b64_decode_password(encryptedPassword: string): string {
         return Buffer.from(encryptedPassword, 'base64').toString('utf-8');
     }
 
     /**
-     * Convert bool/number/string to boolean (tm1py RestService.py:1012-1023).
+     * Convert bool/number/string to boolean (tm1py RestService.translate_to_boolean).
      * Strings: whitespace stripped, lowercased, compared to 'true'.
      */
     public static translate_to_boolean(value: boolean | number | string): boolean {
@@ -830,11 +839,13 @@ export class RestService {
 
     /**
      * Insert 'tm1.compact=v0' into the Accept header at position 1 and return the prior value.
-     * Mirrors tm1py RestService.py:1105-1114 exactly (no idempotency guard).
+     * Mirrors tm1py RestService.add_compact_json_header exactly (no idempotency guard).
      */
     public add_compact_json_header(): string {
-        const original = (this.axiosInstance.defaults.headers.common['Accept'] as string | undefined)
-            ?? RestService.HEADERS['Accept'];
+        const current = this.axiosInstance.defaults.headers.common['Accept'];
+        // axios headers may be string, string[], number, boolean, or null; only string is a
+        // meaningful Accept value. Anything else falls back to the class default.
+        const original = typeof current === 'string' ? current : RestService.HEADERS['Accept'];
         const parts = original.split(';');
         parts.splice(1, 0, 'tm1.compact=v0');
         const modified = parts.join(';');

--- a/src/tests/processService.test.ts
+++ b/src/tests/processService.test.ts
@@ -459,9 +459,15 @@ describe('ProcessService Tests', () => {
 
     describe('Process Async Polling', () => {
         test('pollExecuteWithReturn should return parsed result on success', async () => {
+            // retrieve_async_response returns an AxiosResponse; the execute summary
+            // lives in .data. Tests that mocked the raw body directly did not
+            // reflect production shape and silently passed against the untyped
+            // parser signature.
             (mockRestService as any).retrieve_async_response = jest.fn().mockResolvedValue({
-                ProcessExecuteStatusCode: 'CompletedSuccessfully',
-                ErrorLogFile: null
+                data: {
+                    ProcessExecuteStatusCode: 'CompletedSuccessfully',
+                    ErrorLogFile: null
+                }
             });
 
             const result = await processService.pollExecuteWithReturn('async-001');
@@ -472,8 +478,10 @@ describe('ProcessService Tests', () => {
 
         test('pollExecuteWithReturn should return error log file when present', async () => {
             (mockRestService as any).retrieve_async_response = jest.fn().mockResolvedValue({
-                ProcessExecuteStatusCode: 'CompletedWithMessages',
-                ErrorLogFile: { Filename: 'TM1ProcessError_20240101.log' }
+                data: {
+                    ProcessExecuteStatusCode: 'CompletedWithMessages',
+                    ErrorLogFile: { Filename: 'TM1ProcessError_20240101.log' }
+                }
             });
 
             const result = await processService.pollExecuteWithReturn('async-002');

--- a/src/tests/restService.test.ts
+++ b/src/tests/restService.test.ts
@@ -1,219 +1,421 @@
-/**
- * RestService Tests for tm1npm
- * Comprehensive tests for TM1 REST API operations with proper mocking
- */
-
-import { RestService } from '../services/RestService';
 import axios, { AxiosResponse } from 'axios';
+import { RestService, AuthenticationMode } from '../services/RestService';
+import { TM1RestException, TM1TimeoutException } from '../exceptions/TM1Exception';
 
-// Mock axios
 jest.mock('axios');
+
 const mockedAxios = axios as jest.Mocked<typeof axios>;
 
-// Helper function to create mock AxiosResponse
-const createMockResponse = (data: any, status: number = 200): AxiosResponse => ({
+const createMockResponse = (data: any, status = 200, headers: Record<string, any> = {}): AxiosResponse => ({
     data,
     status,
-    statusText: status === 200 ? 'OK' : status === 201 ? 'Created' : status === 204 ? 'No Content' : 'Error',
-    headers: {},
+    statusText: status === 200 ? 'OK' : status === 201 ? 'Created' : status === 202 ? 'Accepted' : 'Error',
+    headers,
     config: {} as any
 });
 
-describe('RestService Tests', () => {
+describe('RestService', () => {
     let restService: RestService;
+    let mockAxiosInstance: any;
+    let responseErrorHandler: ((error: any) => Promise<any>) | undefined;
 
     beforeEach(() => {
-        // Clear all mocks
         jest.clearAllMocks();
-        
-        // Mock axios.create
-        const mockAxiosInstance = {
+        jest.useRealTimers();
+        responseErrorHandler = undefined;
+
+        mockAxiosInstance = Object.assign(jest.fn(), {
             get: jest.fn(),
             post: jest.fn(),
             patch: jest.fn(),
-            delete: jest.fn(),
             put: jest.fn(),
+            delete: jest.fn(),
+            request: jest.fn(),
+            defaults: { headers: { common: {} } },
             interceptors: {
-                request: { use: jest.fn() },
-                response: { use: jest.fn() }
+                request: {
+                    use: jest.fn()
+                },
+                response: {
+                    use: jest.fn((onFulfilled: any, onRejected: any) => {
+                        responseErrorHandler = onRejected;
+                        return 0;
+                    })
+                }
             }
-        };
+        });
 
-        mockedAxios.create.mockReturnValue(mockAxiosInstance as any);
-        
-        const config = {
+        mockedAxios.create.mockReturnValue(mockAxiosInstance);
+
+        restService = new RestService({
             baseUrl: 'http://localhost:8879/api/v1',
             user: 'admin',
             password: 'password',
-            timeout: 30000
+            timeout: 60
+        });
+    });
+
+    test('routes sync GET requests through the central dispatcher', async () => {
+        mockAxiosInstance.request.mockResolvedValue(createMockResponse({ value: '11.8.0' }));
+
+        const response = await restService.get('/Configuration/ProductVersion');
+
+        expect(response.data.value).toBe('11.8.0');
+        expect(mockAxiosInstance.request).toHaveBeenCalledWith(
+            expect.objectContaining({
+                method: 'GET',
+                url: '/Configuration/ProductVersion',
+                timeout: 60000,
+                _idempotent: true
+            })
+        );
+    });
+
+    test('routes async requests with Prefer header and polls /_async endpoint', async () => {
+        mockAxiosInstance.request
+            .mockResolvedValueOnce(createMockResponse({}, 202, {
+                location: "/api/v1/_async('async-001')"
+            }))
+            .mockResolvedValueOnce(createMockResponse({ done: true }, 200));
+
+        const response = await restService.get('/Threads', { asyncRequestsMode: true });
+
+        expect(response.data.done).toBe(true);
+        expect(mockAxiosInstance.request).toHaveBeenNthCalledWith(1,
+            expect.objectContaining({
+                method: 'GET',
+                url: '/Threads',
+                headers: expect.objectContaining({
+                    Prefer: 'respond-async,wait=55'
+                })
+            })
+        );
+        expect(mockAxiosInstance.request).toHaveBeenNthCalledWith(2,
+            expect.objectContaining({
+                method: 'GET',
+                url: "/_async('async-001')"
+            })
+        );
+    });
+
+    test('returns async ID when returnAsyncId is true', async () => {
+        mockAxiosInstance.request.mockResolvedValue(
+            createMockResponse({}, 202, {
+                location: "/api/v1/_async('async-123')"
+            })
+        );
+
+        const asyncId = await restService.post('/Processes', {}, { returnAsyncId: true });
+
+        expect(asyncId).toBe('async-123');
+        expect(mockAxiosInstance.request).toHaveBeenCalledWith(
+            expect.objectContaining({
+                headers: expect.objectContaining({
+                    Prefer: 'respond-async'
+                })
+            })
+        );
+    });
+
+    test('uses per-request asyncRequestsMode over the instance default', async () => {
+        mockAxiosInstance.request.mockResolvedValue(createMockResponse({ ok: true }));
+
+        await restService.get('/test', { asyncRequestsMode: true });
+
+        expect(mockAxiosInstance.request).toHaveBeenCalledWith(
+            expect.objectContaining({
+                headers: expect.objectContaining({
+                    Prefer: 'respond-async,wait=55'
+                })
+            })
+        );
+    });
+
+    test('uses per-request timeout in seconds', async () => {
+        mockAxiosInstance.request.mockResolvedValue(createMockResponse({ ok: true }));
+
+        await restService.post('/test', {}, { timeout: 10 });
+
+        expect(mockAxiosInstance.request).toHaveBeenCalledWith(
+            expect.objectContaining({
+                timeout: 10000
+            })
+        );
+    });
+
+    test('passes responseType and custom headers through to Axios', async () => {
+        mockAxiosInstance.request.mockResolvedValue(createMockResponse(Buffer.from('abc')));
+
+        await restService.get('/files/test', {
+            responseType: 'arraybuffer',
+            headers: {
+                'X-Test': 'value'
+            }
+        });
+
+        expect(mockAxiosInstance.request).toHaveBeenCalledWith(
+            expect.objectContaining({
+                responseType: 'arraybuffer',
+                headers: expect.objectContaining({
+                    'X-Test': 'value'
+                })
+            })
+        );
+    });
+
+    test('honors explicit idempotent: false on a GET request', async () => {
+        mockAxiosInstance.request.mockResolvedValue(createMockResponse({ ok: true }));
+
+        await restService.get('/Configuration/ServerName', { idempotent: false });
+
+        expect(mockAxiosInstance.request).toHaveBeenCalledWith(
+            expect.objectContaining({
+                _idempotent: false
+            })
+        );
+    });
+
+    test('preserves caller-supplied validateStatus when verifyResponse is false', async () => {
+        const callerValidate = jest.fn().mockReturnValue(true);
+        mockAxiosInstance.request.mockResolvedValue(createMockResponse({}, 500));
+
+        await restService.get('/bad', {
+            verifyResponse: false,
+            validateStatus: callerValidate
+        });
+
+        expect(mockAxiosInstance.request).toHaveBeenCalledWith(
+            expect.objectContaining({
+                validateStatus: callerValidate
+            })
+        );
+    });
+
+    test('skips response verification when verifyResponse is false', async () => {
+        mockAxiosInstance.request.mockResolvedValue(createMockResponse({ error: 'bad request' }, 400));
+
+        const response = await restService.get('/bad-request', { verifyResponse: false });
+
+        expect(response.status).toBe(400);
+        expect(mockAxiosInstance.request).toHaveBeenCalledWith(
+            expect.objectContaining({
+                validateStatus: expect.any(Function)
+            })
+        );
+    });
+
+    test('throws when async response has no Location header', async () => {
+        mockAxiosInstance.request.mockResolvedValue(createMockResponse({}, 202));
+
+        await expect(restService.post('/Processes', {}, { asyncRequestsMode: true }))
+            .rejects
+            .toThrow(TM1RestException);
+    });
+
+    test('returns initial response when async request completes synchronously', async () => {
+        mockAxiosInstance.request.mockResolvedValue(createMockResponse({ ok: true }, 200));
+
+        const response = await restService.get('/Threads', { asyncRequestsMode: true });
+
+        expect(response.status).toBe(200);
+        expect(mockAxiosInstance.get).not.toHaveBeenCalled();
+    });
+
+    test('propagates errors thrown by poll requests', async () => {
+        const pollError = new TM1RestException('Internal Server Error', 500);
+        mockAxiosInstance.request
+            .mockResolvedValueOnce(createMockResponse({}, 202, {
+                location: "/api/v1/_async('async-err')"
+            }))
+            .mockRejectedValueOnce(pollError);
+
+        await expect(restService.get('/Threads', { asyncRequestsMode: true }))
+            .rejects.toBe(pollError);
+    });
+
+    test('cancels async operation on timeout when cancelAtTimeout is true', async () => {
+        jest.useFakeTimers();
+
+        mockAxiosInstance.request.mockImplementation((config: any) => {
+            if (config.method === 'GET' && config.url === '/Threads') {
+                return Promise.resolve(createMockResponse({}, 202, {
+                    location: "/api/v1/_async('async-timeout')"
+                }));
+            }
+            if (config.method === 'DELETE') {
+                return Promise.resolve(createMockResponse({}, 204));
+            }
+            return Promise.resolve(createMockResponse({}, 202));
+        });
+
+        const pending = restService.get('/Threads', {
+            asyncRequestsMode: true,
+            timeout: 0.25,
+            cancelAtTimeout: true
+        });
+        const expectation = expect(pending).rejects.toThrow(TM1TimeoutException);
+
+        await Promise.resolve();
+        await jest.advanceTimersByTimeAsync(1000);
+
+        await expectation;
+        expect(mockAxiosInstance.request).toHaveBeenCalledWith(
+            expect.objectContaining({
+                method: 'DELETE',
+                url: "/_async('async-timeout')"
+            })
+        );
+    });
+
+    test('retry interceptor does not retry non-idempotent requests', async () => {
+        expect(responseErrorHandler).toBeDefined();
+
+        const error = {
+            config: { _idempotent: false },
+            code: 'ECONNRESET',
+            message: 'socket hang up'
         };
-        
-        restService = new RestService(config);
+
+        await expect(responseErrorHandler!(error)).rejects.toThrow('socket hang up');
+        expect(mockAxiosInstance).not.toHaveBeenCalled();
     });
 
-    describe('Basic HTTP Operations', () => {
-        test('should handle GET requests', async () => {
-            const mockResponse = createMockResponse({ value: '11.8.0' });
-            (restService as any).axiosInstance.get.mockResolvedValue(mockResponse);
+    test('retry interceptor retries idempotent requests', async () => {
+        jest.useFakeTimers();
+        expect(responseErrorHandler).toBeDefined();
 
-            const response = await restService.get('/Configuration/ProductVersion');
-            
-            expect(response.status).toBe(200);
-            expect(response.data.value).toBe('11.8.0');
-        });
+        mockAxiosInstance.mockResolvedValue(createMockResponse({ ok: true }));
 
-        test('should handle POST requests', async () => {
-            const mockResponse = createMockResponse({}, 201);
-            (restService as any).axiosInstance.post.mockResolvedValue(mockResponse);
+        const error = {
+            config: { _idempotent: true, headers: {} },
+            code: 'ECONNRESET',
+            message: 'socket hang up'
+        };
 
-            const response = await restService.post('/test', { data: 'test' });
-            
-            expect(response.status).toBe(201);
-        });
+        const retryPromise = responseErrorHandler!(error);
+        await jest.advanceTimersByTimeAsync(2000);
 
-        test('should handle PATCH requests', async () => {
-            const mockResponse = createMockResponse({}, 200);
-            (restService as any).axiosInstance.patch.mockResolvedValue(mockResponse);
-
-            const response = await restService.patch('/test', { data: 'updated' });
-            
-            expect(response.status).toBe(200);
-        });
-
-        test('should handle DELETE requests', async () => {
-            const mockResponse = createMockResponse({}, 204);
-            (restService as any).axiosInstance.delete.mockResolvedValue(mockResponse);
-
-            const response = await restService.delete('/test');
-            
-            expect(response.status).toBe(204);
-        });
-
-        test('should handle PUT requests', async () => {
-            const mockResponse = createMockResponse({}, 200);
-            (restService as any).axiosInstance.put.mockResolvedValue(mockResponse);
-
-            const response = await restService.put('/test', { data: 'test' });
-            
-            expect(response.status).toBe(200);
-        });
+        await expect(retryPromise).resolves.toMatchObject({ data: { ok: true } });
+        expect(mockAxiosInstance).toHaveBeenCalledWith(
+            expect.objectContaining({
+                _retryCount: 1
+            })
+        );
     });
 
-    describe('Configuration and Setup', () => {
-        test('should build base URL correctly', () => {
-            expect(restService).toBeDefined();
-            expect((restService as any).config.baseUrl).toContain('localhost:8879');
-        });
+    test('waitTimeGenerator produces capped exponential backoff', () => {
+        const generator = (restService as any).waitTimeGenerator(4);
+        const waits = Array.from({ length: 7 }, () => generator.next().value);
 
-        test('should set timeout correctly', () => {
-            expect((restService as any).config.timeout).toBe(30000);
-        });
-
-        test('should handle authentication config', () => {
-            expect((restService as any).config.user).toBe('admin');
-            expect((restService as any).config.password).toBe('password');
-        });
+        expect(waits).toEqual([0.1, 0.2, 0.4, 0.8, 1, 1, 1]);
     });
 
-    describe('Session Management', () => {
-        test('should handle session ID', () => {
-            restService.setSandbox('TestSandbox');
-            expect(restService.getSandbox()).toBe('TestSandbox');
-        });
+    test('waitTimeGenerator runs unbounded when timeout is falsy', () => {
+        const generator = (restService as any).waitTimeGenerator(0);
+        const waits = Array.from({ length: 5 }, () => generator.next().value);
 
-        test('should check login status', () => {
-            // Initially not logged in
-            expect(restService.isLoggedIn()).toBe(false);
-        });
+        expect(waits).toEqual([0.1, 0.2, 0.4, 0.8, 1]);
+        expect(generator.next().done).toBe(false);
     });
 
-    describe('Error Handling', () => {
-        test('should handle network errors', async () => {
-            const networkError = new Error('Network Error');
-            (restService as any).axiosInstance.get.mockRejectedValue(networkError);
+    test('waitTimeGenerator stops once timeout is exceeded', () => {
+        const generator = (restService as any).waitTimeGenerator(0.5);
+        const waits: number[] = [];
 
-            await expect(restService.get('/test')).rejects.toThrow('Network Error');
-        });
+        while (true) {
+            const next = generator.next();
+            if (next.done) {
+                break;
+            }
+            waits.push(next.value);
+        }
 
-        test('should handle HTTP errors', async () => {
-            const httpError = {
-                response: {
-                    status: 404,
-                    statusText: 'Not Found',
-                    data: { error: 'Resource not found' }
-                }
-            };
-            (restService as any).axiosInstance.get.mockRejectedValue(httpError);
-
-            await expect(restService.get('/nonexistent')).rejects.toMatchObject(httpError);
-        });
-
-        test('should handle timeout errors', async () => {
-            const timeoutError = {
-                code: 'ECONNABORTED',
-                message: 'timeout of 30000ms exceeded'
-            };
-            (restService as any).axiosInstance.get.mockRejectedValue(timeoutError);
-
-            await expect(restService.get('/slow-endpoint')).rejects.toMatchObject(timeoutError);
-        });
+        expect(waits).toEqual([0.1, 0.2, 0.4]);
     });
 
-    describe('API Metadata', () => {
-        test('should get API metadata', async () => {
-            const mockResponse = createMockResponse({ 
-                version: '1.0',
-                capabilities: ['read', 'write'] 
-            });
-            (restService as any).axiosInstance.get.mockResolvedValue(mockResponse);
+    test('cancel_async_operation uses DELETE against /_async', async () => {
+        mockAxiosInstance.request.mockResolvedValue(createMockResponse({}, 204));
 
-            const metadata = await restService.getApiMetadata();
-            
-            expect(metadata.version).toBe('1.0');
-            expect(metadata.capabilities).toEqual(['read', 'write']);
-        });
+        await restService.cancel_async_operation('cancel-001');
+
+        expect(mockAxiosInstance.request).toHaveBeenCalledWith(
+            expect.objectContaining({
+                method: 'DELETE',
+                url: "/_async('cancel-001')"
+            })
+        );
     });
 
-    describe('RestService Integration', () => {
-        test('should handle complex request scenarios', async () => {
-            // Mock a sequence of operations
-            const getMockResponse = createMockResponse({ id: 'test123' });
-            const postMockResponse = createMockResponse({}, 201);
-            const patchMockResponse = createMockResponse({}, 200);
-            const deleteMockResponse = createMockResponse({}, 204);
+    test('retrieve_async_response uses /_async and returns full response', async () => {
+        mockAxiosInstance.request.mockResolvedValue(createMockResponse({ Status: 'CompletedSuccessfully' }));
 
-            (restService as any).axiosInstance.get
-                .mockResolvedValueOnce(getMockResponse);
-            (restService as any).axiosInstance.post
-                .mockResolvedValueOnce(postMockResponse);
-            (restService as any).axiosInstance.patch
-                .mockResolvedValueOnce(patchMockResponse);
-            (restService as any).axiosInstance.delete
-                .mockResolvedValueOnce(deleteMockResponse);
+        const response = await restService.retrieve_async_response('poll-001');
 
-            // Execute sequence
-            const getResponse = await restService.get('/test');
-            expect(getResponse.data.id).toBe('test123');
+        expect(response.data.Status).toBe('CompletedSuccessfully');
+        expect(mockAxiosInstance.request).toHaveBeenCalledWith(
+            expect.objectContaining({
+                method: 'GET',
+                url: "/_async('poll-001')"
+            })
+        );
+    });
 
-            const postResponse = await restService.post('/test', { name: 'test' });
-            expect(postResponse.status).toBe(201);
+    test('async dispatcher retries on transient 404 from /_async resource not yet materialized', async () => {
+        mockAxiosInstance.request
+            .mockResolvedValueOnce(createMockResponse({}, 202, {
+                location: "/api/v1/_async('async-404')"
+            }))
+            .mockResolvedValueOnce(createMockResponse({}, 404))
+            .mockResolvedValueOnce(createMockResponse({ done: true }, 200));
 
-            const patchResponse = await restService.patch('/test', { name: 'updated' });
-            expect(patchResponse.status).toBe(200);
+        const response = await restService.get('/Threads', { asyncRequestsMode: true });
 
-            const deleteResponse = await restService.delete('/test');
-            expect(deleteResponse.status).toBe(204);
-        });
+        expect(response.data.done).toBe(true);
+        expect(mockAxiosInstance.request).toHaveBeenNthCalledWith(2,
+            expect.objectContaining({
+                method: 'GET',
+                url: "/_async('async-404')",
+                validateStatus: expect.any(Function)
+            })
+        );
+    });
 
-        test('should maintain consistency across operations', async () => {
-            const mockResponse = createMockResponse({ consistent: true });
-            (restService as any).axiosInstance.get.mockResolvedValue(mockResponse);
+    test('async dispatcher throws when poll response carries non-2xx asyncresult header', async () => {
+        mockAxiosInstance.request
+            .mockResolvedValueOnce(createMockResponse({}, 202, {
+                location: "/api/v1/_async('async-fail')"
+            }))
+            .mockResolvedValueOnce(createMockResponse({}, 200, {
+                asyncresult: '500 Internal Server Error'
+            }));
 
-            const response1 = await restService.get('/test');
-            const response2 = await restService.get('/test');
+        await expect(restService.get('/Threads', { asyncRequestsMode: true }))
+            .rejects.toMatchObject({ status: 500 });
+    });
 
-            expect(response1.data).toEqual(response2.data);
-        });
+    test('wait_for_async_operation throws when asyncresult header encodes non-2xx status', async () => {
+        mockAxiosInstance.request.mockResolvedValue(
+            createMockResponse({ ok: false }, 200, {
+                asyncresult: '500 Internal Server Error'
+            })
+        );
+
+        await expect(restService.wait_for_async_operation('poll-500', 1))
+            .rejects.toMatchObject({ status: 500 });
+    });
+
+    test('wait_for_async_operation returns response data', async () => {
+        mockAxiosInstance.request.mockResolvedValue(createMockResponse({ Status: 'Completed', Result: 1 }, 200));
+
+        const data = await restService.wait_for_async_operation('poll-002', 1);
+
+        expect(data).toEqual({ Status: 'Completed', Result: 1 });
+        expect(mockAxiosInstance.request).toHaveBeenCalledWith(
+            expect.objectContaining({
+                method: 'GET',
+                url: "/_async('poll-002')"
+            })
+        );
     });
 
     describe('Cookie-based Session Management', () => {
@@ -531,219 +733,6 @@ describe('RestService Tests', () => {
                 (svc as any).isConnected = true;
                 (svc as any).sessionCookies.set('TM1SessionId', 'abc');
                 expect(svc.isLoggedIn()).toBe(true);
-            });
-        });
-
-        describe('Admin role checks (issue #81)', () => {
-            test('ADMIN username fast-path seeds all four caches at construction', () => {
-                const { svc, instance } = makeSvc({ user: 'ADMIN' });
-                expect(svc.isAdmin).toBe(true);
-                expect(svc.isDataAdmin).toBe(true);
-                expect(svc.isSecurityAdmin).toBe(true);
-                expect(svc.isOpsAdmin).toBe(true);
-                expect(instance.get).not.toHaveBeenCalled();
-            });
-
-            test('ADMIN fast-path is case-and-space insensitive', () => {
-                expect(makeSvc({ user: 'admin' }).svc.isAdmin).toBe(true);
-                expect(makeSvc({ user: ' A D M I N ' }).svc.isAdmin).toBe(true);
-                expect(makeSvc({ user: 'Admin' }).svc.isAdmin).toBe(true);
-            });
-
-            test('sync isAdmin getter returns false before roles loaded', () => {
-                const { svc } = makeSvc({ user: 'alice' });
-                expect(svc.isAdmin).toBe(false);
-                expect(svc.isDataAdmin).toBe(false);
-                expect(svc.isSecurityAdmin).toBe(false);
-                expect(svc.isOpsAdmin).toBe(false);
-            });
-
-            test('is_admin loads roles once then caches across all methods', async () => {
-                const { svc, instance } = makeSvc({ user: 'alice' });
-                instance.get.mockResolvedValue(createMockResponse({ value: [{ Name: 'ADMIN' }] }));
-                expect(await svc.is_admin()).toBe(true);
-                expect(await svc.is_data_admin()).toBe(true);
-                expect(await svc.is_security_admin()).toBe(true);
-                expect(await svc.is_ops_admin()).toBe(true);
-                expect(instance.get).toHaveBeenCalledTimes(1);
-            });
-
-            test('is_admin matches group name case/space insensitively', async () => {
-                const { svc, instance } = makeSvc({ user: 'alice' });
-                instance.get.mockResolvedValue(createMockResponse({ value: [{ Name: 'A D M I N' }] }));
-                expect(await svc.is_admin()).toBe(true);
-                expect(svc.isAdmin).toBe(true);
-            });
-
-            test('is_data_admin matches "Data Admin" with spaces', async () => {
-                const { svc, instance } = makeSvc({ user: 'alice' });
-                instance.get.mockResolvedValue(createMockResponse({ value: [{ Name: 'Data Admin' }] }));
-                expect(await svc.is_data_admin()).toBe(true);
-                expect(await svc.is_admin()).toBe(false);
-            });
-
-            test('is_security_admin maps to SecurityAdmin group only', async () => {
-                const { svc, instance } = makeSvc({ user: 'alice' });
-                instance.get.mockResolvedValue(createMockResponse({ value: [{ Name: 'SecurityAdmin' }] }));
-                expect(await svc.is_security_admin()).toBe(true);
-                expect(await svc.is_ops_admin()).toBe(false);
-            });
-
-            test('is_ops_admin maps to OperationsAdmin group only', async () => {
-                const { svc, instance } = makeSvc({ user: 'alice' });
-                instance.get.mockResolvedValue(createMockResponse({ value: [{ Name: 'OperationsAdmin' }] }));
-                expect(await svc.is_ops_admin()).toBe(true);
-                expect(await svc.is_security_admin()).toBe(false);
-            });
-
-            test('concurrent is_*_admin() calls share a single HTTP request', async () => {
-                const { svc, instance } = makeSvc({ user: 'alice' });
-                instance.get.mockResolvedValue(createMockResponse({ value: [{ Name: 'ADMIN' }] }));
-                const [a, b, c, d] = await Promise.all([
-                    svc.is_admin(),
-                    svc.is_data_admin(),
-                    svc.is_security_admin(),
-                    svc.is_ops_admin()
-                ]);
-                expect([a, b, c, d]).toEqual([true, true, true, true]);
-                expect(instance.get).toHaveBeenCalledTimes(1);
-            });
-
-            test('failed /ActiveUser/Groups returns false transiently without caching', async () => {
-                const warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => {});
-                const { svc, instance } = makeSvc({ user: 'alice' });
-                instance.get.mockRejectedValueOnce(new Error('network down'));
-                expect(await svc.is_admin()).toBe(false);
-                // Cache must NOT be poisoned by the transient failure.
-                expect((svc as any)._isAdmin).toBeUndefined();
-                expect((svc as any)._rolesLoading).toBeUndefined();
-
-                instance.get.mockResolvedValueOnce(createMockResponse({ value: [{ Name: 'ADMIN' }] }));
-                expect(await svc.is_admin()).toBe(true);
-                expect(instance.get).toHaveBeenCalledTimes(2);
-                warnSpy.mockRestore();
-            });
-        });
-
-        describe('Static utility methods (issue #81)', () => {
-            test('translate_to_boolean handles bool/number/string', () => {
-                expect(RestService.translate_to_boolean(true)).toBe(true);
-                expect(RestService.translate_to_boolean(false)).toBe(false);
-                expect(RestService.translate_to_boolean(1)).toBe(true);
-                expect(RestService.translate_to_boolean(0)).toBe(false);
-                expect(RestService.translate_to_boolean('true')).toBe(true);
-                expect(RestService.translate_to_boolean('True')).toBe(true);
-                expect(RestService.translate_to_boolean('FALSE')).toBe(false);
-                expect(RestService.translate_to_boolean(' T R U E ')).toBe(true);
-                expect(RestService.translate_to_boolean('yes')).toBe(false);
-                expect(RestService.translate_to_boolean('')).toBe(false);
-            });
-
-            test('translate_to_boolean throws on unsupported types', () => {
-                expect(() => RestService.translate_to_boolean({} as any)).toThrow();
-                expect(() => RestService.translate_to_boolean(null as any)).toThrow();
-                expect(() => RestService.translate_to_boolean(undefined as any)).toThrow();
-            });
-
-            test('b64_decode_password round-trips a UTF-8 string', () => {
-                const encoded = Buffer.from('s3cr3t', 'utf-8').toString('base64');
-                expect(RestService.b64_decode_password(encoded)).toBe('s3cr3t');
-                expect(RestService.b64_decode_password('')).toBe('');
-            });
-        });
-
-        describe('add_compact_json_header (issue #81)', () => {
-            test('inserts tm1.compact=v0 at position 1 and returns prior Accept value', () => {
-                const { svc, instance } = makeSvc();
-                instance.defaults.headers.common['Accept'] = 'application/json;odata.metadata=none,text/plain';
-                const prev = svc.add_compact_json_header();
-                expect(prev).toBe('application/json;odata.metadata=none,text/plain');
-                const after = instance.defaults.headers.common['Accept'] as string;
-                expect(after.split(';')[1]).toBe('tm1.compact=v0');
-                expect(after).toBe('application/json;tm1.compact=v0;odata.metadata=none,text/plain');
-            });
-
-            test('falls back to class HEADERS Accept when axios default is unset', () => {
-                const { svc, instance } = makeSvc();
-                delete instance.defaults.headers.common['Accept'];
-                const prev = svc.add_compact_json_header();
-                expect(prev).toContain('application/json');
-                expect(instance.defaults.headers.common['Accept']).toContain('tm1.compact=v0');
-            });
-        });
-
-        describe('Reconnect configuration (issue #81)', () => {
-            test('applies tm1py-compatible defaults', () => {
-                const { svc } = makeSvc();
-                expect((svc as any).reConnectOnSessionTimeout).toBe(true);
-                expect((svc as any).reConnectOnRemoteDisconnect).toBe(true);
-                expect((svc as any).remoteDisconnectMaxRetries).toBe(5);
-                expect((svc as any).remoteDisconnectRetryDelay).toBe(1);
-                expect((svc as any).remoteDisconnectMaxDelay).toBe(30);
-                expect((svc as any).remoteDisconnectBackoffFactor).toBe(2);
-            });
-
-            test('honors custom overrides', () => {
-                const { svc } = makeSvc({
-                    reConnectOnSessionTimeout: false,
-                    reConnectOnRemoteDisconnect: false,
-                    remoteDisconnectMaxRetries: 7,
-                    remoteDisconnectRetryDelay: 2,
-                    remoteDisconnectMaxDelay: 60,
-                    remoteDisconnectBackoffFactor: 3
-                });
-                expect((svc as any).reConnectOnSessionTimeout).toBe(false);
-                expect((svc as any).reConnectOnRemoteDisconnect).toBe(false);
-                expect((svc as any).remoteDisconnectMaxRetries).toBe(7);
-                expect((svc as any).remoteDisconnectRetryDelay).toBe(2);
-                expect((svc as any).remoteDisconnectMaxDelay).toBe(60);
-                expect((svc as any).remoteDisconnectBackoffFactor).toBe(3);
-            });
-
-            test('canRetryRequest honors remoteDisconnectMaxRetries', () => {
-                const { svc } = makeSvc({ remoteDisconnectMaxRetries: 1 });
-                const cfg: any = {};
-                expect((svc as any).canRetryRequest(cfg)).toBe(true);
-                cfg._retryCount = 1;
-                expect((svc as any).canRetryRequest(cfg)).toBe(false);
-            });
-
-            test('retryRequest caps delay at remoteDisconnectMaxDelay', async () => {
-                jest.useFakeTimers();
-                const { svc, instance } = makeSvc({ remoteDisconnectRetryDelay: 1, remoteDisconnectMaxDelay: 2 });
-                const axiosCallable = jest.fn().mockResolvedValue({ data: 'ok' });
-                (svc as any).axiosInstance = Object.assign(axiosCallable, instance);
-                const cfg: any = { _retryCount: 5 }; // large exponential term triggers the cap
-                const promise = (svc as any).retryRequest(cfg);
-                // Delay should be capped at 2000ms (remoteDisconnectMaxDelay), not 2^5 * 1000 = 32000ms
-                await jest.advanceTimersByTimeAsync(2000);
-                await promise;
-                expect(cfg._retryCount).toBe(6);
-                expect(axiosCallable).toHaveBeenCalledWith(cfg);
-                jest.useRealTimers();
-            });
-
-            test('retryRequest uses remoteDisconnectBackoffFactor for exponential term', async () => {
-                jest.useFakeTimers();
-                const setTimeoutSpy = jest.spyOn(global, 'setTimeout');
-                // retryDelay=1s, backoffFactor=3, maxDelay=1000s (so cap never engages).
-                // On 2nd retry (_retryCount becomes 2), delay = 1000 * 3^(2-1) = 3000ms.
-                const { svc, instance } = makeSvc({
-                    remoteDisconnectRetryDelay: 1,
-                    remoteDisconnectMaxDelay: 1000,
-                    remoteDisconnectBackoffFactor: 3
-                });
-                const axiosCallable = jest.fn().mockResolvedValue({ data: 'ok' });
-                (svc as any).axiosInstance = Object.assign(axiosCallable, instance);
-                const cfg: any = { _retryCount: 1 };
-                const promise = (svc as any).retryRequest(cfg);
-                await jest.advanceTimersByTimeAsync(3000);
-                await promise;
-                // Confirm the delay passed to setTimeout is exactly 3000ms (1000 * 3^1)
-                const delays = setTimeoutSpy.mock.calls.map(call => call[1]);
-                expect(delays).toContain(3000);
-                setTimeoutSpy.mockRestore();
-                jest.useRealTimers();
             });
         });
     });
@@ -1123,7 +1112,7 @@ describe('RestService URL topology dispatch', () => {
                 applicationClientId: 'id',
                 applicationClientSecret: 'secret'
             });
-            await expect((svc as any).setupServiceToServiceAuthentication()).rejects.toThrow(
+            await expect((svc as any)._authenticateServiceToService()).rejects.toThrow(
                 /'authUrl' is required for Service-to-Service authentication on v11 topology/
             );
         });
@@ -1134,7 +1123,7 @@ describe('RestService URL topology dispatch', () => {
                 applicationClientId: 'id',
                 applicationClientSecret: 'secret'
             });
-            await expect((svc as any).setupServiceToServiceAuthentication()).rejects.toThrow(
+            await expect((svc as any)._authenticateServiceToService()).rejects.toThrow(
                 /'authUrl' is required for Service-to-Service authentication on v11 topology/
             );
         });
@@ -1147,8 +1136,695 @@ describe('RestService URL topology dispatch', () => {
                 applicationClientSecret: 'secret'
             });
             // Will reject with network-level error when trying to POST, but NOT the guard error.
-            await expect((svc as any).setupServiceToServiceAuthentication())
+            await expect((svc as any)._authenticateServiceToService())
                 .rejects.not.toThrow(/'authUrl' is required/);
+        });
+    });
+});
+
+// =========================================================================
+// Authentication flow tests — issue #59
+// =========================================================================
+describe('RestService authentication flows', () => {
+    let mockAxiosInstance: any;
+
+    beforeEach(() => {
+        jest.clearAllMocks();
+        mockAxiosInstance = {
+            get: jest.fn(),
+            post: jest.fn(),
+            patch: jest.fn(),
+            delete: jest.fn(),
+            put: jest.fn(),
+            interceptors: {
+                request: { use: jest.fn() },
+                response: { use: jest.fn() }
+            },
+            defaults: { headers: { common: {} as Record<string, string> } }
+        };
+        mockedAxios.create.mockReturnValue(mockAxiosInstance as any);
+    });
+
+    describe('getAuthenticationMode', () => {
+        test('should detect BASIC when only user and password are provided', () => {
+            const svc = new RestService({ address: 'host', ssl: true, user: 'admin', password: 'pw' });
+            expect(svc.getAuthenticationMode()).toBe(AuthenticationMode.BASIC);
+        });
+
+        test('should detect CAM when namespace is set without gateway', () => {
+            const svc = new RestService({
+                address: 'host', ssl: true,
+                user: 'u', password: 'p', namespace: 'LDAP'
+            });
+            expect(svc.getAuthenticationMode()).toBe(AuthenticationMode.CAM);
+        });
+
+        test('should detect CAM when camPassport is set', () => {
+            const svc = new RestService({
+                address: 'host', ssl: true, camPassport: 'passport123'
+            });
+            expect(svc.getAuthenticationMode()).toBe(AuthenticationMode.CAM);
+        });
+
+        test('should detect CAM_SSO when gateway is set', () => {
+            const svc = new RestService({
+                address: 'host', ssl: true,
+                user: 'u', password: 'p', namespace: 'LDAP', gateway: 'https://gw'
+            });
+            expect(svc.getAuthenticationMode()).toBe(AuthenticationMode.CAM_SSO);
+        });
+
+        test('should detect IBM_CLOUD_API_KEY when iamUrl is set', () => {
+            const svc = new RestService({
+                address: 'pa.ibm.com', tenant: 'T1', database: 'DB1',
+                iamUrl: 'https://iam.cloud.ibm.com', ssl: true, apiKey: 'k'
+            });
+            expect(svc.getAuthenticationMode()).toBe(AuthenticationMode.IBM_CLOUD_API_KEY);
+        });
+
+        test('should detect PA_PROXY when address + user + paUrl (no instance)', () => {
+            const svc = new RestService({
+                address: 'host', user: 'u', password: 'p',
+                paUrl: 'https://pa', database: 'db', ssl: true
+            });
+            expect(svc.getAuthenticationMode()).toBe(AuthenticationMode.PA_PROXY);
+        });
+
+        test('should detect SERVICE_TO_SERVICE with instance + database', () => {
+            const svc = new RestService({
+                address: 'h', instance: 'INST', database: 'DB', ssl: true,
+                applicationClientId: 'id', applicationClientSecret: 'secret'
+            });
+            expect(svc.getAuthenticationMode()).toBe(AuthenticationMode.SERVICE_TO_SERVICE);
+        });
+
+        test('should detect SERVICE_TO_SERVICE on v11 when clientId + clientSecret provided', () => {
+            const svc = new RestService({
+                address: 'host', ssl: true,
+                applicationClientId: 'id', applicationClientSecret: 'secret'
+            });
+            expect(svc.getAuthenticationMode()).toBe(AuthenticationMode.SERVICE_TO_SERVICE);
+        });
+
+        test('should detect ACCESS_TOKEN when accessToken is set', () => {
+            const svc = new RestService({
+                baseUrl: 'http://x/api/v1', accessToken: 'jwt123'
+            });
+            expect(svc.getAuthenticationMode()).toBe(AuthenticationMode.ACCESS_TOKEN);
+        });
+
+        test('should detect BASIC_API_KEY when apiKey is set', () => {
+            const svc = new RestService({
+                baseUrl: 'http://x/api/v1', apiKey: 'mykey'
+            });
+            expect(svc.getAuthenticationMode()).toBe(AuthenticationMode.BASIC_API_KEY);
+        });
+
+        test('should fall through to BASIC when gateway is set without namespace', () => {
+            const svc = new RestService({
+                address: 'host', ssl: true,
+                user: 'u', password: 'p', gateway: 'https://gw'
+            });
+            expect(svc.getAuthenticationMode()).toBe(AuthenticationMode.BASIC);
+        });
+
+        test('should detect WIA when integratedLogin is set', () => {
+            const svc = new RestService({
+                address: 'host', ssl: true,
+                integratedLogin: true
+            });
+            expect(svc.getAuthenticationMode()).toBe(AuthenticationMode.WIA);
+        });
+    });
+
+    describe('setupAuthentication — Basic', () => {
+        test('should set Basic Authorization header', async () => {
+            const svc = new RestService({
+                baseUrl: 'http://x/api/v1', user: 'admin', password: 'apple'
+            });
+            await (svc as any).setupAuthentication();
+            expect(mockAxiosInstance.defaults.headers.common['Authorization'])
+                .toBe('Basic ' + Buffer.from('admin:apple').toString('base64'));
+        });
+
+        test('should decode Base64 password when decodeB64 is true', async () => {
+            const encoded = Buffer.from('mypassword').toString('base64');
+            const svc = new RestService({
+                baseUrl: 'http://x/api/v1', user: 'admin', password: encoded, decodeB64: true
+            });
+            await (svc as any).setupAuthentication();
+            expect(mockAxiosInstance.defaults.headers.common['Authorization'])
+                .toBe('Basic ' + Buffer.from('admin:mypassword').toString('base64'));
+        });
+
+        test('should throw when no user or password for BASIC mode', async () => {
+            const svc = new RestService({ baseUrl: 'http://x/api/v1' });
+            await expect((svc as any).setupAuthentication())
+                .rejects.toThrow('No valid authentication configuration provided');
+        });
+    });
+
+    describe('setupAuthentication — CAM (camPassport)', () => {
+        test('should set CAMPassport Authorization header', async () => {
+            const svc = new RestService({
+                baseUrl: 'http://x/api/v1', camPassport: 'test-passport-value'
+            });
+            await (svc as any).setupAuthentication();
+            expect(mockAxiosInstance.defaults.headers.common['Authorization'])
+                .toBe('CAMPassport test-passport-value');
+        });
+    });
+
+    describe('setupAuthentication — CAM (namespace)', () => {
+        test('should set CAMNamespace Authorization header', async () => {
+            const svc = new RestService({
+                baseUrl: 'http://x/api/v1',
+                user: 'admin', password: 'pass', namespace: 'LDAP'
+            });
+            await (svc as any).setupAuthentication();
+            const expected = 'CAMNamespace ' + Buffer.from('admin:pass:LDAP').toString('base64');
+            expect(mockAxiosInstance.defaults.headers.common['Authorization']).toBe(expected);
+        });
+
+        test('should decode B64 password in CAMNamespace header', async () => {
+            const encoded = Buffer.from('pass').toString('base64');
+            const svc = new RestService({
+                baseUrl: 'http://x/api/v1',
+                user: 'admin', password: encoded, namespace: 'LDAP', decodeB64: true
+            });
+            await (svc as any).setupAuthentication();
+            const expected = 'CAMNamespace ' + Buffer.from('admin:pass:LDAP').toString('base64');
+            expect(mockAxiosInstance.defaults.headers.common['Authorization']).toBe(expected);
+        });
+
+        test('should throw CAM error when namespace set but no user/password/camPassport', async () => {
+            const svc = new RestService({
+                baseUrl: 'http://x/api/v1', namespace: 'LDAP'
+            });
+            await expect((svc as any).setupAuthentication())
+                .rejects.toThrow('CAM authentication requires either camPassport or user/password/namespace');
+        });
+    });
+
+    describe('setupAuthentication — CAM_SSO (gateway)', () => {
+        test('should GET gateway and set CAMPassport header from cam_passport cookie', async () => {
+            (axios.get as jest.Mock).mockResolvedValue({
+                status: 200,
+                headers: {
+                    'set-cookie': ['cam_passport=GW_PASSPORT_VALUE; Path=/; HttpOnly']
+                }
+            });
+            const svc = new RestService({
+                address: 'host', ssl: true,
+                user: 'u', password: 'p', namespace: 'NS', gateway: 'https://gw.example.com'
+            });
+            await (svc as any).setupAuthentication();
+            expect(axios.get).toHaveBeenCalledWith('https://gw.example.com', expect.objectContaining({
+                params: { CAMNamespace: 'NS' }
+            }));
+            expect(mockAxiosInstance.defaults.headers.common['Authorization'])
+                .toBe('CAMPassport GW_PASSPORT_VALUE');
+        });
+
+        test('should throw when gateway response has no cam_passport cookie', async () => {
+            (axios.get as jest.Mock).mockResolvedValue({
+                status: 200,
+                headers: { 'set-cookie': ['other=value; Path=/'] }
+            });
+            const svc = new RestService({
+                address: 'host', ssl: true,
+                user: 'u', password: 'p', namespace: 'NS', gateway: 'https://gw'
+            });
+            await expect((svc as any).setupAuthentication())
+                .rejects.toThrow(/cam_passport/);
+        });
+
+        test('should throw when gateway response has no Set-Cookie header', async () => {
+            (axios.get as jest.Mock).mockResolvedValue({
+                status: 200,
+                headers: {}
+            });
+            const svc = new RestService({
+                address: 'host', ssl: true,
+                user: 'u', password: 'p', namespace: 'NS', gateway: 'https://gw'
+            });
+            await expect((svc as any).setupAuthentication())
+                .rejects.toThrow(/cam_passport/);
+        });
+
+        test('should throw when gateway returns non-200 status', async () => {
+            (axios.get as jest.Mock).mockResolvedValue({
+                status: 403,
+                headers: {}
+            });
+            const svc = new RestService({
+                address: 'host', ssl: true,
+                user: 'u', password: 'p', namespace: 'NS', gateway: 'https://gw'
+            });
+            await expect((svc as any).setupAuthentication())
+                .rejects.toThrow(/Expected status_code 200/);
+        });
+    });
+
+    describe('setupAuthentication — IBM_CLOUD_API_KEY (IAM token exchange)', () => {
+        test('should exchange API key for IAM bearer token', async () => {
+            (axios.post as jest.Mock).mockResolvedValue({
+                data: { access_token: 'iam-bearer-token-123' }
+            });
+            const svc = new RestService({
+                address: 'pa.ibm.com', tenant: 'T1', database: 'DB1',
+                iamUrl: 'https://iam.cloud.ibm.com/identity/token',
+                ssl: true, apiKey: 'test-api-key'
+            });
+            await (svc as any).setupAuthentication();
+            expect(axios.post).toHaveBeenCalledWith(
+                'https://iam.cloud.ibm.com/identity/token',
+                expect.stringContaining('grant_type=urn'),
+                expect.objectContaining({
+                    headers: expect.objectContaining({
+                        'Content-Type': 'application/x-www-form-urlencoded'
+                    })
+                })
+            );
+            expect(mockAxiosInstance.defaults.headers.common['Authorization'])
+                .toBe('Bearer iam-bearer-token-123');
+        });
+
+        test('should include apiKey in URL-encoded payload', async () => {
+            (axios.post as jest.Mock).mockResolvedValue({
+                data: { access_token: 'token' }
+            });
+            const svc = new RestService({
+                address: 'pa.ibm.com', tenant: 'T1', database: 'DB1',
+                iamUrl: 'https://iam.cloud.ibm.com', ssl: true, apiKey: 'my-key'
+            });
+            await (svc as any).setupAuthentication();
+            const calledPayload = (axios.post as jest.Mock).mock.calls[0][1];
+            expect(calledPayload).toContain('apikey=my-key');
+            expect(calledPayload).toContain('grant_type=');
+        });
+
+        test('should throw when IAM response lacks access_token', async () => {
+            (axios.post as jest.Mock).mockResolvedValue({ data: {} });
+            const svc = new RestService({
+                address: 'pa.ibm.com', tenant: 'T1', database: 'DB1',
+                iamUrl: 'https://iam.cloud.ibm.com', ssl: true, apiKey: 'k'
+            });
+            await expect((svc as any).setupAuthentication())
+                .rejects.toThrow(/Failed to generate access_token/);
+        });
+
+        test('should throw when iamUrl is set but apiKey is missing', async () => {
+            const svc = new RestService({
+                address: 'pa.ibm.com', tenant: 'T1', database: 'DB1',
+                iamUrl: 'https://iam.cloud.ibm.com', ssl: true
+            });
+            await expect((svc as any)._generateIbmIamCloudAccessToken())
+                .rejects.toThrow(/'iamUrl' and 'apiKey' must be provided/);
+        });
+    });
+
+    describe('setupAuthentication — PA_PROXY (CPD + proxy auth)', () => {
+        test('should generate CPD token then authenticate with PA Proxy', async () => {
+            (axios.post as jest.Mock)
+                // First call: CPD signin
+                .mockResolvedValueOnce({
+                    data: { token: 'cpd-jwt-token-abc' }
+                })
+                // Second call: PA Proxy auth
+                .mockResolvedValueOnce({
+                    status: 200,
+                    headers: {
+                        'set-cookie': [
+                            'ba-sso-csrf=csrf-value; Path=/',
+                            'paSession=session123; Path=/'
+                        ]
+                    }
+                });
+            const svc = new RestService({
+                address: 'host', user: 'user', password: 'pass',
+                paUrl: 'https://pa', database: 'db', ssl: true,
+                cpdUrl: 'https://cpd.example.com'
+            });
+            await (svc as any).setupAuthentication();
+
+            // Verify CPD signin was called
+            expect(axios.post).toHaveBeenNthCalledWith(1,
+                'https://cpd.example.com/v1/preauth/signin',
+                { username: 'user', password: 'pass' },
+                expect.objectContaining({
+                    headers: expect.objectContaining({ 'Content-Type': 'application/json;charset=UTF-8' })
+                })
+            );
+            // Verify PA Proxy auth was called with jwt
+            expect(axios.post).toHaveBeenNthCalledWith(2,
+                expect.stringContaining('/login'),
+                'jwt=cpd-jwt-token-abc',
+                expect.objectContaining({
+                    headers: expect.objectContaining({ 'Content-Type': 'application/x-www-form-urlencoded' })
+                })
+            );
+            // Verify ba-sso-authenticity header was set
+            expect(mockAxiosInstance.defaults.headers.common['ba-sso-authenticity']).toBe('csrf-value');
+        });
+
+        test('should throw when cpdUrl is missing for PA_PROXY', async () => {
+            const svc = new RestService({
+                address: 'host', user: 'u', password: 'p',
+                paUrl: 'https://pa', database: 'db', ssl: true
+            });
+            await expect((svc as any).setupAuthentication())
+                .rejects.toThrow(/'cpdUrl' must be provided to authenticate via CPD/);
+        });
+
+        test('should throw when CPD response lacks token', async () => {
+            (axios.post as jest.Mock).mockResolvedValue({ data: {} });
+            const svc = new RestService({
+                address: 'host', user: 'u', password: 'p',
+                paUrl: 'https://pa', database: 'db', ssl: true,
+                cpdUrl: 'https://cpd'
+            });
+            await expect((svc as any).setupAuthentication())
+                .rejects.toThrow(/Failed to generate CPD access token/);
+        });
+    });
+
+    describe('setupAuthentication — SERVICE_TO_SERVICE', () => {
+        test('should use Basic auth with clientId:clientSecret and POST {User: user}', async () => {
+            (axios.post as jest.Mock).mockResolvedValue({
+                status: 200,
+                headers: {
+                    'set-cookie': ['TM1SessionId=s2s-session-id; Path=/']
+                }
+            });
+            const svc = new RestService({
+                address: 'h', instance: 'INST', database: 'DB', ssl: true,
+                applicationClientId: 'clientA', applicationClientSecret: 'secretB',
+                user: 'admin'
+            });
+            await (svc as any).setupAuthentication();
+
+            const expectedBasicAuth = 'Basic ' + Buffer.from('clientA:secretB').toString('base64');
+            expect(axios.post).toHaveBeenCalledWith(
+                expect.stringContaining('/auth/v1/session'),
+                JSON.stringify({ User: 'admin' }),
+                expect.objectContaining({
+                    headers: expect.objectContaining({
+                        'Authorization': expectedBasicAuth
+                    })
+                })
+            );
+            // Session cookie should be captured
+            expect((svc as any).sessionCookies.get('TM1SessionId')).toBe('s2s-session-id');
+        });
+
+        test('should capture TM1SessionId from response with wrong domain attribute', async () => {
+            (axios.post as jest.Mock).mockResolvedValue({
+                status: 200,
+                headers: {
+                    'set-cookie': ['TM1SessionId=domain-id; Domain=wrong.domain; Path=/']
+                }
+            });
+            const svc = new RestService({
+                address: 'h', instance: 'INST', database: 'DB', ssl: true,
+                applicationClientId: 'id', applicationClientSecret: 'secret',
+                user: 'admin'
+            });
+            await (svc as any).setupAuthentication();
+            // parseSetCookieHeaders strips Domain and captures the cookie directly
+            expect((svc as any).sessionCookies.get('TM1SessionId')).toBe('domain-id');
+        });
+    });
+
+    describe('setupAuthentication — ACCESS_TOKEN', () => {
+        test('should set Bearer token header', async () => {
+            const svc = new RestService({
+                baseUrl: 'http://x/api/v1', accessToken: 'my-jwt-token'
+            });
+            await (svc as any).setupAuthentication();
+            expect(mockAxiosInstance.defaults.headers.common['Authorization'])
+                .toBe('Bearer my-jwt-token');
+        });
+    });
+
+    describe('setupAuthentication — BASIC_API_KEY', () => {
+        test('should set API-Key header when user is not apikey', async () => {
+            const svc = new RestService({
+                baseUrl: 'http://x/api/v1', apiKey: 'my-api-key'
+            });
+            await (svc as any).setupAuthentication();
+            expect(mockAxiosInstance.defaults.headers.common['API-Key']).toBe('my-api-key');
+        });
+
+        test('should set Basic auth with apikey:key when user is apikey', async () => {
+            const svc = new RestService({
+                baseUrl: 'http://x/api/v1', apiKey: 'my-api-key', user: 'apikey'
+            });
+            await (svc as any).setupAuthentication();
+            const expected = 'Basic ' + Buffer.from('apikey:my-api-key').toString('base64');
+            expect(mockAxiosInstance.defaults.headers.common['Authorization']).toBe(expected);
+        });
+    });
+
+    describe('setupAuthentication — WIA', () => {
+        test('should throw for Windows Integrated Authentication', async () => {
+            const svc = new RestService({
+                address: 'host', ssl: true, integratedLogin: true
+            });
+            await expect((svc as any).setupAuthentication())
+                .rejects.toThrow(/Windows Integrated Authentication.*not supported/);
+        });
+    });
+
+    describe('verify propagation to external auth requests', () => {
+        test('should pass rejectUnauthorized:false to IAM request when verify is false', async () => {
+            (axios.post as jest.Mock).mockResolvedValue({
+                data: { access_token: 'token' }
+            });
+            const svc = new RestService({
+                address: 'pa.ibm.com', tenant: 'T', database: 'D',
+                iamUrl: 'https://iam', ssl: true, apiKey: 'k',
+                verify: false
+            });
+            await (svc as any)._generateIbmIamCloudAccessToken();
+            const callArgs = (axios.post as jest.Mock).mock.calls[0][2];
+            expect(callArgs.httpsAgent).toBeDefined();
+        });
+
+        test('should pass rejectUnauthorized:false to S2S request when verify is false', async () => {
+            (axios.post as jest.Mock).mockResolvedValue({
+                status: 200,
+                headers: { 'set-cookie': ['TM1SessionId=s; Path=/'] }
+            });
+            const svc = new RestService({
+                address: 'h', instance: 'I', database: 'D', ssl: true,
+                applicationClientId: 'id', applicationClientSecret: 'secret',
+                user: 'admin', verify: false
+            });
+            await (svc as any)._authenticateServiceToService();
+            const callArgs = (axios.post as jest.Mock).mock.calls[0][2];
+            expect(callArgs.httpsAgent).toBeDefined();
+        });
+
+        test('should pass rejectUnauthorized:false to CPD request when verify is false', async () => {
+            (axios.post as jest.Mock).mockResolvedValue({
+                data: { token: 'jwt' }
+            });
+            const svc = new RestService({
+                address: 'h', user: 'u', password: 'p',
+                paUrl: 'https://pa', database: 'db', ssl: true,
+                cpdUrl: 'https://cpd', verify: false
+            });
+            await (svc as any)._generateCpdAccessToken({ username: 'u', password: 'p' });
+            const callArgs = (axios.post as jest.Mock).mock.calls[0][2];
+            expect(callArgs.httpsAgent).toBeDefined();
+        });
+    });
+
+    describe('issue #81 — admin checks, utility helpers, reconnect config', () => {
+        let svcMock: any;
+        let onError: ((error: any) => Promise<any>) | undefined;
+
+        const buildService = (extra: Record<string, any> = {}) => {
+            svcMock = Object.assign(jest.fn(), {
+                get: jest.fn(),
+                post: jest.fn(),
+                patch: jest.fn(),
+                put: jest.fn(),
+                delete: jest.fn(),
+                request: jest.fn(),
+                defaults: { headers: { common: {} as Record<string, string> } },
+                interceptors: {
+                    request: { use: jest.fn() },
+                    response: {
+                        use: jest.fn((_onFulfilled: any, onRejected: any) => {
+                            onError = onRejected;
+                            return 0;
+                        })
+                    }
+                }
+            });
+            mockedAxios.create.mockReturnValue(svcMock);
+
+            return new RestService({
+                baseUrl: 'http://localhost:8879/api/v1',
+                user: 'bob',
+                password: 'pw',
+                timeout: 60,
+                ...extra
+            });
+        };
+
+        test('caches is_admin and only calls /ActiveUser/Groups once', async () => {
+            const svc = buildService();
+            svcMock.request.mockResolvedValue(
+                createMockResponse({ value: [{ Name: 'ADMIN' }] })
+            );
+
+            const first = await svc.is_admin();
+            const second = await svc.is_admin();
+
+            expect(first).toBe(true);
+            expect(second).toBe(true);
+            expect(svcMock.request).toHaveBeenCalledTimes(1);
+        });
+
+        test('is_admin returns false when ADMIN group not present', async () => {
+            const svc = buildService();
+            svcMock.request.mockResolvedValue(
+                createMockResponse({ value: [{ Name: 'Users' }] })
+            );
+
+            expect(await svc.is_admin()).toBe(false);
+        });
+
+        test('is_admin matches ADMIN case-insensitively in returned group names', async () => {
+            const svc = buildService();
+            svcMock.request.mockResolvedValue(
+                createMockResponse({ value: [{ Name: 'admin' }] })
+            );
+
+            expect(await svc.is_admin()).toBe(true);
+        });
+
+        test('pre-populates all admin flags when configured user is ADMIN (any casing)', async () => {
+            for (const user of ['ADMIN', 'admin', 'Ad Min']) {
+                const svc = buildService({ user });
+
+                expect(await svc.is_admin()).toBe(true);
+                expect(await svc.is_data_admin()).toBe(true);
+                expect(await svc.is_security_admin()).toBe(true);
+                expect(await svc.is_ops_admin()).toBe(true);
+                expect(svcMock.request).not.toHaveBeenCalled();
+            }
+        });
+
+        test('is_data_admin matches Admin or DataAdmin case+space insensitively', async () => {
+            const svc = buildService();
+            svcMock.request.mockResolvedValue(
+                createMockResponse({ value: [{ Name: 'Data Admin' }] })
+            );
+
+            expect(await svc.is_data_admin()).toBe(true);
+        });
+
+        test('is_security_admin matches SecurityAdmin', async () => {
+            const svc = buildService();
+            svcMock.request.mockResolvedValue(
+                createMockResponse({ value: [{ Name: 'securityadmin' }] })
+            );
+
+            expect(await svc.is_security_admin()).toBe(true);
+        });
+
+        test('is_ops_admin matches OperationsAdmin', async () => {
+            const svc = buildService();
+            svcMock.request.mockResolvedValue(
+                createMockResponse({ value: [{ Name: 'Operations Admin' }] })
+            );
+
+            expect(await svc.is_ops_admin()).toBe(true);
+        });
+
+        test('admin checks propagate errors instead of swallowing them', async () => {
+            const svc = buildService();
+            svcMock.request.mockRejectedValue(new TM1RestException('boom', 500));
+
+            await expect(svc.is_admin()).rejects.toThrow('boom');
+        });
+
+        test('b64_decode_password roundtrips Base64 to UTF-8', () => {
+            const secret = 'p@ssw0rd_äß';
+            const encoded = Buffer.from(secret, 'utf-8').toString('base64');
+
+            expect(RestService.b64_decode_password(encoded)).toBe(secret);
+        });
+
+        test('translate_to_boolean handles booleans, numbers, and strings', () => {
+            expect(RestService.translate_to_boolean(true)).toBe(true);
+            expect(RestService.translate_to_boolean(false)).toBe(false);
+            expect(RestService.translate_to_boolean(1)).toBe(true);
+            expect(RestService.translate_to_boolean(0)).toBe(false);
+            expect(RestService.translate_to_boolean('True')).toBe(true);
+            expect(RestService.translate_to_boolean('  TRUE  ')).toBe(true);
+            expect(RestService.translate_to_boolean('false')).toBe(false);
+            expect(RestService.translate_to_boolean('no')).toBe(false);
+        });
+
+        test('translate_to_boolean throws on invalid types', () => {
+            expect(() => RestService.translate_to_boolean(null)).toThrow(/Invalid argument/);
+            expect(() => RestService.translate_to_boolean(undefined)).toThrow(/Invalid argument/);
+            expect(() => RestService.translate_to_boolean({})).toThrow(/Invalid argument/);
+        });
+
+        test('add_compact_json_header inserts tm1.compact=v0 at position 1 and returns original', () => {
+            const svc = buildService();
+            const accept = 'application/json;odata.metadata=none,text/plain';
+            svcMock.defaults.headers.common['Accept'] = accept;
+
+            const original = svc.add_compact_json_header();
+
+            expect(original).toBe(accept);
+            expect(svcMock.defaults.headers.common['Accept']).toBe(
+                'application/json;tm1.compact=v0;odata.metadata=none,text/plain'
+            );
+        });
+
+        test('skips 401 reauth when reConnectOnSessionTimeout is false', async () => {
+            const svc = buildService({ reConnectOnSessionTimeout: false });
+            (svc as any).isConnected = true;
+            const reAuthSpy = jest.spyOn(svc, 'reAuthenticate');
+
+            const error401: any = {
+                response: { status: 401, statusText: 'Unauthorized', data: {} },
+                config: { _idempotent: true }
+            };
+
+            await expect(onError!(error401)).rejects.toBeInstanceOf(TM1RestException);
+            expect(reAuthSpy).not.toHaveBeenCalled();
+        });
+
+        test('skips connection-error retry when reConnectOnRemoteDisconnect is false', async () => {
+            const svc = buildService({ reConnectOnRemoteDisconnect: false });
+            (svc as any).isConnected = true;
+
+            const networkError: any = { code: 'ECONNRESET', message: 'reset', config: { _idempotent: true } };
+
+            await expect(onError!(networkError)).rejects.toBeInstanceOf(TM1RestException);
+            expect(svcMock).not.toHaveBeenCalled();
+        });
+
+        test('respects remoteDisconnectMaxRetries: stops retrying once cap reached', async () => {
+            const svc = buildService({ remoteDisconnectMaxRetries: 1 });
+            (svc as any).isConnected = true;
+
+            // canRetryRequest is gated on the per-request _retryCount; pre-seed to the cap
+            // so the next retry attempt is rejected and the error propagates as TM1RestException.
+            const requestConfig: any = { _idempotent: true, _retryCount: 1 };
+            const networkError: any = { code: 'ECONNRESET', message: 'reset', config: requestConfig };
+
+            await expect(onError!(networkError)).rejects.toBeInstanceOf(TM1RestException);
+            expect(svcMock).not.toHaveBeenCalled();
         });
     });
 });

--- a/src/tests/restService.test.ts
+++ b/src/tests/restService.test.ts
@@ -609,14 +609,19 @@ describe('RestService Tests', () => {
                 expect(instance.get).toHaveBeenCalledTimes(1);
             });
 
-            test('failed /ActiveUser/Groups sets all 4 to false and caches', async () => {
+            test('failed /ActiveUser/Groups returns false transiently without caching', async () => {
+                const warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => {});
                 const { svc, instance } = makeSvc({ user: 'alice' });
-                instance.get.mockRejectedValue(new Error('network down'));
+                instance.get.mockRejectedValueOnce(new Error('network down'));
                 expect(await svc.is_admin()).toBe(false);
-                expect(await svc.is_data_admin()).toBe(false);
-                expect(await svc.is_security_admin()).toBe(false);
-                expect(await svc.is_ops_admin()).toBe(false);
-                expect(instance.get).toHaveBeenCalledTimes(1);
+                // Cache must NOT be poisoned by the transient failure.
+                expect((svc as any)._isAdmin).toBeUndefined();
+                expect((svc as any)._rolesLoading).toBeUndefined();
+
+                instance.get.mockResolvedValueOnce(createMockResponse({ value: [{ Name: 'ADMIN' }] }));
+                expect(await svc.is_admin()).toBe(true);
+                expect(instance.get).toHaveBeenCalledTimes(2);
+                warnSpy.mockRestore();
             });
         });
 

--- a/src/tests/restService.test.ts
+++ b/src/tests/restService.test.ts
@@ -1892,5 +1892,32 @@ describe('RestService authentication flows', () => {
             await expect(onError!(networkError)).rejects.toBeInstanceOf(TM1RestException);
             expect(svcMock).not.toHaveBeenCalled();
         });
+
+        test('retryRequest clears sessionCookies so connect() re-runs setupAuthentication', async () => {
+            // Mirrors tm1py's _handle_remote_disconnect → connect() flow where
+            // connect() always re-runs auth regardless of any prior cookie
+            // state. Without clearing, connect()'s getSessionCookieValue check
+            // would skip setupAuthentication and reuse a stale cookie.
+            const svc = buildService({ remoteDisconnectMaxRetries: 1, remoteDisconnectRetryDelay: 0 });
+            (svc as any).isConnected = true;
+            (svc as any).sessionCookies.set('TM1SessionId', 'stale-cookie');
+
+            const authSpy = jest.fn().mockResolvedValue(undefined);
+            (svc as any).setupAuthentication = authSpy;
+
+            // Probe GET inside connect() succeeds; replayed request succeeds too.
+            svcMock.mockResolvedValue({ status: 200, data: {} });
+            svcMock.get.mockResolvedValue({ status: 200, data: { value: 'Server1' } });
+
+            const requestConfig: any = { _idempotent: true, headers: { Cookie: 'stale-cookie' } };
+            const networkError: any = { code: 'ECONNRESET', message: 'reset', config: requestConfig };
+
+            await onError!(networkError);
+
+            // sessionCookies cleared before connect() so setupAuthentication runs.
+            expect(authSpy).toHaveBeenCalledTimes(1);
+            // Stale Cookie header on replayed config was stripped.
+            expect(requestConfig.headers.Cookie).toBeUndefined();
+        });
     });
 });

--- a/src/tests/restService.test.ts
+++ b/src/tests/restService.test.ts
@@ -574,8 +574,22 @@ describe('RestService', () => {
                 await svc.connect();
 
                 expect(authSpy).not.toHaveBeenCalled();
-                expect(instance.get).toHaveBeenCalledWith('/Configuration/ServerName');
+                expect(instance.get).toHaveBeenCalledWith(
+                    '/Configuration/ServerName',
+                    expect.objectContaining({ _idempotent: false })
+                );
                 expect(svc.isLoggedIn()).toBe(true);
+            });
+
+            test('connect probe is marked non-idempotent so interceptor retry skips it', async () => {
+                const { svc, instance } = makeSvc({ sessionId: 'seed' });
+                instance.get.mockResolvedValue(createMockResponse({ value: 'Server1' }));
+
+                await svc.connect();
+
+                const probeConfig = instance.get.mock.calls[0][1];
+                expect(probeConfig).toBeDefined();
+                expect(probeConfig._idempotent).toBe(false);
             });
 
             test('connect calls setupAuthentication when no session cookie is seeded', async () => {
@@ -1751,6 +1765,58 @@ describe('RestService authentication flows', () => {
             svcMock.request.mockRejectedValue(new TM1RestException('boom', 500));
 
             await expect(svc.is_admin()).rejects.toThrow('boom');
+        });
+
+        test('sync isAdmin/isDataAdmin/isSecurityAdmin/isOpsAdmin getters reflect cached state', async () => {
+            const svc = buildService();
+            // Before any is_*() call resolves, all sync getters return false.
+            expect(svc.isAdmin).toBe(false);
+            expect(svc.isDataAdmin).toBe(false);
+            expect(svc.isSecurityAdmin).toBe(false);
+            expect(svc.isOpsAdmin).toBe(false);
+
+            svcMock.request.mockResolvedValue(
+                createMockResponse({ value: [{ Name: 'ADMIN' }] })
+            );
+            await svc.is_admin();
+            await svc.is_data_admin();
+            await svc.is_security_admin();
+            await svc.is_ops_admin();
+
+            expect(svc.isAdmin).toBe(true);
+            expect(svc.isDataAdmin).toBe(true);
+            expect(svc.isSecurityAdmin).toBe(true);
+            expect(svc.isOpsAdmin).toBe(true);
+        });
+
+        test('concurrent is_*_admin() calls coalesce onto a single /ActiveUser/Groups request', async () => {
+            const svc = buildService();
+            // Non-ADMIN user so pre-populated fast-path does not apply.
+            svcMock.request.mockResolvedValue(
+                createMockResponse({ value: [{ Name: 'Users' }] })
+            );
+
+            const [a, b, c, d] = await Promise.all([
+                svc.is_admin(),
+                svc.is_data_admin(),
+                svc.is_security_admin(),
+                svc.is_ops_admin()
+            ]);
+
+            expect([a, b, c, d]).toEqual([false, false, false, false]);
+            expect(svcMock.request).toHaveBeenCalledTimes(1);
+        });
+
+        test('failed in-flight fetch does not poison subsequent calls', async () => {
+            const svc = buildService();
+            svcMock.request.mockRejectedValueOnce(new TM1RestException('boom', 500));
+            await expect(svc.is_admin()).rejects.toThrow('boom');
+
+            // In-flight promise cleared on rejection; next call hits a fresh request.
+            svcMock.request.mockResolvedValueOnce(
+                createMockResponse({ value: [{ Name: 'ADMIN' }] })
+            );
+            expect(await svc.is_admin()).toBe(true);
         });
 
         test('b64_decode_password roundtrips Base64 to UTF-8', () => {

--- a/src/tests/restService.test.ts
+++ b/src/tests/restService.test.ts
@@ -677,24 +677,27 @@ describe('RestService Tests', () => {
                 const { svc } = makeSvc();
                 expect((svc as any).reConnectOnSessionTimeout).toBe(true);
                 expect((svc as any).reConnectOnRemoteDisconnect).toBe(true);
-                expect((svc as any).remoteDisconnectMaxRetries).toBe(3);
-                expect((svc as any).remoteDisconnectDelay).toBe(1);
+                expect((svc as any).remoteDisconnectMaxRetries).toBe(5);
+                expect((svc as any).remoteDisconnectRetryDelay).toBe(1);
                 expect((svc as any).remoteDisconnectMaxDelay).toBe(30);
+                expect((svc as any).remoteDisconnectBackoffFactor).toBe(2);
             });
 
             test('honors custom overrides', () => {
                 const { svc } = makeSvc({
                     reConnectOnSessionTimeout: false,
                     reConnectOnRemoteDisconnect: false,
-                    remoteDisconnectMaxRetries: 5,
-                    remoteDisconnectDelay: 2,
-                    remoteDisconnectMaxDelay: 60
+                    remoteDisconnectMaxRetries: 7,
+                    remoteDisconnectRetryDelay: 2,
+                    remoteDisconnectMaxDelay: 60,
+                    remoteDisconnectBackoffFactor: 3
                 });
                 expect((svc as any).reConnectOnSessionTimeout).toBe(false);
                 expect((svc as any).reConnectOnRemoteDisconnect).toBe(false);
-                expect((svc as any).remoteDisconnectMaxRetries).toBe(5);
-                expect((svc as any).remoteDisconnectDelay).toBe(2);
+                expect((svc as any).remoteDisconnectMaxRetries).toBe(7);
+                expect((svc as any).remoteDisconnectRetryDelay).toBe(2);
                 expect((svc as any).remoteDisconnectMaxDelay).toBe(60);
+                expect((svc as any).remoteDisconnectBackoffFactor).toBe(3);
             });
 
             test('canRetryRequest honors remoteDisconnectMaxRetries', () => {
@@ -707,7 +710,7 @@ describe('RestService Tests', () => {
 
             test('retryRequest caps delay at remoteDisconnectMaxDelay', async () => {
                 jest.useFakeTimers();
-                const { svc, instance } = makeSvc({ remoteDisconnectDelay: 1, remoteDisconnectMaxDelay: 2 });
+                const { svc, instance } = makeSvc({ remoteDisconnectRetryDelay: 1, remoteDisconnectMaxDelay: 2 });
                 const axiosCallable = jest.fn().mockResolvedValue({ data: 'ok' });
                 (svc as any).axiosInstance = Object.assign(axiosCallable, instance);
                 const cfg: any = { _retryCount: 5 }; // large exponential term triggers the cap
@@ -717,6 +720,29 @@ describe('RestService Tests', () => {
                 await promise;
                 expect(cfg._retryCount).toBe(6);
                 expect(axiosCallable).toHaveBeenCalledWith(cfg);
+                jest.useRealTimers();
+            });
+
+            test('retryRequest uses remoteDisconnectBackoffFactor for exponential term', async () => {
+                jest.useFakeTimers();
+                const setTimeoutSpy = jest.spyOn(global, 'setTimeout');
+                // retryDelay=1s, backoffFactor=3, maxDelay=1000s (so cap never engages).
+                // On 2nd retry (_retryCount becomes 2), delay = 1000 * 3^(2-1) = 3000ms.
+                const { svc, instance } = makeSvc({
+                    remoteDisconnectRetryDelay: 1,
+                    remoteDisconnectMaxDelay: 1000,
+                    remoteDisconnectBackoffFactor: 3
+                });
+                const axiosCallable = jest.fn().mockResolvedValue({ data: 'ok' });
+                (svc as any).axiosInstance = Object.assign(axiosCallable, instance);
+                const cfg: any = { _retryCount: 1 };
+                const promise = (svc as any).retryRequest(cfg);
+                await jest.advanceTimersByTimeAsync(3000);
+                await promise;
+                // Confirm the delay passed to setTimeout is exactly 3000ms (1000 * 3^1)
+                const delays = setTimeoutSpy.mock.calls.map(call => call[1]);
+                expect(delays).toContain(3000);
+                setTimeoutSpy.mockRestore();
                 jest.useRealTimers();
             });
         });

--- a/src/tests/restService.test.ts
+++ b/src/tests/restService.test.ts
@@ -533,5 +533,187 @@ describe('RestService Tests', () => {
                 expect(svc.isLoggedIn()).toBe(true);
             });
         });
+
+        describe('Admin role checks (issue #81)', () => {
+            test('ADMIN username fast-path seeds all four caches at construction', () => {
+                const { svc, instance } = makeSvc({ user: 'ADMIN' });
+                expect(svc.isAdmin).toBe(true);
+                expect(svc.isDataAdmin).toBe(true);
+                expect(svc.isSecurityAdmin).toBe(true);
+                expect(svc.isOpsAdmin).toBe(true);
+                expect(instance.get).not.toHaveBeenCalled();
+            });
+
+            test('ADMIN fast-path is case-and-space insensitive', () => {
+                expect(makeSvc({ user: 'admin' }).svc.isAdmin).toBe(true);
+                expect(makeSvc({ user: ' A D M I N ' }).svc.isAdmin).toBe(true);
+                expect(makeSvc({ user: 'Admin' }).svc.isAdmin).toBe(true);
+            });
+
+            test('sync isAdmin getter returns false before roles loaded', () => {
+                const { svc } = makeSvc({ user: 'alice' });
+                expect(svc.isAdmin).toBe(false);
+                expect(svc.isDataAdmin).toBe(false);
+                expect(svc.isSecurityAdmin).toBe(false);
+                expect(svc.isOpsAdmin).toBe(false);
+            });
+
+            test('is_admin loads roles once then caches across all methods', async () => {
+                const { svc, instance } = makeSvc({ user: 'alice' });
+                instance.get.mockResolvedValue(createMockResponse({ value: [{ Name: 'ADMIN' }] }));
+                expect(await svc.is_admin()).toBe(true);
+                expect(await svc.is_data_admin()).toBe(true);
+                expect(await svc.is_security_admin()).toBe(true);
+                expect(await svc.is_ops_admin()).toBe(true);
+                expect(instance.get).toHaveBeenCalledTimes(1);
+            });
+
+            test('is_admin matches group name case/space insensitively', async () => {
+                const { svc, instance } = makeSvc({ user: 'alice' });
+                instance.get.mockResolvedValue(createMockResponse({ value: [{ Name: 'A D M I N' }] }));
+                expect(await svc.is_admin()).toBe(true);
+                expect(svc.isAdmin).toBe(true);
+            });
+
+            test('is_data_admin matches "Data Admin" with spaces', async () => {
+                const { svc, instance } = makeSvc({ user: 'alice' });
+                instance.get.mockResolvedValue(createMockResponse({ value: [{ Name: 'Data Admin' }] }));
+                expect(await svc.is_data_admin()).toBe(true);
+                expect(await svc.is_admin()).toBe(false);
+            });
+
+            test('is_security_admin maps to SecurityAdmin group only', async () => {
+                const { svc, instance } = makeSvc({ user: 'alice' });
+                instance.get.mockResolvedValue(createMockResponse({ value: [{ Name: 'SecurityAdmin' }] }));
+                expect(await svc.is_security_admin()).toBe(true);
+                expect(await svc.is_ops_admin()).toBe(false);
+            });
+
+            test('is_ops_admin maps to OperationsAdmin group only', async () => {
+                const { svc, instance } = makeSvc({ user: 'alice' });
+                instance.get.mockResolvedValue(createMockResponse({ value: [{ Name: 'OperationsAdmin' }] }));
+                expect(await svc.is_ops_admin()).toBe(true);
+                expect(await svc.is_security_admin()).toBe(false);
+            });
+
+            test('concurrent is_*_admin() calls share a single HTTP request', async () => {
+                const { svc, instance } = makeSvc({ user: 'alice' });
+                instance.get.mockResolvedValue(createMockResponse({ value: [{ Name: 'ADMIN' }] }));
+                const [a, b, c, d] = await Promise.all([
+                    svc.is_admin(),
+                    svc.is_data_admin(),
+                    svc.is_security_admin(),
+                    svc.is_ops_admin()
+                ]);
+                expect([a, b, c, d]).toEqual([true, true, true, true]);
+                expect(instance.get).toHaveBeenCalledTimes(1);
+            });
+
+            test('failed /ActiveUser/Groups sets all 4 to false and caches', async () => {
+                const { svc, instance } = makeSvc({ user: 'alice' });
+                instance.get.mockRejectedValue(new Error('network down'));
+                expect(await svc.is_admin()).toBe(false);
+                expect(await svc.is_data_admin()).toBe(false);
+                expect(await svc.is_security_admin()).toBe(false);
+                expect(await svc.is_ops_admin()).toBe(false);
+                expect(instance.get).toHaveBeenCalledTimes(1);
+            });
+        });
+
+        describe('Static utility methods (issue #81)', () => {
+            test('translate_to_boolean handles bool/number/string', () => {
+                expect(RestService.translate_to_boolean(true)).toBe(true);
+                expect(RestService.translate_to_boolean(false)).toBe(false);
+                expect(RestService.translate_to_boolean(1)).toBe(true);
+                expect(RestService.translate_to_boolean(0)).toBe(false);
+                expect(RestService.translate_to_boolean('true')).toBe(true);
+                expect(RestService.translate_to_boolean('True')).toBe(true);
+                expect(RestService.translate_to_boolean('FALSE')).toBe(false);
+                expect(RestService.translate_to_boolean(' T R U E ')).toBe(true);
+                expect(RestService.translate_to_boolean('yes')).toBe(false);
+                expect(RestService.translate_to_boolean('')).toBe(false);
+            });
+
+            test('translate_to_boolean throws on unsupported types', () => {
+                expect(() => RestService.translate_to_boolean({} as any)).toThrow();
+                expect(() => RestService.translate_to_boolean(null as any)).toThrow();
+                expect(() => RestService.translate_to_boolean(undefined as any)).toThrow();
+            });
+
+            test('b64_decode_password round-trips a UTF-8 string', () => {
+                const encoded = Buffer.from('s3cr3t', 'utf-8').toString('base64');
+                expect(RestService.b64_decode_password(encoded)).toBe('s3cr3t');
+                expect(RestService.b64_decode_password('')).toBe('');
+            });
+        });
+
+        describe('add_compact_json_header (issue #81)', () => {
+            test('inserts tm1.compact=v0 at position 1 and returns prior Accept value', () => {
+                const { svc, instance } = makeSvc();
+                instance.defaults.headers.common['Accept'] = 'application/json;odata.metadata=none,text/plain';
+                const prev = svc.add_compact_json_header();
+                expect(prev).toBe('application/json;odata.metadata=none,text/plain');
+                const after = instance.defaults.headers.common['Accept'] as string;
+                expect(after.split(';')[1]).toBe('tm1.compact=v0');
+                expect(after).toBe('application/json;tm1.compact=v0;odata.metadata=none,text/plain');
+            });
+
+            test('falls back to class HEADERS Accept when axios default is unset', () => {
+                const { svc, instance } = makeSvc();
+                delete instance.defaults.headers.common['Accept'];
+                const prev = svc.add_compact_json_header();
+                expect(prev).toContain('application/json');
+                expect(instance.defaults.headers.common['Accept']).toContain('tm1.compact=v0');
+            });
+        });
+
+        describe('Reconnect configuration (issue #81)', () => {
+            test('applies tm1py-compatible defaults', () => {
+                const { svc } = makeSvc();
+                expect((svc as any).reConnectOnSessionTimeout).toBe(true);
+                expect((svc as any).reConnectOnRemoteDisconnect).toBe(true);
+                expect((svc as any).remoteDisconnectMaxRetries).toBe(3);
+                expect((svc as any).remoteDisconnectDelay).toBe(1);
+                expect((svc as any).remoteDisconnectMaxDelay).toBe(30);
+            });
+
+            test('honors custom overrides', () => {
+                const { svc } = makeSvc({
+                    reConnectOnSessionTimeout: false,
+                    reConnectOnRemoteDisconnect: false,
+                    remoteDisconnectMaxRetries: 5,
+                    remoteDisconnectDelay: 2,
+                    remoteDisconnectMaxDelay: 60
+                });
+                expect((svc as any).reConnectOnSessionTimeout).toBe(false);
+                expect((svc as any).reConnectOnRemoteDisconnect).toBe(false);
+                expect((svc as any).remoteDisconnectMaxRetries).toBe(5);
+                expect((svc as any).remoteDisconnectDelay).toBe(2);
+                expect((svc as any).remoteDisconnectMaxDelay).toBe(60);
+            });
+
+            test('canRetryRequest honors remoteDisconnectMaxRetries', () => {
+                const { svc } = makeSvc({ remoteDisconnectMaxRetries: 1 });
+                const cfg: any = {};
+                expect((svc as any).canRetryRequest(cfg)).toBe(true);
+                cfg._retryCount = 1;
+                expect((svc as any).canRetryRequest(cfg)).toBe(false);
+            });
+
+            test('retryRequest caps delay at remoteDisconnectMaxDelay', async () => {
+                jest.useFakeTimers();
+                const { svc, instance } = makeSvc({ remoteDisconnectDelay: 1, remoteDisconnectMaxDelay: 2 });
+                const axiosCallable = jest.fn().mockResolvedValue({ data: 'ok' });
+                (svc as any).axiosInstance = Object.assign(axiosCallable, instance);
+                const cfg: any = { _retryCount: 5 }; // large exponential term triggers the cap
+                const promise = (svc as any).retryRequest(cfg);
+                // Delay should be capped at 2000ms (remoteDisconnectMaxDelay), not 2^5 * 1000 = 32000ms
+                await jest.advanceTimersByTimeAsync(2000);
+                await promise;
+                expect(cfg._retryCount).toBe(6);
+                expect(axiosCallable).toHaveBeenCalledWith(cfg);
+                jest.useRealTimers();
+            });
+        });
     });
 });


### PR DESCRIPTION
Closes #81.

## Summary

Aligns `RestService` admin role checks, utility methods, and reconnect configuration with tm1py `RestService.py` to close the Phase 1 v2.0.0 parity gap:

- **Admin role caching & fast-path** — `is_admin` / `is_data_admin` / `is_security_admin` / `is_ops_admin` now use `CaseAndSpaceInsensitiveSet` for group comparison, share a single `/ActiveUser/Groups` fetch via `loadActiveUserRoles`, and dedupe concurrent callers via an in-flight promise. When the configured user matches `ADMIN` case-and-space-insensitively, all four caches are seeded `true` at construction — no HTTP round-trip needed. New sync `isAdmin` / `isDataAdmin` / `isSecurityAdmin` / `isOpsAdmin` getters expose the cached state for the duck-typed access in `ObjectService` (`ObjectService.ts:77-89`).
- **Utility methods** — adds `RestService.b64_decode_password`, `RestService.translate_to_boolean`, and instance `add_compact_json_header`. Signatures and behavior mirror tm1py `RestService.py:1012-1031` and `:1105-1114`.
- **Reconnect configuration** — adds `reConnectOnSessionTimeout` (default `true`), `reConnectOnRemoteDisconnect` (default `true`), `remoteDisconnectMaxRetries` (3), `remoteDisconnectDelay` (1s), `remoteDisconnectMaxDelay` (30s). Wired into the response interceptor so 401 re-auth and connection-error retries can be disabled, with capped exponential backoff.

Parity reference: tm1py `RestService.py:158-177` (reconnect + admin cache init), `:961-994` (admin getters).

## Test plan

- [x] `node_modules/.bin/tsc --noEmit` — no errors
- [x] `node_modules/.bin/jest src/tests/restService.test.ts` — 62/62 pass (19 new)
- [x] `node_modules/.bin/jest` full suite — 1304/1306 pass (the 2 failing suites are pre-existing credential-dependent integration tests unchanged by this PR)
- [x] ADMIN fast-path verified for `'ADMIN'`, `'admin'`, `'Admin'`, `' A D M I N '`
- [x] Concurrent `Promise.all([is_admin, is_data_admin, is_security_admin, is_ops_admin])` triggers exactly 1 HTTP call
- [x] Retry count / backoff cap / reconnect config defaults verified