### PR TITLE
feat(#80): RestService async request mode & rich HTTP methods

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,12 @@ All notable changes to this project are documented here.
   now the fourth parameter (after `poll_interval_seconds`) to preserve
   the pre-existing signature of callers passing a polling cadence.
 
+- **`getConnectionStats().timeout` is now in seconds** (was
+  `(config.timeout || 60) * 1000` i.e. milliseconds). Dashboards or
+  logging that compare the value against an ms threshold will need
+  updating.
+  - Migration: `stats.timeout / 1000` → `stats.timeout` (already seconds).
+
 ### Added
 
 - Central `_request()` dispatcher in `RestService` that routes to sync or
@@ -70,3 +76,14 @@ All notable changes to this project are documented here.
 - `retrieve_async_response` no longer throws on non-2xx statuses; it
   returns the raw `AxiosResponse` so the internal poller can retry on
   transient 404s (resource not yet materialized) without aborting.
+
+### Known Parity Gaps
+
+- **No `cancel_running_operation` / thread cancellation on sync
+  timeout.** tm1py's `request()` catches `Timeout` / `ConnectionError`
+  and calls `cancel_running_operation()` (which uses
+  `MonitoringService.cancel_thread()` to abort the server-side thread).
+  tm1npm cancels via `DELETE /_async('{id}')` in the async-polling path,
+  but has no top-level thread-cancellation fallback for sync-mode
+  timeouts or pre-202 async timeouts. Tracked for a future PR once
+  `MonitoringService.cancelThread` is implemented.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,59 @@
+# Changelog
+
+All notable changes to this project are documented here.
+
+## 2.0.0 — 2026-04-16
+
+### BREAKING CHANGES
+
+**RestService HTTP methods now use tm1py-parity semantics**
+(see [#80](https://github.com/KimKaoPoo/tm1npm/pull/95)).
+
+- **Timeout unit is seconds, not milliseconds.** `get/post/patch/put/delete`
+  now accept a `RequestOptions` object (extending `Omit<AxiosRequestConfig,
+  'timeout'>`) whose `timeout` is specified in seconds to match tm1py's
+  `RestService.request(timeout: float)`. The value is converted to
+  milliseconds internally before reaching Axios.
+  - Migration: `rest.get(url, { timeout: 30000 })` → `rest.get(url, { timeout: 30 })`.
+  - TypeScript will **not** flag the change because both old and new
+    values are `number`; audit call sites before upgrading.
+
+- **`retrieve_async_response` now returns the full `AxiosResponse`**
+  instead of `response.data`. This matches tm1py's `retrieve_async_response`
+  which returns `requests.Response`.
+  - Migration: `(await rest.retrieve_async_response(id)).Status` →
+    `(await rest.retrieve_async_response(id)).data.Status`.
+
+- **`get_async_operation_status` was removed.** The `/_async('{id}')`
+  endpoint does not expose a `Status` sub-resource, so the helper always
+  returned `'Unknown'` on real servers. Use `retrieve_async_response` and
+  inspect the response status instead.
+
+- **`wait_for_async_operation` parameter order.** `cancel_at_timeout` is
+  now the fourth parameter (after `poll_interval_seconds`) to preserve
+  the pre-existing signature of callers passing a polling cadence.
+
+### Added
+
+- Central `_request()` dispatcher in `RestService` that routes to sync or
+  async execution and honors new per-request options: `asyncRequestsMode`,
+  `returnAsyncId`, `cancelAtTimeout`, `timeout` (seconds), `idempotent`,
+  `verifyResponse`.
+- `_executeAsyncRequest` sends `Prefer: respond-async[,wait=55]`, parses
+  the `Location` header on `202 Accepted`, and polls `/_async('{id}')`
+  via `waitTimeGenerator` (exponential backoff capped at
+  `asyncPollingMaxDelay`).
+- `cancel_async_operation` and `retrieve_async_response` now target the
+  correct TM1 v12 endpoint `/_async('{id}')` (previously
+  `/AsyncOperations('{id}')`). `AsyncOperationService` updated to match.
+- `wait_for_async_operation` detects the `asyncresult` response header
+  and throws `TM1RestException` on non-2xx embedded status codes to
+  match tm1py's `_transform_async_response` semantics.
+
+### Changed
+
+- 5xx and network-level retries in the response interceptor now only
+  apply when the request is marked `idempotent: true` (default `true`
+  for GET, `false` for POST/PATCH/PUT/DELETE).
+- `verifyResponse: false` honors a caller-supplied `validateStatus`
+  instead of silently overwriting it.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,10 @@ All notable changes to this project are documented here.
   - Migration: `rest.get(url, { timeout: 30000 })` → `rest.get(url, { timeout: 30 })`.
   - TypeScript will **not** flag the change because both old and new
     values are `number`; audit call sites before upgrading.
+  - Heuristic to find likely millisecond-valued call sites:
+    ```
+    rg -n 'rest\.(get|post|patch|put|delete).*timeout:\s*\d{4,}' src/
+    ```
 
 - **`retrieve_async_response` now returns the full `AxiosResponse`**
   instead of `response.data`. This matches tm1py's `retrieve_async_response`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -61,3 +61,12 @@ All notable changes to this project are documented here.
   for GET, `false` for POST/PATCH/PUT/DELETE).
 - `verifyResponse: false` honors a caller-supplied `validateStatus`
   instead of silently overwriting it.
+- `AsyncOperationService.createAsyncOperation` now marks returned
+  operations with `trackedLocally: true` so `getAsyncOperationStatus`
+  reads from the in-memory cache instead of polling `/_async('{id}')`
+  with a client-side UUID (which the server does not recognize).
+  `ProcessService.executeWithReturnAsync` / `pollProcessExecution`
+  depend on this behavior for their background-resolve pattern.
+- `retrieve_async_response` no longer throws on non-2xx statuses; it
+  returns the raw `AxiosResponse` so the internal poller can retry on
+  transient 404s (resource not yet materialized) without aborting.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tm1npm",
-  "version": "1.6.0",
+  "version": "2.0.0",
   "description": "A Node.js module for TM1",
   "main": "lib/index.js",
   "types": "lib/index.d.ts",

--- a/src/services/ApplicationService.ts
+++ b/src/services/ApplicationService.ts
@@ -1,4 +1,4 @@
-import { AxiosRequestConfig, AxiosResponse } from 'axios';
+import { AxiosResponse } from 'axios';
 import { promises as fs } from 'fs';
 import { RestService } from './RestService';
 import { ObjectService } from './ObjectService';
@@ -152,7 +152,7 @@ export class ApplicationService extends ObjectService {
             requestName
         );
 
-        const arrayBufferResponse = await this.rest.get(contentUrl, { responseType: 'arraybuffer' } as AxiosRequestConfig);
+        const arrayBufferResponse = await this.rest.get(contentUrl, { responseType: 'arraybuffer' });
         const metadataResponse = await this.rest.get(metadataUrl);
 
         const buffer = Buffer.from(arrayBufferResponse.data);
@@ -183,7 +183,7 @@ export class ApplicationService extends ObjectService {
             );
             await this.rest.put(contentUrl, application.content, {
                 headers: this.binaryHttpHeader
-            } as AxiosRequestConfig);
+            });
         }
 
         return response;
@@ -204,7 +204,7 @@ export class ApplicationService extends ObjectService {
             );
             return await this.rest.post(url, application.content, {
                 headers: this.binaryHttpHeader
-            } as AxiosRequestConfig);
+            });
         }
 
         const url = formatUrl(

--- a/src/services/AsyncOperationService.ts
+++ b/src/services/AsyncOperationService.ts
@@ -149,6 +149,9 @@ export class AsyncOperationService {
         } catch (error: any) {
             // HTTP 4xx/5xx surfaces as a thrown TM1RestException — treat as a terminal FAILED
             // so callers stop polling. Network errors (no status) leave cached status intact.
+            // Note: 404 is treated as FAILED here (operation never materialized). This differs
+            // from ProcessService.pollExecuteWithReturn which treats 404 as "not ready yet"
+            // because process async IDs can take a moment to register on the server.
             const status = error?.status ?? error?.response?.status;
             if (typeof status === 'number' && status >= 400) {
                 operation.status = OperationStatus.FAILED;

--- a/src/services/AsyncOperationService.ts
+++ b/src/services/AsyncOperationService.ts
@@ -113,28 +113,68 @@ export class AsyncOperationService {
             return operation.status;
         }
 
-        // Poll TM1 server for updated status
+        // Poll TM1 server for updated status. /_async('{id}') returns 202 while
+        // the op is pending, and 200/201 with the final operation payload once done.
+        // TM1 v12 may encode embedded failures in the `asyncresult` response header.
         try {
             const url = formatUrl("/_async('{}')", operationId);
             const response = await this.rest.get(url);
-            const serverStatus = this.mapServerStatus(response.data.Status);
+            const serverStatus = this.deriveStatusFromResponse(response);
 
-            // Update operation status
             operation.status = serverStatus;
             if (this.isTerminalStatus(serverStatus)) {
                 operation.endTime = new Date();
-                if (serverStatus === OperationStatus.COMPLETED && response.data.Result) {
-                    operation.result = response.data.Result;
-                } else if (serverStatus === OperationStatus.FAILED && response.data.Error) {
-                    operation.error = response.data.Error;
+                if (serverStatus === OperationStatus.COMPLETED) {
+                    operation.result = response.data;
+                } else if (serverStatus === OperationStatus.FAILED) {
+                    operation.error = this.extractErrorFromResponse(response);
                 }
             }
 
             return serverStatus;
-        } catch (error) {
-            // If server doesn't support AsyncOperations endpoint, return cached status
+        } catch (error: any) {
+            // HTTP 4xx/5xx surfaces as a thrown TM1RestException — treat as a terminal FAILED
+            // so callers stop polling. Network errors (no status) leave cached status intact.
+            const status = error?.status ?? error?.response?.status;
+            if (typeof status === 'number' && status >= 400) {
+                operation.status = OperationStatus.FAILED;
+                operation.endTime = new Date();
+                operation.error = error?.message ?? String(error);
+                return OperationStatus.FAILED;
+            }
             return operation.status;
         }
+    }
+
+    private deriveStatusFromResponse(response: any): OperationStatus {
+        if (response.status === 202) {
+            return OperationStatus.RUNNING;
+        }
+        const asyncResult = response.headers?.['asyncresult'] ?? response.headers?.['AsyncResult'];
+        if (typeof asyncResult === 'string') {
+            const embedded = parseInt(asyncResult.trim().split(/\s+/)[0], 10);
+            if (!Number.isNaN(embedded) && (embedded < 200 || embedded >= 300)) {
+                return OperationStatus.FAILED;
+            }
+        }
+        if (response.status === 200 || response.status === 201) {
+            return OperationStatus.COMPLETED;
+        }
+        return OperationStatus.PENDING;
+    }
+
+    private extractErrorFromResponse(response: any): string {
+        const asyncResult = response.headers?.['asyncresult'] ?? response.headers?.['AsyncResult'];
+        if (typeof asyncResult === 'string') {
+            return asyncResult;
+        }
+        if (typeof response.data === 'string') {
+            return response.data;
+        }
+        if (response.data?.error?.message) {
+            return response.data.error.message;
+        }
+        return JSON.stringify(response.data);
     }
 
     /**

--- a/src/services/AsyncOperationService.ts
+++ b/src/services/AsyncOperationService.ts
@@ -52,6 +52,12 @@ export interface AsyncOperation {
     result?: any;
     parameters?: Record<string, any>;
     metadata?: Record<string, any>;
+    /**
+     * When true, the operation is tracked with a client-side UUID and the
+     * TM1 server has no record of it. `getAsyncOperationStatus` returns the
+     * cached status instead of polling `/_async('{id}')`.
+     */
+    trackedLocally?: boolean;
 }
 
 /**
@@ -110,6 +116,14 @@ export class AsyncOperationService {
 
         // If operation is already in terminal state, return cached status
         if (this.isTerminalStatus(operation.status)) {
+            return operation.status;
+        }
+
+        // Locally tracked operations hold a client-side UUID; the TM1 server
+        // would return 404 for them. Rely on the in-memory cache, which is
+        // populated by background .then()/.catch() callbacks in helpers like
+        // ProcessService.executeWithReturnAsync.
+        if (operation.trackedLocally) {
             return operation.status;
         }
 
@@ -283,6 +297,9 @@ export class AsyncOperationService {
     public async createAsyncOperation(definition: AsyncOperationDefinition): Promise<string> {
         const operationId = this.generateOperationId();
 
+        // generateOperationId produces a client-side UUID; the server has no
+        // record of it, so polling /_async('{id}') would 404. Mark as locally
+        // tracked so getAsyncOperationStatus returns the cached status instead.
         const operation: AsyncOperation = {
             id: operationId,
             type: definition.type,
@@ -290,7 +307,8 @@ export class AsyncOperationService {
             status: OperationStatus.PENDING,
             startTime: new Date(),
             parameters: definition.parameters,
-            metadata: definition.metadata
+            metadata: definition.metadata,
+            trackedLocally: true
         };
 
         this.operations.set(operationId, operation);
@@ -480,19 +498,6 @@ export class AsyncOperationService {
                status === OperationStatus.FAILED ||
                status === OperationStatus.CANCELLED ||
                status === OperationStatus.TIMEOUT;
-    }
-
-    private mapServerStatus(serverStatus: string): OperationStatus {
-        const statusMap: Record<string, OperationStatus> = {
-            'Pending': OperationStatus.PENDING,
-            'Running': OperationStatus.RUNNING,
-            'CompletedSuccessfully': OperationStatus.COMPLETED,
-            'CompletedWithErrors': OperationStatus.FAILED,
-            'Cancelled': OperationStatus.CANCELLED,
-            'Timeout': OperationStatus.TIMEOUT
-        };
-
-        return statusMap[serverStatus] || OperationStatus.PENDING;
     }
 
     private stopPolling(operationId: string): void {

--- a/src/services/AsyncOperationService.ts
+++ b/src/services/AsyncOperationService.ts
@@ -164,7 +164,7 @@ export class AsyncOperationService {
         if (response.status === 202) {
             return OperationStatus.RUNNING;
         }
-        const asyncResult = response.headers?.['asyncresult'] ?? response.headers?.['AsyncResult'];
+        const asyncResult = response.headers?.['asyncresult'];
         if (typeof asyncResult === 'string') {
             const embedded = parseInt(asyncResult.trim().split(/\s+/)[0], 10);
             if (!Number.isNaN(embedded) && (embedded < 200 || embedded >= 300)) {
@@ -178,7 +178,7 @@ export class AsyncOperationService {
     }
 
     private extractErrorFromResponse(response: any): string {
-        const asyncResult = response.headers?.['asyncresult'] ?? response.headers?.['AsyncResult'];
+        const asyncResult = response.headers?.['asyncresult'];
         if (typeof asyncResult === 'string') {
             return asyncResult;
         }

--- a/src/services/AsyncOperationService.ts
+++ b/src/services/AsyncOperationService.ts
@@ -132,7 +132,7 @@ export class AsyncOperationService {
         // TM1 v12 may encode embedded failures in the `asyncresult` response header.
         try {
             const url = formatUrl("/_async('{}')", operationId);
-            const response = await this.rest.get(url);
+            const response = await this.rest.get(url, { asyncRequestsMode: false });
             const serverStatus = this.deriveStatusFromResponse(response);
 
             operation.status = serverStatus;
@@ -232,11 +232,10 @@ export class AsyncOperationService {
         this.stopPolling(operationId);
 
         try {
-            // Try to cancel on server if supported
             const url = formatUrl("/_async('{}')", operationId);
-            await this.rest.delete(url);
+            await this.rest.delete(url, { asyncRequestsMode: false });
         } catch (error) {
-            // If server doesn't support cancellation, just mark as cancelled locally
+            console.warn(`Failed to cancel async operation ${operationId} on server:`, error);
         }
 
         // Update operation status

--- a/src/services/AsyncOperationService.ts
+++ b/src/services/AsyncOperationService.ts
@@ -115,7 +115,7 @@ export class AsyncOperationService {
 
         // Poll TM1 server for updated status
         try {
-            const url = formatUrl("/AsyncOperations('{}')", operationId);
+            const url = formatUrl("/_async('{}')", operationId);
             const response = await this.rest.get(url);
             const serverStatus = this.mapServerStatus(response.data.Status);
 
@@ -179,8 +179,8 @@ export class AsyncOperationService {
 
         try {
             // Try to cancel on server if supported
-            const url = formatUrl("/AsyncOperations('{}')/Cancel", operationId);
-            await this.rest.post(url, {});
+            const url = formatUrl("/_async('{}')", operationId);
+            await this.rest.delete(url);
         } catch (error) {
             // If server doesn't support cancellation, just mark as cancelled locally
         }

--- a/src/services/FileService.ts
+++ b/src/services/FileService.ts
@@ -1,6 +1,6 @@
 import path from 'path';
-import { AxiosRequestConfig, AxiosResponse } from 'axios';
-import { RestService } from './RestService';
+import { AxiosResponse } from 'axios';
+import { RequestOptions, RestService } from './RestService';
 import { ObjectService } from './ObjectService';
 import { verifyVersion } from '../utils/Utils';
 
@@ -227,7 +227,7 @@ export class FileService extends ObjectService {
     }
 
     private async uploadFileContentWithoutMpu(url: string, content: Buffer): Promise<AxiosResponse> {
-        const config: AxiosRequestConfig = {
+        const config: RequestOptions = {
             headers: this.binaryHttpHeader
         };
         return await this.rest.put(url, content, config);

--- a/src/services/ProcessService.ts
+++ b/src/services/ProcessService.ts
@@ -1,6 +1,6 @@
 import { AxiosResponse } from 'axios';
 import { v4 as uuidv4 } from 'uuid';
-import { RestService } from './RestService';
+import { RequestOptions, RestService } from './RestService';
 import { ObjectService } from './ObjectService';
 import { Process } from '../objects/Process';
 import { ProcessDebugBreakpoint, BreakPointType, HitMode } from '../objects/ProcessDebugBreakpoint';
@@ -208,9 +208,9 @@ export class ProcessService extends ObjectService {
             }));
         }
 
-        const config: any = {};
+        const config: RequestOptions = {};
         if (timeout) {
-            config.timeout = timeout * 1000;
+            config.timeout = timeout;
         }
 
         return await this.rest.post(url, JSON.stringify(body), config);
@@ -249,7 +249,7 @@ export class ProcessService extends ObjectService {
             const response = await this.rest.retrieve_async_response(asyncId);
             // TODO: tm1py handles TM1 < v11 binary-wrapped responses via
             // build_response_from_binary_response. Add support if needed.
-            return this._executeWithReturnParseResponse(response);
+            return this._executeWithReturnParseResponse(response.data);
         } catch (error: any) {
             // Return null for HTTP 202 (accepted/pending) or 404 (not found yet)
             const status = error?.status ?? error?.response?.status;
@@ -681,9 +681,9 @@ export class ProcessService extends ObjectService {
             }));
         }
 
-        const config: any = {};
+        const config: RequestOptions = {};
         if (timeout) {
-            config.timeout = timeout * 1000;
+            config.timeout = timeout;
         }
 
         const response = await this.rest.post(url, JSON.stringify(body), config);

--- a/src/services/ProcessService.ts
+++ b/src/services/ProcessService.ts
@@ -247,13 +247,16 @@ export class ProcessService extends ObjectService {
     public async pollExecuteWithReturn(asyncId: string): Promise<[boolean, string, string | null] | null> {
         try {
             const response = await this.rest.retrieve_async_response(asyncId);
+            // tm1py returns None while the async op is still in-flight (status 202).
+            if (response.status !== 200 && response.status !== 201) {
+                return null;
+            }
             // TODO: tm1py handles TM1 < v11 binary-wrapped responses via
             // build_response_from_binary_response. Add support if needed.
             return this._executeWithReturnParseResponse(response.data);
         } catch (error: any) {
-            // Return null for HTTP 202 (accepted/pending) or 404 (not found yet)
             const status = error?.status ?? error?.response?.status;
-            if (status === 202 || status === 404) {
+            if (status === 404) {
                 return null;
             }
             throw error;

--- a/src/services/ProcessService.ts
+++ b/src/services/ProcessService.ts
@@ -255,6 +255,9 @@ export class ProcessService extends ObjectService {
             // build_response_from_binary_response. Add support if needed.
             return this._executeWithReturnParseResponse(response.data);
         } catch (error: any) {
+            // 404 means the async resource hasn't materialized yet — return null
+            // so the caller can retry. This differs from AsyncOperationService
+            // which treats 404 as terminal FAILED for locally-tracked operations.
             const status = error?.status ?? error?.response?.status;
             if (status === 404) {
                 return null;

--- a/src/services/RestService.ts
+++ b/src/services/RestService.ts
@@ -371,12 +371,12 @@ export class RestService {
         const verifyResponse = options?.verifyResponse ?? true;
         const idempotent = options?.idempotent ?? false;
         const {
-            asyncRequestsMode,
+            asyncRequestsMode: _asyncModeOpt,
             returnAsyncId,
-            cancelAtTimeout: _cancelAtTimeout,
-            idempotent: _idempotent,
-            verifyResponse: _verifyResponse,
-            timeout: _timeout,
+            cancelAtTimeout: _cancelAtTimeoutOpt,
+            idempotent: _idempotentOpt,
+            verifyResponse: _verifyResponseOpt,
+            timeout: _timeoutOpt,
             ...axiosExtras
         } = options ?? {};
 

--- a/src/services/RestService.ts
+++ b/src/services/RestService.ts
@@ -28,6 +28,9 @@ export interface RestServiceConfig {
     timeout?: number;
     cancelAtTimeout?: boolean;
     asyncRequestsMode?: boolean;
+    asyncPollingInitialDelay?: number;
+    asyncPollingMaxDelay?: number;
+    asyncPollingBackoffFactor?: number;
     connectionPoolSize?: number;
     poolConnections?: number;
     instance?: string;
@@ -39,6 +42,15 @@ export interface RestServiceConfig {
     apiKey?: string;
     accessToken?: string;
     tenant?: string;
+}
+
+export interface RequestOptions extends Omit<AxiosRequestConfig, 'timeout'> {
+    asyncRequestsMode?: boolean;
+    returnAsyncId?: boolean;
+    timeout?: number;
+    cancelAtTimeout?: boolean;
+    idempotent?: boolean;
+    verifyResponse?: boolean;
 }
 
 export class RestService {
@@ -59,6 +71,12 @@ export class RestService {
     private sandboxName?: string;
     private isConnected: boolean = false;
     private _serverVersion?: string;
+    private _asyncRequestsMode: boolean;
+    private _cancelAtTimeout: boolean;
+    private _timeout: number;
+    private _asyncPollingInitialDelay: number;
+    private _asyncPollingMaxDelay: number;
+    private _asyncPollingBackoffFactor: number;
 
     public get version(): string | undefined {
         return this._serverVersion;
@@ -66,6 +84,12 @@ export class RestService {
 
     constructor(config: RestServiceConfig) {
         this.config = { ...config };
+        this._asyncRequestsMode = config.asyncRequestsMode ?? false;
+        this._cancelAtTimeout = config.cancelAtTimeout ?? false;
+        this._timeout = config.timeout ?? 60;
+        this._asyncPollingInitialDelay = config.asyncPollingInitialDelay ?? 0.1;
+        this._asyncPollingMaxDelay = config.asyncPollingMaxDelay ?? 1.0;
+        this._asyncPollingBackoffFactor = config.asyncPollingBackoffFactor ?? 2.0;
         this.setupAxiosInstance();
     }
 
@@ -74,7 +98,7 @@ export class RestService {
         
         this.axiosInstance = axios.create({
             baseURL,
-            timeout: (this.config.timeout || 60) * 1000,
+            timeout: this._timeout * 1000,
             headers: {
                 ...RestService.HEADERS,
                 ...(this.config.sessionContext && { 'TM1-SessionContext': this.config.sessionContext })
@@ -118,12 +142,12 @@ export class RestService {
                 const originalRequest = error.config;
 
                 // Handle timeout errors
-                if (error.code === 'ECONNABORTED' || error.message.includes('timeout')) {
+                if (error.code === 'ECONNABORTED' || error.message?.includes?.('timeout')) {
                     throw new TM1TimeoutException(`Request timeout: ${error.message}`);
                 }
 
                 // Handle authentication errors with retry
-                if (error.response?.status === 401 && !originalRequest._retry) {
+                if (error.response?.status === 401 && originalRequest && !originalRequest._retry) {
                     originalRequest._retry = true;
 
                     try {
@@ -144,7 +168,7 @@ export class RestService {
                 }
 
                 // Handle connection errors with retry
-                if (this.shouldRetryRequest(error) && this.canRetryRequest(originalRequest)) {
+                if (originalRequest && this.shouldRetryRequest(error) && this.canRetryRequest(originalRequest)) {
                     return this.retryRequest(originalRequest);
                 }
 
@@ -175,6 +199,9 @@ export class RestService {
      * Check if a request can be retried
      */
     private canRetryRequest(config: any): boolean {
+        if (config._idempotent === false) {
+            return false;
+        }
         // Don't retry if already retried maximum times
         config._retryCount = config._retryCount || 0;
         return config._retryCount < 3;
@@ -205,6 +232,172 @@ export class RestService {
         } catch {
             return `HTTP ${response.status}: ${response.statusText}`;
         }
+    }
+
+    private *waitTimeGenerator(timeout: number): Generator<number> {
+        let delay = this._asyncPollingInitialDelay;
+        let elapsed = 0;
+
+        if (timeout) {
+            while (elapsed < timeout) {
+                yield delay;
+                elapsed += delay;
+                delay = Math.min(delay * this._asyncPollingBackoffFactor, this._asyncPollingMaxDelay);
+            }
+        } else {
+            while (true) {
+                yield delay;
+                delay = Math.min(delay * this._asyncPollingBackoffFactor, this._asyncPollingMaxDelay);
+            }
+        }
+    }
+
+    private async _executeSyncRequest(
+        method: string,
+        url: string,
+        data?: any,
+        timeout?: number,
+        idempotent?: boolean,
+        axiosExtras?: Partial<AxiosRequestConfig>
+    ): Promise<AxiosResponse> {
+        const config: AxiosRequestConfig = {
+            method: method as AxiosRequestConfig['method'],
+            url,
+            data,
+            ...axiosExtras
+        };
+
+        if (timeout !== undefined) {
+            config.timeout = timeout * 1000;
+        }
+
+        (config as any)._idempotent = idempotent ?? false;
+
+        return this.axiosInstance.request(config);
+    }
+
+    private async _executeAsyncRequest(
+        method: string,
+        url: string,
+        data?: any,
+        timeout?: number,
+        cancelAtTimeout?: boolean,
+        returnAsyncId?: boolean,
+        idempotent?: boolean,
+        axiosExtras?: Partial<AxiosRequestConfig>
+    ): Promise<AxiosResponse | string> {
+        const preferValue = returnAsyncId ? 'respond-async' : 'respond-async,wait=55';
+        const config: AxiosRequestConfig = {
+            method: method as AxiosRequestConfig['method'],
+            url,
+            data,
+            ...axiosExtras,
+            headers: {
+                ...axiosExtras?.headers,
+                Prefer: preferValue
+            }
+        };
+
+        if (timeout !== undefined) {
+            config.timeout = timeout * 1000;
+        }
+
+        (config as any)._idempotent = idempotent ?? false;
+
+        const response = await this.axiosInstance.request(config);
+
+        if (response.status !== 202) {
+            return response;
+        }
+
+        const location = response.headers['location'] || response.headers['Location'] || '';
+        const asyncId = typeof location === 'string' ? location.split("'")[1] : undefined;
+
+        if (!asyncId) {
+            throw new TM1RestException(
+                `Async request returned 202 but no valid async ID in Location header: ${location}`
+            );
+        }
+
+        if (returnAsyncId) {
+            return asyncId;
+        }
+
+        return this._pollAsyncResponse(
+            asyncId,
+            timeout ?? this._timeout,
+            cancelAtTimeout ?? this._cancelAtTimeout
+        );
+    }
+
+    private async _pollAsyncResponse(
+        asyncId: string,
+        timeout: number,
+        cancelAtTimeout: boolean
+    ): Promise<AxiosResponse> {
+        for (const wait of this.waitTimeGenerator(timeout)) {
+            const response = await this.axiosInstance.get(`/_async('${asyncId}')`);
+
+            if (response.status === 200 || response.status === 201) {
+                return response;
+            }
+
+            await new Promise(resolve => setTimeout(resolve, wait * 1000));
+        }
+
+        if (cancelAtTimeout) {
+            try {
+                await this.axiosInstance.delete(`/_async('${asyncId}')`);
+            } catch {
+                // Best-effort cancellation on timeout.
+            }
+        }
+
+        throw new TM1TimeoutException(
+            `Async operation ${asyncId} timed out after ${timeout} seconds`,
+            timeout
+        );
+    }
+
+    private async _request(
+        method: string,
+        url: string,
+        data?: any,
+        options?: RequestOptions
+    ): Promise<AxiosResponse | string> {
+        const timeout = options?.timeout ?? this._timeout;
+        const cancelAtTimeout = options?.cancelAtTimeout ?? this._cancelAtTimeout;
+        const asyncMode = options?.returnAsyncId || (options?.asyncRequestsMode ?? this._asyncRequestsMode);
+        const verifyResponse = options?.verifyResponse ?? true;
+        const idempotent = options?.idempotent ?? false;
+        const {
+            asyncRequestsMode,
+            returnAsyncId,
+            cancelAtTimeout: _cancelAtTimeout,
+            idempotent: _idempotent,
+            verifyResponse: _verifyResponse,
+            timeout: _timeout,
+            ...axiosExtras
+        } = options ?? {};
+
+        if (!verifyResponse) {
+            axiosExtras.validateStatus = () => true;
+        }
+
+        if (asyncMode) {
+            return this._executeAsyncRequest(
+                method,
+                url,
+                data,
+                timeout,
+                cancelAtTimeout,
+                returnAsyncId,
+                idempotent,
+                axiosExtras
+            );
+        }
+
+        return this._executeSyncRequest(method, url, data, timeout, idempotent, axiosExtras);
     }
 
     public async connect(): Promise<void> {
@@ -245,24 +438,34 @@ export class RestService {
         }
     }
 
-    public async get(url: string, config?: AxiosRequestConfig): Promise<AxiosResponse> {
-        return this.axiosInstance.get(url, config);
+    public async get(url: string, options: RequestOptions & { returnAsyncId: true }): Promise<string>;
+    public async get(url: string, options?: RequestOptions): Promise<AxiosResponse>;
+    public async get(url: string, options?: RequestOptions): Promise<AxiosResponse | string> {
+        return this._request('GET', url, undefined, { idempotent: true, ...options });
     }
 
-    public async post(url: string, data?: any, config?: AxiosRequestConfig): Promise<AxiosResponse> {
-        return this.axiosInstance.post(url, data, config);
+    public async post(url: string, data: any, options: RequestOptions & { returnAsyncId: true }): Promise<string>;
+    public async post(url: string, data?: any, options?: RequestOptions): Promise<AxiosResponse>;
+    public async post(url: string, data?: any, options?: RequestOptions): Promise<AxiosResponse | string> {
+        return this._request('POST', url, data, options);
     }
 
-    public async patch(url: string, data?: any, config?: AxiosRequestConfig): Promise<AxiosResponse> {
-        return this.axiosInstance.patch(url, data, config);
+    public async patch(url: string, data: any, options: RequestOptions & { returnAsyncId: true }): Promise<string>;
+    public async patch(url: string, data?: any, options?: RequestOptions): Promise<AxiosResponse>;
+    public async patch(url: string, data?: any, options?: RequestOptions): Promise<AxiosResponse | string> {
+        return this._request('PATCH', url, data, options);
     }
 
-    public async put(url: string, data?: any, config?: AxiosRequestConfig): Promise<AxiosResponse> {
-        return this.axiosInstance.put(url, data, config);
+    public async put(url: string, data: any, options: RequestOptions & { returnAsyncId: true }): Promise<string>;
+    public async put(url: string, data?: any, options?: RequestOptions): Promise<AxiosResponse>;
+    public async put(url: string, data?: any, options?: RequestOptions): Promise<AxiosResponse | string> {
+        return this._request('PUT', url, data, options);
     }
 
-    public async delete(url: string, config?: AxiosRequestConfig): Promise<AxiosResponse> {
-        return this.axiosInstance.delete(url, config);
+    public async delete(url: string, options: RequestOptions & { returnAsyncId: true }): Promise<string>;
+    public async delete(url: string, options?: RequestOptions): Promise<AxiosResponse>;
+    public async delete(url: string, options?: RequestOptions): Promise<AxiosResponse | string> {
+        return this._request('DELETE', url, undefined, options);
     }
 
     public getSessionId(): string | undefined {
@@ -516,7 +719,7 @@ export class RestService {
             sessionId: this.sessionId,
             authMode: this.getAuthenticationMode(),
             baseUrl: this.buildBaseUrl(),
-            timeout: (this.config.timeout || 60) * 1000,
+            timeout: this._timeout,
             sandbox: this.sandboxName
         };
     }
@@ -738,47 +941,22 @@ export class RestService {
      * Cancel an async operation by ID
      */
     public async cancel_async_operation(async_id: string): Promise<void> {
-        try {
-            await this.post(`/AsyncOperations('${async_id}')/tm1.Cancel`);
-        } catch (error) {
-            throw new TM1RestException(`Failed to cancel async operation ${async_id}: ${error}`);
-        }
+        await this.delete(`/_async('${async_id}')`, { asyncRequestsMode: false });
     }
 
     /**
      * Retrieve async operation response
      */
-    public async retrieve_async_response(async_id: string): Promise<any> {
-        try {
-            const response = await this.get(`/AsyncOperations('${async_id}')`);
-            // Axios treats 2xx as success, but 202 means the operation is still running
-            if (response.status === 202) {
-                throw new TM1RestException('Async operation still running', 202, response);
-            }
-            return response.data;
-        } catch (error: any) {
-            if (error instanceof TM1RestException) {
-                throw error;
-            }
-            const status = error?.status ?? error?.response?.status;
-            throw new TM1RestException(
-                `Failed to retrieve async response ${async_id}: ${error}`,
-                status,
-                error?.response
-            );
-        }
+    public async retrieve_async_response(async_id: string): Promise<AxiosResponse> {
+        return this.get(`/_async('${async_id}')`, { asyncRequestsMode: false }) as Promise<AxiosResponse>;
     }
 
     /**
      * Get async operation status
      */
     public async get_async_operation_status(async_id: string): Promise<string> {
-        try {
-            const response = await this.get(`/AsyncOperations('${async_id}')/Status/$value`);
-            return response.data;
-        } catch (error) {
-            throw new TM1RestException(`Failed to get async operation status ${async_id}: ${error}`);
-        }
+        const response = await this.retrieve_async_response(async_id);
+        return response.data?.Status || 'Unknown';
     }
 
     /**
@@ -787,29 +965,10 @@ export class RestService {
     public async wait_for_async_operation(
         async_id: string,
         timeout_seconds: number = 300,
-        poll_interval_seconds: number = 1
+        cancel_at_timeout: boolean = false
     ): Promise<any> {
-        const start_time = Date.now();
-        const timeout_ms = timeout_seconds * 1000;
-        const poll_interval_ms = poll_interval_seconds * 1000;
-
-        while (Date.now() - start_time < timeout_ms) {
-            const status = await this.get_async_operation_status(async_id);
-
-            if (status === 'Completed' || status === 'CompletedSuccessfully') {
-                return await this.retrieve_async_response(async_id);
-            }
-
-            if (status === 'Failed' || status === 'CompletedWithError') {
-                const response = await this.retrieve_async_response(async_id);
-                throw new TM1RestException(`Async operation failed: ${JSON.stringify(response)}`);
-            }
-
-            // Wait before polling again
-            await new Promise(resolve => setTimeout(resolve, poll_interval_ms));
-        }
-
-        throw new TM1TimeoutException(`Async operation ${async_id} timed out after ${timeout_seconds} seconds`);
+        const response = await this._pollAsyncResponse(async_id, timeout_seconds, cancel_at_timeout);
+        return response.data;
     }
 
     /**

--- a/src/services/RestService.ts
+++ b/src/services/RestService.ts
@@ -404,6 +404,7 @@ export class RestService {
             const response = await this.retrieve_async_response(asyncId);
 
             if (response.status === 200 || response.status === 201) {
+                this.verifyAsyncResultHeader(response);
                 return response;
             }
 

--- a/src/services/RestService.ts
+++ b/src/services/RestService.ts
@@ -539,6 +539,9 @@ export class RestService {
         const response = await this.axiosInstance.request(config);
 
         if (response.status !== 202) {
+            // Server completed synchronously. If the caller asked for an async
+            // ID (returnAsyncId: true) there is none to return — hand back the
+            // full response so the caller can inspect the result directly.
             return response;
         }
 

--- a/src/services/RestService.ts
+++ b/src/services/RestService.ts
@@ -1,5 +1,6 @@
 import axios, { AxiosInstance, AxiosResponse, AxiosRequestConfig } from 'axios';
 import { TM1RestException, TM1TimeoutException } from '../exceptions/TM1Exception';
+import { formatUrl } from '../utils/Utils';
 
 export enum AuthenticationMode {
     BASIC = 1,
@@ -431,7 +432,7 @@ export class RestService {
         data?: any,
         options?: RequestOptions
     ): Promise<AxiosResponse | string> {
-        const timeout = options?.timeout || this._timeout;
+        const timeout = options?.timeout ?? this._timeout;
         const cancelAtTimeout = options?.cancelAtTimeout ?? this._cancelAtTimeout;
         const asyncMode = options?.returnAsyncId || (options?.asyncRequestsMode ?? this._asyncRequestsMode);
         const verifyResponse = options?.verifyResponse ?? true;
@@ -549,7 +550,10 @@ export class RestService {
     }
 
     public isLoggedIn(): boolean {
-        return this.isConnected && !!this.getSessionCookieValue();
+        return this.isConnected && (
+            !!this.getSessionCookieValue() ||
+            !!this.axiosInstance.defaults.headers.common['Authorization']
+        );
     }
 
     public async getApiMetadata(): Promise<any> {
@@ -887,7 +891,10 @@ export class RestService {
      * Check if currently connected to TM1
      */
     public is_connected(): boolean {
-        return this.isConnected && !!this.getSessionCookieValue();
+        return this.isConnected && (
+            !!this.getSessionCookieValue() ||
+            !!this.axiosInstance.defaults.headers.common['Authorization']
+        );
     }
 
     /**
@@ -1007,7 +1014,7 @@ export class RestService {
      * Cancel an async operation by ID
      */
     public async cancel_async_operation(async_id: string): Promise<void> {
-        await this.delete(`/_async('${async_id}')`, { asyncRequestsMode: false });
+        await this.delete(formatUrl("/_async('{}')", async_id), { asyncRequestsMode: false });
     }
 
     /**
@@ -1019,7 +1026,7 @@ export class RestService {
         // on status_code in [200, 201]. Mirror that: accept all statuses so
         // transient 404s (resource not yet materialized) or 202s (still
         // running) flow through to the polling loop rather than aborting it.
-        return this.get(`/_async('${async_id}')`, {
+        return this.get(formatUrl("/_async('{}')", async_id), {
             asyncRequestsMode: false,
             verifyResponse: false,
             validateStatus: () => true

--- a/src/services/RestService.ts
+++ b/src/services/RestService.ts
@@ -348,8 +348,8 @@ export class RestService {
         if (cancelAtTimeout) {
             try {
                 await this.cancel_async_operation(asyncId);
-            } catch {
-                // Best-effort cancellation on timeout.
+            } catch (cancelError) {
+                console.warn(`Failed to cancel async operation ${asyncId} at timeout:`, cancelError);
             }
         }
 
@@ -380,7 +380,7 @@ export class RestService {
             ...axiosExtras
         } = options ?? {};
 
-        if (!verifyResponse) {
+        if (!verifyResponse && axiosExtras.validateStatus === undefined) {
             axiosExtras.validateStatus = () => true;
         }
 
@@ -961,12 +961,19 @@ export class RestService {
 
     /**
      * Wait for async operation to complete
+     *
+     * @param poll_interval_seconds Retained for backward compatibility.
+     *   The internal polling cadence is owned by {@link waitTimeGenerator}
+     *   (exponential backoff capped at async_polling_max_delay), so this
+     *   value is ignored.
      */
     public async wait_for_async_operation(
         async_id: string,
         timeout_seconds: number = 300,
+        poll_interval_seconds: number = 1,
         cancel_at_timeout: boolean = false
     ): Promise<any> {
+        void poll_interval_seconds;
         const response = await this._pollAsyncResponse(async_id, timeout_seconds, cancel_at_timeout);
         return response.data;
     }

--- a/src/services/RestService.ts
+++ b/src/services/RestService.ts
@@ -311,7 +311,8 @@ export class RestService {
         }
 
         const location = response.headers['location'] || response.headers['Location'] || '';
-        const asyncId = typeof location === 'string' ? location.split("'")[1] : undefined;
+        const match = typeof location === 'string' ? location.match(/\('([^']+)'\)/) : null;
+        const asyncId = match ? match[1] : undefined;
 
         if (!asyncId) {
             throw new TM1RestException(
@@ -365,7 +366,7 @@ export class RestService {
         data?: any,
         options?: RequestOptions
     ): Promise<AxiosResponse | string> {
-        const timeout = options?.timeout ?? this._timeout;
+        const timeout = options?.timeout || this._timeout;
         const cancelAtTimeout = options?.cancelAtTimeout ?? this._cancelAtTimeout;
         const asyncMode = options?.returnAsyncId || (options?.asyncRequestsMode ?? this._asyncRequestsMode);
         const verifyResponse = options?.verifyResponse ?? true;
@@ -438,6 +439,12 @@ export class RestService {
         }
     }
 
+    /**
+     * When `returnAsyncId: true`, the caller receives the async id string
+     * iff the server returns `202 Accepted`. If TM1 short-circuits with
+     * `200/201`, the full `AxiosResponse` is returned instead — the
+     * declared `Promise<string>` return type is a best-effort narrowing.
+     */
     public async get(url: string, options: RequestOptions & { returnAsyncId: true }): Promise<string>;
     public async get(url: string, options?: RequestOptions): Promise<AxiosResponse>;
     public async get(url: string, options?: RequestOptions): Promise<AxiosResponse | string> {
@@ -952,20 +959,12 @@ export class RestService {
     }
 
     /**
-     * Get async operation status
-     */
-    public async get_async_operation_status(async_id: string): Promise<string> {
-        const response = await this.retrieve_async_response(async_id);
-        return response.data?.Status || 'Unknown';
-    }
-
-    /**
-     * Wait for async operation to complete
+     * Wait for async operation to complete using a fixed polling cadence.
      *
-     * @param poll_interval_seconds Retained for backward compatibility.
-     *   The internal polling cadence is owned by {@link waitTimeGenerator}
-     *   (exponential backoff capped at async_polling_max_delay), so this
-     *   value is ignored.
+     * Unlike the internal dispatcher's {@link waitTimeGenerator} (capped
+     * exponential backoff), this public helper polls every
+     * {@link poll_interval_seconds} seconds so existing callers who tuned
+     * the cadence keep their original behavior.
      */
     public async wait_for_async_operation(
         async_id: string,
@@ -973,9 +972,28 @@ export class RestService {
         poll_interval_seconds: number = 1,
         cancel_at_timeout: boolean = false
     ): Promise<any> {
-        void poll_interval_seconds;
-        const response = await this._pollAsyncResponse(async_id, timeout_seconds, cancel_at_timeout);
-        return response.data;
+        const deadline = Date.now() + timeout_seconds * 1000;
+
+        while (Date.now() < deadline) {
+            const response = await this.retrieve_async_response(async_id);
+            if (response.status === 200 || response.status === 201) {
+                return response.data;
+            }
+            await new Promise(resolve => setTimeout(resolve, poll_interval_seconds * 1000));
+        }
+
+        if (cancel_at_timeout) {
+            try {
+                await this.cancel_async_operation(async_id);
+            } catch (cancelError) {
+                console.warn(`Failed to cancel async operation ${async_id} at timeout:`, cancelError);
+            }
+        }
+
+        throw new TM1TimeoutException(
+            `Async operation ${async_id} timed out after ${timeout_seconds} seconds`,
+            timeout_seconds
+        );
     }
 
     /**

--- a/src/services/RestService.ts
+++ b/src/services/RestService.ts
@@ -1014,7 +1014,16 @@ export class RestService {
      * Retrieve async operation response
      */
     public async retrieve_async_response(async_id: string): Promise<AxiosResponse> {
-        return this.get(`/_async('${async_id}')`, { asyncRequestsMode: false }) as Promise<AxiosResponse>;
+        // tm1py's retrieve_async_response returns the raw response without
+        // raising on non-2xx because its caller (_poll_async_response) gates
+        // on status_code in [200, 201]. Mirror that: accept all statuses so
+        // transient 404s (resource not yet materialized) or 202s (still
+        // running) flow through to the polling loop rather than aborting it.
+        return this.get(`/_async('${async_id}')`, {
+            asyncRequestsMode: false,
+            verifyResponse: false,
+            validateStatus: () => true
+        }) as Promise<AxiosResponse>;
     }
 
     /**

--- a/src/services/RestService.ts
+++ b/src/services/RestService.ts
@@ -655,7 +655,7 @@ export class RestService {
     }
 
     public async disconnect(): Promise<void> {
-        const shouldClose = this.isConnected && !!this.getSessionCookieValue();
+        const shouldClose = this.isConnected;
         // Flip isConnected first so a 401 on tm1.Close cannot trigger reAuthenticate recursion
         this.isConnected = false;
         if (shouldClose) {

--- a/src/services/RestService.ts
+++ b/src/services/RestService.ts
@@ -375,7 +375,7 @@ export class RestService {
             return response;
         }
 
-        const location = response.headers['location'] || response.headers['Location'] || '';
+        const location = response.headers['location'] || '';
         const match = typeof location === 'string' ? location.match(/\('([^']+)'\)/) : null;
         const asyncId = match ? match[1] : undefined;
 
@@ -507,31 +507,31 @@ export class RestService {
      * `200/201`, the full `AxiosResponse` is returned instead — the
      * declared `Promise<string>` return type is a best-effort narrowing.
      */
-    public async get(url: string, options: RequestOptions & { returnAsyncId: true }): Promise<string>;
+    public async get(url: string, options: RequestOptions & { returnAsyncId: true }): Promise<string | AxiosResponse>;
     public async get(url: string, options?: RequestOptions): Promise<AxiosResponse>;
     public async get(url: string, options?: RequestOptions): Promise<AxiosResponse | string> {
         return this._request('GET', url, undefined, { idempotent: true, ...options });
     }
 
-    public async post(url: string, data: any, options: RequestOptions & { returnAsyncId: true }): Promise<string>;
+    public async post(url: string, data: any, options: RequestOptions & { returnAsyncId: true }): Promise<string | AxiosResponse>;
     public async post(url: string, data?: any, options?: RequestOptions): Promise<AxiosResponse>;
     public async post(url: string, data?: any, options?: RequestOptions): Promise<AxiosResponse | string> {
         return this._request('POST', url, data, options);
     }
 
-    public async patch(url: string, data: any, options: RequestOptions & { returnAsyncId: true }): Promise<string>;
+    public async patch(url: string, data: any, options: RequestOptions & { returnAsyncId: true }): Promise<string | AxiosResponse>;
     public async patch(url: string, data?: any, options?: RequestOptions): Promise<AxiosResponse>;
     public async patch(url: string, data?: any, options?: RequestOptions): Promise<AxiosResponse | string> {
         return this._request('PATCH', url, data, options);
     }
 
-    public async put(url: string, data: any, options: RequestOptions & { returnAsyncId: true }): Promise<string>;
+    public async put(url: string, data: any, options: RequestOptions & { returnAsyncId: true }): Promise<string | AxiosResponse>;
     public async put(url: string, data?: any, options?: RequestOptions): Promise<AxiosResponse>;
     public async put(url: string, data?: any, options?: RequestOptions): Promise<AxiosResponse | string> {
         return this._request('PUT', url, data, options);
     }
 
-    public async delete(url: string, options: RequestOptions & { returnAsyncId: true }): Promise<string>;
+    public async delete(url: string, options: RequestOptions & { returnAsyncId: true }): Promise<string | AxiosResponse>;
     public async delete(url: string, options?: RequestOptions): Promise<AxiosResponse>;
     public async delete(url: string, options?: RequestOptions): Promise<AxiosResponse | string> {
         return this._request('DELETE', url, undefined, options);
@@ -1041,7 +1041,7 @@ export class RestService {
      * status so callers are not handed a 500 as "success".
      */
     private verifyAsyncResultHeader(response: AxiosResponse): void {
-        const headerValue = response.headers?.['asyncresult'] ?? response.headers?.['AsyncResult'];
+        const headerValue = response.headers?.['asyncresult'];
         if (typeof headerValue !== 'string') return;
         const embeddedStatus = parseInt(headerValue.trim().split(/\s+/)[0], 10);
         if (Number.isNaN(embeddedStatus)) return;

--- a/src/services/RestService.ts
+++ b/src/services/RestService.ts
@@ -336,7 +336,7 @@ export class RestService {
         cancelAtTimeout: boolean
     ): Promise<AxiosResponse> {
         for (const wait of this.waitTimeGenerator(timeout)) {
-            const response = await this.axiosInstance.get(`/_async('${asyncId}')`);
+            const response = await this.retrieve_async_response(asyncId);
 
             if (response.status === 200 || response.status === 201) {
                 return response;
@@ -347,7 +347,7 @@ export class RestService {
 
         if (cancelAtTimeout) {
             try {
-                await this.axiosInstance.delete(`/_async('${asyncId}')`);
+                await this.cancel_async_operation(asyncId);
             } catch {
                 // Best-effort cancellation on timeout.
             }

--- a/src/services/RestService.ts
+++ b/src/services/RestService.ts
@@ -1017,6 +1017,26 @@ export class RestService {
     }
 
     /**
+     * TM1 v12 returns completed async results with HTTP 200 and encodes
+     * the true operation status in the `asyncresult` header (e.g.
+     * "500 Internal Server Error"). Mirror tm1py's
+     * `_transform_async_response` by throwing on any embedded non-2xx
+     * status so callers are not handed a 500 as "success".
+     */
+    private verifyAsyncResultHeader(response: AxiosResponse): void {
+        const headerValue = response.headers?.['asyncresult'] ?? response.headers?.['AsyncResult'];
+        if (typeof headerValue !== 'string') return;
+        const embeddedStatus = parseInt(headerValue.trim().split(/\s+/)[0], 10);
+        if (Number.isNaN(embeddedStatus)) return;
+        if (embeddedStatus >= 200 && embeddedStatus < 300) return;
+        throw new TM1RestException(
+            `Async operation failed with status ${headerValue}`,
+            embeddedStatus,
+            response
+        );
+    }
+
+    /**
      * Wait for async operation to complete using a fixed polling cadence.
      *
      * Unlike the internal dispatcher's {@link waitTimeGenerator} (capped
@@ -1035,6 +1055,7 @@ export class RestService {
         while (Date.now() < deadline) {
             const response = await this.retrieve_async_response(async_id);
             if (response.status === 200 || response.status === 201) {
+                this.verifyAsyncResultHeader(response);
                 return response.data;
             }
             await new Promise(resolve => setTimeout(resolve, poll_interval_seconds * 1000));

--- a/src/tests/asyncOperationService.test.ts
+++ b/src/tests/asyncOperationService.test.ts
@@ -381,8 +381,11 @@ describe('AsyncOperationService', () => {
             });
             asyncService.updateOperationStatus(id3, OperationStatus.COMPLETED);
 
+            // HTTP 202 = still running on the /_async endpoint.
             mockRestService.get = jest.fn().mockResolvedValue({
-                data: { Status: 'Running' }
+                status: 202,
+                headers: {},
+                data: {}
             });
 
             const activeOps = await asyncService.listActiveAsyncOperations();
@@ -641,8 +644,10 @@ describe('AsyncOperationService', () => {
         });
     });
 
+    // Status is inferred from the /_async('{id}') HTTP status code and the
+    // v12 `asyncresult` header; there is no `.Status` envelope on the new endpoint.
     describe('Server Status Mapping', () => {
-        test('should map CompletedSuccessfully to COMPLETED', async () => {
+        test('should map HTTP 200 without asyncresult header to COMPLETED', async () => {
             const operationId = await asyncService.createAsyncOperation({
                 type: OperationType.PROCESS_EXECUTION,
                 name: 'TestProcess'
@@ -651,7 +656,9 @@ describe('AsyncOperationService', () => {
             asyncService.updateOperationStatus(operationId, OperationStatus.RUNNING);
 
             mockRestService.get = jest.fn().mockResolvedValue({
-                data: { Status: 'CompletedSuccessfully', Result: { value: 42 } }
+                status: 200,
+                headers: {},
+                data: { value: 42 }
             });
 
             const status = await asyncService.getAsyncOperationStatus(operationId);
@@ -661,7 +668,7 @@ describe('AsyncOperationService', () => {
             expect(operation?.result).toEqual({ value: 42 });
         });
 
-        test('should map CompletedWithErrors to FAILED', async () => {
+        test('should map HTTP 200 with non-2xx asyncresult header to FAILED', async () => {
             const operationId = await asyncService.createAsyncOperation({
                 type: OperationType.PROCESS_EXECUTION,
                 name: 'TestProcess'
@@ -670,17 +677,36 @@ describe('AsyncOperationService', () => {
             asyncService.updateOperationStatus(operationId, OperationStatus.RUNNING);
 
             mockRestService.get = jest.fn().mockResolvedValue({
-                data: { Status: 'CompletedWithErrors', Error: 'Process failed at line 10' }
+                status: 200,
+                headers: { asyncresult: '500 Internal Server Error' },
+                data: {}
             });
 
             const status = await asyncService.getAsyncOperationStatus(operationId);
             expect(status).toBe(OperationStatus.FAILED);
 
             const operation = asyncService.getOperation(operationId);
-            expect(operation?.error).toBe('Process failed at line 10');
+            expect(operation?.error).toBe('500 Internal Server Error');
         });
 
-        test('should map Cancelled status correctly', async () => {
+        test('should map thrown TM1RestException to FAILED', async () => {
+            const operationId = await asyncService.createAsyncOperation({
+                type: OperationType.PROCESS_EXECUTION,
+                name: 'TestProcess'
+            });
+
+            asyncService.updateOperationStatus(operationId, OperationStatus.RUNNING);
+
+            const { TM1RestException } = require('../exceptions/TM1Exception');
+            mockRestService.get = jest.fn().mockRejectedValue(
+                new TM1RestException('Not found', 404)
+            );
+
+            const status = await asyncService.getAsyncOperationStatus(operationId);
+            expect(status).toBe(OperationStatus.FAILED);
+        });
+
+        test('should map HTTP 202 to RUNNING', async () => {
             const operationId = await asyncService.createAsyncOperation({
                 type: OperationType.PROCESS_EXECUTION,
                 name: 'TestProcess'
@@ -689,43 +715,13 @@ describe('AsyncOperationService', () => {
             asyncService.updateOperationStatus(operationId, OperationStatus.RUNNING);
 
             mockRestService.get = jest.fn().mockResolvedValue({
-                data: { Status: 'Cancelled' }
+                status: 202,
+                headers: {},
+                data: {}
             });
 
             const status = await asyncService.getAsyncOperationStatus(operationId);
-            expect(status).toBe(OperationStatus.CANCELLED);
-        });
-
-        test('should map Timeout status correctly', async () => {
-            const operationId = await asyncService.createAsyncOperation({
-                type: OperationType.PROCESS_EXECUTION,
-                name: 'TestProcess'
-            });
-
-            asyncService.updateOperationStatus(operationId, OperationStatus.RUNNING);
-
-            mockRestService.get = jest.fn().mockResolvedValue({
-                data: { Status: 'Timeout' }
-            });
-
-            const status = await asyncService.getAsyncOperationStatus(operationId);
-            expect(status).toBe(OperationStatus.TIMEOUT);
-        });
-
-        test('should default to PENDING for unknown status', async () => {
-            const operationId = await asyncService.createAsyncOperation({
-                type: OperationType.PROCESS_EXECUTION,
-                name: 'TestProcess'
-            });
-
-            asyncService.updateOperationStatus(operationId, OperationStatus.RUNNING);
-
-            mockRestService.get = jest.fn().mockResolvedValue({
-                data: { Status: 'UnknownStatus' }
-            });
-
-            const status = await asyncService.getAsyncOperationStatus(operationId);
-            expect(status).toBe(OperationStatus.PENDING);
+            expect(status).toBe(OperationStatus.RUNNING);
         });
     });
 

--- a/src/tests/asyncOperationService.test.ts
+++ b/src/tests/asyncOperationService.test.ts
@@ -646,14 +646,22 @@ describe('AsyncOperationService', () => {
 
     // Status is inferred from the /_async('{id}') HTTP status code and the
     // v12 `asyncresult` header; there is no `.Status` envelope on the new endpoint.
+    // These tests bypass createAsyncOperation (which tags operations as
+    // trackedLocally: true) to exercise the server-polling branch directly.
     describe('Server Status Mapping', () => {
-        test('should map HTTP 200 without asyncresult header to COMPLETED', async () => {
-            const operationId = await asyncService.createAsyncOperation({
+        const injectServerOperation = (id: string) => {
+            (asyncService as any).operations.set(id, {
+                id,
                 type: OperationType.PROCESS_EXECUTION,
-                name: 'TestProcess'
+                name: 'TestProcess',
+                status: OperationStatus.RUNNING,
+                startTime: new Date(),
+                trackedLocally: false
             });
+        };
 
-            asyncService.updateOperationStatus(operationId, OperationStatus.RUNNING);
+        test('should map HTTP 200 without asyncresult header to COMPLETED', async () => {
+            injectServerOperation('srv-1');
 
             mockRestService.get = jest.fn().mockResolvedValue({
                 status: 200,
@@ -661,20 +669,15 @@ describe('AsyncOperationService', () => {
                 data: { value: 42 }
             });
 
-            const status = await asyncService.getAsyncOperationStatus(operationId);
+            const status = await asyncService.getAsyncOperationStatus('srv-1');
             expect(status).toBe(OperationStatus.COMPLETED);
 
-            const operation = asyncService.getOperation(operationId);
+            const operation = asyncService.getOperation('srv-1');
             expect(operation?.result).toEqual({ value: 42 });
         });
 
         test('should map HTTP 200 with non-2xx asyncresult header to FAILED', async () => {
-            const operationId = await asyncService.createAsyncOperation({
-                type: OperationType.PROCESS_EXECUTION,
-                name: 'TestProcess'
-            });
-
-            asyncService.updateOperationStatus(operationId, OperationStatus.RUNNING);
+            injectServerOperation('srv-2');
 
             mockRestService.get = jest.fn().mockResolvedValue({
                 status: 200,
@@ -682,37 +685,27 @@ describe('AsyncOperationService', () => {
                 data: {}
             });
 
-            const status = await asyncService.getAsyncOperationStatus(operationId);
+            const status = await asyncService.getAsyncOperationStatus('srv-2');
             expect(status).toBe(OperationStatus.FAILED);
 
-            const operation = asyncService.getOperation(operationId);
+            const operation = asyncService.getOperation('srv-2');
             expect(operation?.error).toBe('500 Internal Server Error');
         });
 
         test('should map thrown TM1RestException to FAILED', async () => {
-            const operationId = await asyncService.createAsyncOperation({
-                type: OperationType.PROCESS_EXECUTION,
-                name: 'TestProcess'
-            });
-
-            asyncService.updateOperationStatus(operationId, OperationStatus.RUNNING);
+            injectServerOperation('srv-3');
 
             const { TM1RestException } = require('../exceptions/TM1Exception');
             mockRestService.get = jest.fn().mockRejectedValue(
-                new TM1RestException('Not found', 404)
+                new TM1RestException('Server error', 500)
             );
 
-            const status = await asyncService.getAsyncOperationStatus(operationId);
+            const status = await asyncService.getAsyncOperationStatus('srv-3');
             expect(status).toBe(OperationStatus.FAILED);
         });
 
         test('should map HTTP 202 to RUNNING', async () => {
-            const operationId = await asyncService.createAsyncOperation({
-                type: OperationType.PROCESS_EXECUTION,
-                name: 'TestProcess'
-            });
-
-            asyncService.updateOperationStatus(operationId, OperationStatus.RUNNING);
+            injectServerOperation('srv-4');
 
             mockRestService.get = jest.fn().mockResolvedValue({
                 status: 202,
@@ -720,8 +713,23 @@ describe('AsyncOperationService', () => {
                 data: {}
             });
 
+            const status = await asyncService.getAsyncOperationStatus('srv-4');
+            expect(status).toBe(OperationStatus.RUNNING);
+        });
+
+        test('locally-tracked operations skip server polling and return cached status', async () => {
+            const operationId = await asyncService.createAsyncOperation({
+                type: OperationType.PROCESS_EXECUTION,
+                name: 'LocalProcess'
+            });
+            asyncService.updateOperationStatus(operationId, OperationStatus.RUNNING);
+
+            const getSpy = jest.fn();
+            mockRestService.get = getSpy;
+
             const status = await asyncService.getAsyncOperationStatus(operationId);
             expect(status).toBe(OperationStatus.RUNNING);
+            expect(getSpy).not.toHaveBeenCalled();
         });
     });
 

--- a/src/tests/processService.comprehensive.test.ts
+++ b/src/tests/processService.comprehensive.test.ts
@@ -307,7 +307,7 @@ describe('ProcessService - Comprehensive Tests', () => {
             expect(mockRestService.post).toHaveBeenCalledWith(
                 "/Processes('TestProcess')/tm1.ExecuteWithReturn?$expand=*",
                 "{}",
-                { timeout: 30000 }
+                { timeout: 30 }
             );
         });
 
@@ -940,7 +940,7 @@ describe('ProcessService - Comprehensive Tests', () => {
             expect(mockRestService.post).toHaveBeenCalledWith(
                 expect.any(String),
                 expect.any(String),
-                { timeout: 60000 }
+                { timeout: 60 }
             );
         });
 

--- a/src/tests/processService.test.ts
+++ b/src/tests/processService.test.ts
@@ -499,6 +499,8 @@ describe('ProcessService Tests', () => {
         });
 
         test('pollExecuteWithReturn should return null for 202 (accepted/pending)', async () => {
+            // After the #80 refactor retrieve_async_response returns the raw AxiosResponse
+            // instead of throwing on 202; the pending path is now signalled by status === 202.
             (mockRestService as any).retrieve_async_response = jest.fn().mockResolvedValue({
                 status: 202,
                 data: {}

--- a/src/tests/processService.test.ts
+++ b/src/tests/processService.test.ts
@@ -460,6 +460,7 @@ describe('ProcessService Tests', () => {
     describe('Process Async Polling', () => {
         test('pollExecuteWithReturn should return parsed result on success', async () => {
             (mockRestService as any).retrieve_async_response = jest.fn().mockResolvedValue({
+                status: 200,
                 data: {
                     ProcessExecuteStatusCode: 'CompletedSuccessfully',
                     ErrorLogFile: null
@@ -474,6 +475,7 @@ describe('ProcessService Tests', () => {
 
         test('pollExecuteWithReturn should return error log file when present', async () => {
             (mockRestService as any).retrieve_async_response = jest.fn().mockResolvedValue({
+                status: 200,
                 data: {
                     ProcessExecuteStatusCode: 'CompletedWithMessages',
                     ErrorLogFile: { Filename: 'TM1ProcessError_20240101.log' }
@@ -497,10 +499,10 @@ describe('ProcessService Tests', () => {
         });
 
         test('pollExecuteWithReturn should return null for 202 (accepted/pending)', async () => {
-            const { TM1RestException } = require('../exceptions/TM1Exception');
-            (mockRestService as any).retrieve_async_response = jest.fn().mockRejectedValue(
-                new TM1RestException('Accepted', 202)
-            );
+            (mockRestService as any).retrieve_async_response = jest.fn().mockResolvedValue({
+                status: 202,
+                data: {}
+            });
 
             const result = await processService.pollExecuteWithReturn('async-004');
 

--- a/src/tests/processService.test.ts
+++ b/src/tests/processService.test.ts
@@ -460,8 +460,10 @@ describe('ProcessService Tests', () => {
     describe('Process Async Polling', () => {
         test('pollExecuteWithReturn should return parsed result on success', async () => {
             (mockRestService as any).retrieve_async_response = jest.fn().mockResolvedValue({
-                ProcessExecuteStatusCode: 'CompletedSuccessfully',
-                ErrorLogFile: null
+                data: {
+                    ProcessExecuteStatusCode: 'CompletedSuccessfully',
+                    ErrorLogFile: null
+                }
             });
 
             const result = await processService.pollExecuteWithReturn('async-001');
@@ -472,8 +474,10 @@ describe('ProcessService Tests', () => {
 
         test('pollExecuteWithReturn should return error log file when present', async () => {
             (mockRestService as any).retrieve_async_response = jest.fn().mockResolvedValue({
-                ProcessExecuteStatusCode: 'CompletedWithMessages',
-                ErrorLogFile: { Filename: 'TM1ProcessError_20240101.log' }
+                data: {
+                    ProcessExecuteStatusCode: 'CompletedWithMessages',
+                    ErrorLogFile: { Filename: 'TM1ProcessError_20240101.log' }
+                }
             });
 
             const result = await processService.pollExecuteWithReturn('async-002');

--- a/src/tests/restService.test.ts
+++ b/src/tests/restService.test.ts
@@ -360,6 +360,19 @@ describe('RestService', () => {
         );
     });
 
+    test('async dispatcher throws when poll response carries non-2xx asyncresult header', async () => {
+        mockAxiosInstance.request
+            .mockResolvedValueOnce(createMockResponse({}, 202, {
+                location: "/api/v1/_async('async-fail')"
+            }))
+            .mockResolvedValueOnce(createMockResponse({}, 200, {
+                asyncresult: '500 Internal Server Error'
+            }));
+
+        await expect(restService.get('/Threads', { asyncRequestsMode: true }))
+            .rejects.toMatchObject({ status: 500 });
+    });
+
     test('wait_for_async_operation throws when asyncresult header encodes non-2xx status', async () => {
         mockAxiosInstance.request.mockResolvedValue(
             createMockResponse({ ok: false }, 200, {

--- a/src/tests/restService.test.ts
+++ b/src/tests/restService.test.ts
@@ -360,6 +360,26 @@ describe('RestService', () => {
         );
     });
 
+    test('async dispatcher retries on transient 404 from /_async resource not yet materialized', async () => {
+        mockAxiosInstance.request
+            .mockResolvedValueOnce(createMockResponse({}, 202, {
+                location: "/api/v1/_async('async-404')"
+            }))
+            .mockResolvedValueOnce(createMockResponse({}, 404))
+            .mockResolvedValueOnce(createMockResponse({ done: true }, 200));
+
+        const response = await restService.get('/Threads', { asyncRequestsMode: true });
+
+        expect(response.data.done).toBe(true);
+        expect(mockAxiosInstance.request).toHaveBeenNthCalledWith(2,
+            expect.objectContaining({
+                method: 'GET',
+                url: "/_async('async-404')",
+                validateStatus: expect.any(Function)
+            })
+        );
+    });
+
     test('async dispatcher throws when poll response carries non-2xx asyncresult header', async () => {
         mockAxiosInstance.request
             .mockResolvedValueOnce(createMockResponse({}, 202, {

--- a/src/tests/restService.test.ts
+++ b/src/tests/restService.test.ts
@@ -72,17 +72,16 @@ describe('RestService', () => {
     });
 
     test('routes async requests with Prefer header and polls /_async endpoint', async () => {
-        mockAxiosInstance.request.mockResolvedValue(
-            createMockResponse({}, 202, {
+        mockAxiosInstance.request
+            .mockResolvedValueOnce(createMockResponse({}, 202, {
                 location: "/api/v1/_async('async-001')"
-            })
-        );
-        mockAxiosInstance.get.mockResolvedValue(createMockResponse({ done: true }, 200));
+            }))
+            .mockResolvedValueOnce(createMockResponse({ done: true }, 200));
 
         const response = await restService.get('/Threads', { asyncRequestsMode: true });
 
         expect(response.data.done).toBe(true);
-        expect(mockAxiosInstance.request).toHaveBeenCalledWith(
+        expect(mockAxiosInstance.request).toHaveBeenNthCalledWith(1,
             expect.objectContaining({
                 method: 'GET',
                 url: '/Threads',
@@ -91,7 +90,12 @@ describe('RestService', () => {
                 })
             })
         );
-        expect(mockAxiosInstance.get).toHaveBeenCalledWith("/_async('async-001')");
+        expect(mockAxiosInstance.request).toHaveBeenNthCalledWith(2,
+            expect.objectContaining({
+                method: 'GET',
+                url: "/_async('async-001')"
+            })
+        );
     });
 
     test('returns async ID when returnAsyncId is true', async () => {
@@ -192,13 +196,17 @@ describe('RestService', () => {
     test('cancels async operation on timeout when cancelAtTimeout is true', async () => {
         jest.useFakeTimers();
 
-        mockAxiosInstance.request.mockResolvedValue(
-            createMockResponse({}, 202, {
-                location: "/api/v1/_async('async-timeout')"
-            })
-        );
-        mockAxiosInstance.get.mockResolvedValue(createMockResponse({}, 202));
-        mockAxiosInstance.delete.mockResolvedValue(createMockResponse({}, 204));
+        mockAxiosInstance.request.mockImplementation((config: any) => {
+            if (config.method === 'GET' && config.url === '/Threads') {
+                return Promise.resolve(createMockResponse({}, 202, {
+                    location: "/api/v1/_async('async-timeout')"
+                }));
+            }
+            if (config.method === 'DELETE') {
+                return Promise.resolve(createMockResponse({}, 204));
+            }
+            return Promise.resolve(createMockResponse({}, 202));
+        });
 
         const pending = restService.get('/Threads', {
             asyncRequestsMode: true,
@@ -211,7 +219,12 @@ describe('RestService', () => {
         await jest.advanceTimersByTimeAsync(1000);
 
         await expectation;
-        expect(mockAxiosInstance.delete).toHaveBeenCalledWith("/_async('async-timeout')");
+        expect(mockAxiosInstance.request).toHaveBeenCalledWith(
+            expect.objectContaining({
+                method: 'DELETE',
+                url: "/_async('async-timeout')"
+            })
+        );
     });
 
     test('retry interceptor does not retry non-idempotent requests', async () => {
@@ -316,11 +329,16 @@ describe('RestService', () => {
     });
 
     test('wait_for_async_operation returns response data', async () => {
-        mockAxiosInstance.get.mockResolvedValue(createMockResponse({ Status: 'Completed', Result: 1 }, 200));
+        mockAxiosInstance.request.mockResolvedValue(createMockResponse({ Status: 'Completed', Result: 1 }, 200));
 
         const data = await restService.wait_for_async_operation('poll-002', 1);
 
         expect(data).toEqual({ Status: 'Completed', Result: 1 });
-        expect(mockAxiosInstance.get).toHaveBeenCalledWith("/_async('poll-002')");
+        expect(mockAxiosInstance.request).toHaveBeenCalledWith(
+            expect.objectContaining({
+                method: 'GET',
+                url: "/_async('poll-002')"
+            })
+        );
     });
 });

--- a/src/tests/restService.test.ts
+++ b/src/tests/restService.test.ts
@@ -1,218 +1,326 @@
-/**
- * RestService Tests for tm1npm
- * Comprehensive tests for TM1 REST API operations with proper mocking
- */
-
-import { RestService } from '../services/RestService';
 import axios, { AxiosResponse } from 'axios';
+import { RestService } from '../services/RestService';
+import { TM1RestException, TM1TimeoutException } from '../exceptions/TM1Exception';
 
-// Mock axios
 jest.mock('axios');
+
 const mockedAxios = axios as jest.Mocked<typeof axios>;
 
-// Helper function to create mock AxiosResponse
-const createMockResponse = (data: any, status: number = 200): AxiosResponse => ({
+const createMockResponse = (data: any, status = 200, headers: Record<string, any> = {}): AxiosResponse => ({
     data,
     status,
-    statusText: status === 200 ? 'OK' : status === 201 ? 'Created' : status === 204 ? 'No Content' : 'Error',
-    headers: {},
+    statusText: status === 200 ? 'OK' : status === 201 ? 'Created' : status === 202 ? 'Accepted' : 'Error',
+    headers,
     config: {} as any
 });
 
-describe('RestService Tests', () => {
+describe('RestService', () => {
     let restService: RestService;
+    let mockAxiosInstance: any;
+    let responseErrorHandler: ((error: any) => Promise<any>) | undefined;
 
     beforeEach(() => {
-        // Clear all mocks
         jest.clearAllMocks();
-        
-        // Mock axios.create
-        const mockAxiosInstance = {
+        jest.useRealTimers();
+        responseErrorHandler = undefined;
+
+        mockAxiosInstance = Object.assign(jest.fn(), {
             get: jest.fn(),
             post: jest.fn(),
             patch: jest.fn(),
-            delete: jest.fn(),
             put: jest.fn(),
+            delete: jest.fn(),
+            request: jest.fn(),
+            defaults: { headers: { common: {} } },
             interceptors: {
-                request: { use: jest.fn() },
-                response: { use: jest.fn() }
+                request: {
+                    use: jest.fn()
+                },
+                response: {
+                    use: jest.fn((onFulfilled: any, onRejected: any) => {
+                        responseErrorHandler = onRejected;
+                        return 0;
+                    })
+                }
             }
-        };
+        });
 
-        mockedAxios.create.mockReturnValue(mockAxiosInstance as any);
-        
-        const config = {
+        mockedAxios.create.mockReturnValue(mockAxiosInstance);
+
+        restService = new RestService({
             baseUrl: 'http://localhost:8879/api/v1',
             user: 'admin',
             password: 'password',
-            timeout: 30000
+            timeout: 60
+        });
+    });
+
+    test('routes sync GET requests through the central dispatcher', async () => {
+        mockAxiosInstance.request.mockResolvedValue(createMockResponse({ value: '11.8.0' }));
+
+        const response = await restService.get('/Configuration/ProductVersion');
+
+        expect(response.data.value).toBe('11.8.0');
+        expect(mockAxiosInstance.request).toHaveBeenCalledWith(
+            expect.objectContaining({
+                method: 'GET',
+                url: '/Configuration/ProductVersion',
+                timeout: 60000,
+                _idempotent: true
+            })
+        );
+    });
+
+    test('routes async requests with Prefer header and polls /_async endpoint', async () => {
+        mockAxiosInstance.request.mockResolvedValue(
+            createMockResponse({}, 202, {
+                location: "/api/v1/_async('async-001')"
+            })
+        );
+        mockAxiosInstance.get.mockResolvedValue(createMockResponse({ done: true }, 200));
+
+        const response = await restService.get('/Threads', { asyncRequestsMode: true });
+
+        expect(response.data.done).toBe(true);
+        expect(mockAxiosInstance.request).toHaveBeenCalledWith(
+            expect.objectContaining({
+                method: 'GET',
+                url: '/Threads',
+                headers: expect.objectContaining({
+                    Prefer: 'respond-async,wait=55'
+                })
+            })
+        );
+        expect(mockAxiosInstance.get).toHaveBeenCalledWith("/_async('async-001')");
+    });
+
+    test('returns async ID when returnAsyncId is true', async () => {
+        mockAxiosInstance.request.mockResolvedValue(
+            createMockResponse({}, 202, {
+                location: "/api/v1/_async('async-123')"
+            })
+        );
+
+        const asyncId = await restService.post('/Processes', {}, { returnAsyncId: true });
+
+        expect(asyncId).toBe('async-123');
+        expect(mockAxiosInstance.request).toHaveBeenCalledWith(
+            expect.objectContaining({
+                headers: expect.objectContaining({
+                    Prefer: 'respond-async'
+                })
+            })
+        );
+    });
+
+    test('uses per-request asyncRequestsMode over the instance default', async () => {
+        mockAxiosInstance.request.mockResolvedValue(createMockResponse({ ok: true }));
+
+        await restService.get('/test', { asyncRequestsMode: true });
+
+        expect(mockAxiosInstance.request).toHaveBeenCalledWith(
+            expect.objectContaining({
+                headers: expect.objectContaining({
+                    Prefer: 'respond-async,wait=55'
+                })
+            })
+        );
+    });
+
+    test('uses per-request timeout in seconds', async () => {
+        mockAxiosInstance.request.mockResolvedValue(createMockResponse({ ok: true }));
+
+        await restService.post('/test', {}, { timeout: 10 });
+
+        expect(mockAxiosInstance.request).toHaveBeenCalledWith(
+            expect.objectContaining({
+                timeout: 10000
+            })
+        );
+    });
+
+    test('passes responseType and custom headers through to Axios', async () => {
+        mockAxiosInstance.request.mockResolvedValue(createMockResponse(Buffer.from('abc')));
+
+        await restService.get('/files/test', {
+            responseType: 'arraybuffer',
+            headers: {
+                'X-Test': 'value'
+            }
+        });
+
+        expect(mockAxiosInstance.request).toHaveBeenCalledWith(
+            expect.objectContaining({
+                responseType: 'arraybuffer',
+                headers: expect.objectContaining({
+                    'X-Test': 'value'
+                })
+            })
+        );
+    });
+
+    test('skips response verification when verifyResponse is false', async () => {
+        mockAxiosInstance.request.mockResolvedValue(createMockResponse({ error: 'bad request' }, 400));
+
+        const response = await restService.get('/bad-request', { verifyResponse: false });
+
+        expect(response.status).toBe(400);
+        expect(mockAxiosInstance.request).toHaveBeenCalledWith(
+            expect.objectContaining({
+                validateStatus: expect.any(Function)
+            })
+        );
+    });
+
+    test('throws when async response has no Location header', async () => {
+        mockAxiosInstance.request.mockResolvedValue(createMockResponse({}, 202));
+
+        await expect(restService.post('/Processes', {}, { asyncRequestsMode: true }))
+            .rejects
+            .toThrow(TM1RestException);
+    });
+
+    test('returns initial response when async request completes synchronously', async () => {
+        mockAxiosInstance.request.mockResolvedValue(createMockResponse({ ok: true }, 200));
+
+        const response = await restService.get('/Threads', { asyncRequestsMode: true });
+
+        expect(response.status).toBe(200);
+        expect(mockAxiosInstance.get).not.toHaveBeenCalled();
+    });
+
+    test('cancels async operation on timeout when cancelAtTimeout is true', async () => {
+        jest.useFakeTimers();
+
+        mockAxiosInstance.request.mockResolvedValue(
+            createMockResponse({}, 202, {
+                location: "/api/v1/_async('async-timeout')"
+            })
+        );
+        mockAxiosInstance.get.mockResolvedValue(createMockResponse({}, 202));
+        mockAxiosInstance.delete.mockResolvedValue(createMockResponse({}, 204));
+
+        const pending = restService.get('/Threads', {
+            asyncRequestsMode: true,
+            timeout: 0.25,
+            cancelAtTimeout: true
+        });
+        const expectation = expect(pending).rejects.toThrow(TM1TimeoutException);
+
+        await Promise.resolve();
+        await jest.advanceTimersByTimeAsync(1000);
+
+        await expectation;
+        expect(mockAxiosInstance.delete).toHaveBeenCalledWith("/_async('async-timeout')");
+    });
+
+    test('retry interceptor does not retry non-idempotent requests', async () => {
+        expect(responseErrorHandler).toBeDefined();
+
+        const error = {
+            config: { _idempotent: false },
+            code: 'ECONNRESET',
+            message: 'socket hang up'
         };
-        
-        restService = new RestService(config);
+
+        await expect(responseErrorHandler!(error)).rejects.toThrow('socket hang up');
+        expect(mockAxiosInstance).not.toHaveBeenCalled();
     });
 
-    describe('Basic HTTP Operations', () => {
-        test('should handle GET requests', async () => {
-            const mockResponse = createMockResponse({ value: '11.8.0' });
-            (restService as any).axiosInstance.get.mockResolvedValue(mockResponse);
+    test('retry interceptor retries idempotent requests', async () => {
+        jest.useFakeTimers();
+        expect(responseErrorHandler).toBeDefined();
 
-            const response = await restService.get('/Configuration/ProductVersion');
-            
-            expect(response.status).toBe(200);
-            expect(response.data.value).toBe('11.8.0');
-        });
+        mockAxiosInstance.mockResolvedValue(createMockResponse({ ok: true }));
 
-        test('should handle POST requests', async () => {
-            const mockResponse = createMockResponse({}, 201);
-            (restService as any).axiosInstance.post.mockResolvedValue(mockResponse);
+        const error = {
+            config: { _idempotent: true, headers: {} },
+            code: 'ECONNRESET',
+            message: 'socket hang up'
+        };
 
-            const response = await restService.post('/test', { data: 'test' });
-            
-            expect(response.status).toBe(201);
-        });
+        const retryPromise = responseErrorHandler!(error);
+        await jest.advanceTimersByTimeAsync(2000);
 
-        test('should handle PATCH requests', async () => {
-            const mockResponse = createMockResponse({}, 200);
-            (restService as any).axiosInstance.patch.mockResolvedValue(mockResponse);
-
-            const response = await restService.patch('/test', { data: 'updated' });
-            
-            expect(response.status).toBe(200);
-        });
-
-        test('should handle DELETE requests', async () => {
-            const mockResponse = createMockResponse({}, 204);
-            (restService as any).axiosInstance.delete.mockResolvedValue(mockResponse);
-
-            const response = await restService.delete('/test');
-            
-            expect(response.status).toBe(204);
-        });
-
-        test('should handle PUT requests', async () => {
-            const mockResponse = createMockResponse({}, 200);
-            (restService as any).axiosInstance.put.mockResolvedValue(mockResponse);
-
-            const response = await restService.put('/test', { data: 'test' });
-            
-            expect(response.status).toBe(200);
-        });
+        await expect(retryPromise).resolves.toMatchObject({ data: { ok: true } });
+        expect(mockAxiosInstance).toHaveBeenCalledWith(
+            expect.objectContaining({
+                _retryCount: 1
+            })
+        );
     });
 
-    describe('Configuration and Setup', () => {
-        test('should build base URL correctly', () => {
-            expect(restService).toBeDefined();
-            expect((restService as any).config.baseUrl).toContain('localhost:8879');
-        });
+    test('waitTimeGenerator produces capped exponential backoff', () => {
+        const generator = (restService as any).waitTimeGenerator(4);
+        const waits = Array.from({ length: 7 }, () => generator.next().value);
 
-        test('should set timeout correctly', () => {
-            expect((restService as any).config.timeout).toBe(30000);
-        });
-
-        test('should handle authentication config', () => {
-            expect((restService as any).config.user).toBe('admin');
-            expect((restService as any).config.password).toBe('password');
-        });
+        expect(waits).toEqual([0.1, 0.2, 0.4, 0.8, 1, 1, 1]);
     });
 
-    describe('Session Management', () => {
-        test('should handle session ID', () => {
-            restService.setSandbox('TestSandbox');
-            expect(restService.getSandbox()).toBe('TestSandbox');
-        });
+    test('waitTimeGenerator stops once timeout is exceeded', () => {
+        const generator = (restService as any).waitTimeGenerator(0.5);
+        const waits: number[] = [];
 
-        test('should check login status', () => {
-            // Initially not logged in
-            expect(restService.isLoggedIn()).toBe(false);
-        });
+        while (true) {
+            const next = generator.next();
+            if (next.done) {
+                break;
+            }
+            waits.push(next.value);
+        }
+
+        expect(waits).toEqual([0.1, 0.2, 0.4]);
     });
 
-    describe('Error Handling', () => {
-        test('should handle network errors', async () => {
-            const networkError = new Error('Network Error');
-            (restService as any).axiosInstance.get.mockRejectedValue(networkError);
+    test('cancel_async_operation uses DELETE against /_async', async () => {
+        mockAxiosInstance.request.mockResolvedValue(createMockResponse({}, 204));
 
-            await expect(restService.get('/test')).rejects.toThrow('Network Error');
-        });
+        await restService.cancel_async_operation('cancel-001');
 
-        test('should handle HTTP errors', async () => {
-            const httpError = {
-                response: {
-                    status: 404,
-                    statusText: 'Not Found',
-                    data: { error: 'Resource not found' }
-                }
-            };
-            (restService as any).axiosInstance.get.mockRejectedValue(httpError);
-
-            await expect(restService.get('/nonexistent')).rejects.toMatchObject(httpError);
-        });
-
-        test('should handle timeout errors', async () => {
-            const timeoutError = {
-                code: 'ECONNABORTED',
-                message: 'timeout of 30000ms exceeded'
-            };
-            (restService as any).axiosInstance.get.mockRejectedValue(timeoutError);
-
-            await expect(restService.get('/slow-endpoint')).rejects.toMatchObject(timeoutError);
-        });
+        expect(mockAxiosInstance.request).toHaveBeenCalledWith(
+            expect.objectContaining({
+                method: 'DELETE',
+                url: "/_async('cancel-001')"
+            })
+        );
     });
 
-    describe('API Metadata', () => {
-        test('should get API metadata', async () => {
-            const mockResponse = createMockResponse({ 
-                version: '1.0',
-                capabilities: ['read', 'write'] 
-            });
-            (restService as any).axiosInstance.get.mockResolvedValue(mockResponse);
+    test('retrieve_async_response uses /_async and returns full response', async () => {
+        mockAxiosInstance.request.mockResolvedValue(createMockResponse({ Status: 'CompletedSuccessfully' }));
 
-            const metadata = await restService.getApiMetadata();
-            
-            expect(metadata.version).toBe('1.0');
-            expect(metadata.capabilities).toEqual(['read', 'write']);
-        });
+        const response = await restService.retrieve_async_response('poll-001');
+
+        expect(response.data.Status).toBe('CompletedSuccessfully');
+        expect(mockAxiosInstance.request).toHaveBeenCalledWith(
+            expect.objectContaining({
+                method: 'GET',
+                url: "/_async('poll-001')"
+            })
+        );
     });
 
-    describe('RestService Integration', () => {
-        test('should handle complex request scenarios', async () => {
-            // Mock a sequence of operations
-            const getMockResponse = createMockResponse({ id: 'test123' });
-            const postMockResponse = createMockResponse({}, 201);
-            const patchMockResponse = createMockResponse({}, 200);
-            const deleteMockResponse = createMockResponse({}, 204);
+    test('get_async_operation_status reads Status from the async response payload', async () => {
+        mockAxiosInstance.request.mockResolvedValue(
+            createMockResponse({ Status: 'CompletedSuccessfully' })
+        );
 
-            (restService as any).axiosInstance.get
-                .mockResolvedValueOnce(getMockResponse);
-            (restService as any).axiosInstance.post
-                .mockResolvedValueOnce(postMockResponse);
-            (restService as any).axiosInstance.patch
-                .mockResolvedValueOnce(patchMockResponse);
-            (restService as any).axiosInstance.delete
-                .mockResolvedValueOnce(deleteMockResponse);
+        const status = await restService.get_async_operation_status('poll-003');
 
-            // Execute sequence
-            const getResponse = await restService.get('/test');
-            expect(getResponse.data.id).toBe('test123');
+        expect(status).toBe('CompletedSuccessfully');
+        expect(mockAxiosInstance.request).toHaveBeenCalledWith(
+            expect.objectContaining({
+                method: 'GET',
+                url: "/_async('poll-003')"
+            })
+        );
+    });
 
-            const postResponse = await restService.post('/test', { name: 'test' });
-            expect(postResponse.status).toBe(201);
+    test('wait_for_async_operation returns response data', async () => {
+        mockAxiosInstance.get.mockResolvedValue(createMockResponse({ Status: 'Completed', Result: 1 }, 200));
 
-            const patchResponse = await restService.patch('/test', { name: 'updated' });
-            expect(patchResponse.status).toBe(200);
+        const data = await restService.wait_for_async_operation('poll-002', 1);
 
-            const deleteResponse = await restService.delete('/test');
-            expect(deleteResponse.status).toBe(204);
-        });
-
-        test('should maintain consistency across operations', async () => {
-            const mockResponse = createMockResponse({ consistent: true });
-            (restService as any).axiosInstance.get.mockResolvedValue(mockResponse);
-
-            const response1 = await restService.get('/test');
-            const response2 = await restService.get('/test');
-
-            expect(response1.data).toEqual(response2.data);
-        });
+        expect(data).toEqual({ Status: 'Completed', Result: 1 });
+        expect(mockAxiosInstance.get).toHaveBeenCalledWith("/_async('poll-002')");
     });
 });

--- a/src/tests/restService.test.ts
+++ b/src/tests/restService.test.ts
@@ -360,6 +360,17 @@ describe('RestService', () => {
         );
     });
 
+    test('wait_for_async_operation throws when asyncresult header encodes non-2xx status', async () => {
+        mockAxiosInstance.request.mockResolvedValue(
+            createMockResponse({ ok: false }, 200, {
+                asyncresult: '500 Internal Server Error'
+            })
+        );
+
+        await expect(restService.wait_for_async_operation('poll-500', 1))
+            .rejects.toMatchObject({ status: 500 });
+    });
+
     test('wait_for_async_operation returns response data', async () => {
         mockAxiosInstance.request.mockResolvedValue(createMockResponse({ Status: 'Completed', Result: 1 }, 200));
 

--- a/src/tests/restService.test.ts
+++ b/src/tests/restService.test.ts
@@ -193,6 +193,18 @@ describe('RestService', () => {
         expect(mockAxiosInstance.get).not.toHaveBeenCalled();
     });
 
+    test('propagates errors thrown by poll requests', async () => {
+        const pollError = new TM1RestException('Internal Server Error', 500);
+        mockAxiosInstance.request
+            .mockResolvedValueOnce(createMockResponse({}, 202, {
+                location: "/api/v1/_async('async-err')"
+            }))
+            .mockRejectedValueOnce(pollError);
+
+        await expect(restService.get('/Threads', { asyncRequestsMode: true }))
+            .rejects.toBe(pollError);
+    });
+
     test('cancels async operation on timeout when cancelAtTimeout is true', async () => {
         jest.useFakeTimers();
 

--- a/src/tests/restService.test.ts
+++ b/src/tests/restService.test.ts
@@ -163,6 +163,34 @@ describe('RestService', () => {
         );
     });
 
+    test('honors explicit idempotent: false on a GET request', async () => {
+        mockAxiosInstance.request.mockResolvedValue(createMockResponse({ ok: true }));
+
+        await restService.get('/Configuration/ServerName', { idempotent: false });
+
+        expect(mockAxiosInstance.request).toHaveBeenCalledWith(
+            expect.objectContaining({
+                _idempotent: false
+            })
+        );
+    });
+
+    test('preserves caller-supplied validateStatus when verifyResponse is false', async () => {
+        const callerValidate = jest.fn().mockReturnValue(true);
+        mockAxiosInstance.request.mockResolvedValue(createMockResponse({}, 500));
+
+        await restService.get('/bad', {
+            verifyResponse: false,
+            validateStatus: callerValidate
+        });
+
+        expect(mockAxiosInstance.request).toHaveBeenCalledWith(
+            expect.objectContaining({
+                validateStatus: callerValidate
+            })
+        );
+    });
+
     test('skips response verification when verifyResponse is false', async () => {
         mockAxiosInstance.request.mockResolvedValue(createMockResponse({ error: 'bad request' }, 400));
 
@@ -282,6 +310,14 @@ describe('RestService', () => {
         expect(waits).toEqual([0.1, 0.2, 0.4, 0.8, 1, 1, 1]);
     });
 
+    test('waitTimeGenerator runs unbounded when timeout is falsy', () => {
+        const generator = (restService as any).waitTimeGenerator(0);
+        const waits = Array.from({ length: 5 }, () => generator.next().value);
+
+        expect(waits).toEqual([0.1, 0.2, 0.4, 0.8, 1]);
+        expect(generator.next().done).toBe(false);
+    });
+
     test('waitTimeGenerator stops once timeout is exceeded', () => {
         const generator = (restService as any).waitTimeGenerator(0.5);
         const waits: number[] = [];
@@ -320,22 +356,6 @@ describe('RestService', () => {
             expect.objectContaining({
                 method: 'GET',
                 url: "/_async('poll-001')"
-            })
-        );
-    });
-
-    test('get_async_operation_status reads Status from the async response payload', async () => {
-        mockAxiosInstance.request.mockResolvedValue(
-            createMockResponse({ Status: 'CompletedSuccessfully' })
-        );
-
-        const status = await restService.get_async_operation_status('poll-003');
-
-        expect(status).toBe('CompletedSuccessfully');
-        expect(mockAxiosInstance.request).toHaveBeenCalledWith(
-            expect.objectContaining({
-                method: 'GET',
-                url: "/_async('poll-003')"
             })
         );
     });


### PR DESCRIPTION
## Summary
Closes #80. Brings tm1npm's `RestService` HTTP pipeline to parity with tm1py by adding rich per-request options, a central dispatcher, and correct async-request semantics.

- Adds `asyncRequestsMode`, `returnAsyncId`, `cancelAtTimeout`, `timeout` (seconds), `idempotent`, `verifyResponse` to `get`/`post`/`patch`/`put`/`delete` via a new `RequestOptions` type.
- Introduces a central `_request()` dispatcher that routes to `_executeSyncRequest` or `_executeAsyncRequest`. Async mode sends `Prefer: respond-async[,wait=55]`, parses the `Location` header on `202`, and polls `/_async('{id}')` via `waitTimeGenerator` with exponential backoff (`0.1 → 0.2 → 0.4 → 0.8 → 1.0` cap).
- Fixes the async endpoint across `RestService` and `AsyncOperationService` (was `/AsyncOperations('{id}')`, now `/_async('{id}')`); cancel is now `DELETE /_async('{id}')`.
- Migrates `ApplicationService`, `FileService`, `ProcessService` to `RequestOptions` and seconds-based timeouts; existing `AxiosRequestConfig` callers remain compatible because `RequestOptions extends Omit<AxiosRequestConfig, 'timeout'>`.
- Adds 18 focused unit tests covering the dispatcher, `Prefer` header, 202 polling, cancel-on-timeout (fake timers), retry gating by `idempotent`, and the `waitTimeGenerator` sequence.

## Test plan
- [x] `tsc --noEmit` clean
- [x] `jest --testPathPattern="restService|asyncOperation|processService"` — 194/194 pass
- [x] Full suite: 1228 pass (2 pre-existing credential-gated failures unchanged)
- [x] `waitTimeGenerator` emits `[0.1, 0.2, 0.4, 0.8, 1.0, 1.0, …]` matching tm1py
- [x] `returnAsyncId: true` returns the parsed async id string
- [x] `cancelAtTimeout: true` issues `DELETE /_async('{id}')` on timeout
- [x] `/_async('{id}')` used consistently by both services