### PR TITLE
fix(#59): align CAM, IAM, CPD, gateway SSO and S2S auth with tm1py

### DIFF
--- a/src/services/RestService.ts
+++ b/src/services/RestService.ts
@@ -125,7 +125,7 @@ export class RestService {
 
     private parseSetCookieHeaders(setCookie: string[] | string | undefined): void {
         if (!setCookie) return;
-        const list = Array.isArray(setCookie) ? setCookie : [setCookie];
+        const list = RestService.normaliseSetCookie(setCookie);
         for (const raw of list) {
             const firstSegment = raw.split(';')[0];
             const eqIdx = firstSegment.indexOf('=');
@@ -526,6 +526,39 @@ export class RestService {
     }
 
     /**
+     * Build an httpsAgent option that skips TLS verification when verify is false.
+     */
+    private static insecureAgentOption(
+        verify?: boolean | string
+    ): { httpsAgent: https.Agent } | Record<string, never> {
+        return verify === false
+            ? { httpsAgent: new https.Agent({ rejectUnauthorized: false }) }
+            : {};
+    }
+
+    /**
+     * Normalise a Set-Cookie header value (string | string[] | undefined) into a string[].
+     */
+    private static normaliseSetCookie(raw: string | string[] | undefined): string[] {
+        if (!raw) return [];
+        return Array.isArray(raw) ? raw : [raw];
+    }
+
+    /**
+     * Extract a named cookie value from raw Set-Cookie headers.
+     */
+    private static extractCookieValue(
+        raw: string | string[] | undefined,
+        name: string
+    ): string | undefined {
+        for (const header of RestService.normaliseSetCookie(raw)) {
+            const match = header.match(new RegExp(`${name}=([^;]+)`));
+            if (match?.[1]) return match[1];
+        }
+        return undefined;
+    }
+
+    /**
      * Build Basic Authorization header.
      * Mirrors tm1py's _build_authorization_token_basic.
      */
@@ -563,9 +596,7 @@ export class RestService {
     ): Promise<string> {
         const response = await axios.get(gateway, {
             params: { CAMNamespace: namespace },
-            ...(verify === false && {
-                httpsAgent: new https.Agent({ rejectUnauthorized: false })
-            })
+            ...RestService.insecureAgentOption(verify)
         });
         if (response.status !== 200) {
             throw new Error(
@@ -573,22 +604,15 @@ export class RestService {
                 response.status
             );
         }
-        const setCookie = response.headers['set-cookie'];
-        if (!setCookie) {
+        const passport = RestService.extractCookieValue(
+            response.headers['set-cookie'], 'cam_passport'
+        );
+        if (!passport) {
             throw new Error(
                 "Failed to authenticate through CAM. HTTP response does not contain 'cam_passport' cookie"
             );
         }
-        const cookies = Array.isArray(setCookie) ? setCookie : [setCookie];
-        for (const cookie of cookies) {
-            const match = cookie.match(/cam_passport=([^;]+)/);
-            if (match) {
-                return 'CAMPassport ' + match[1];
-            }
-        }
-        throw new Error(
-            "Failed to authenticate through CAM. HTTP response does not contain 'cam_passport' cookie"
-        );
+        return 'CAMPassport ' + passport;
     }
 
     /**
@@ -607,9 +631,7 @@ export class RestService {
         };
         const response = await axios.post(iamUrl, payload, {
             headers,
-            ...(this.config.verify === false && {
-                httpsAgent: new https.Agent({ rejectUnauthorized: false })
-            })
+            ...RestService.insecureAgentOption(this.config.verify)
         });
         if (!response.data?.access_token) {
             throw new Error(`Failed to generate access_token from URL: '${iamUrl}'`);
@@ -626,15 +648,13 @@ export class RestService {
     ): Promise<string> {
         const { cpdUrl } = this.config;
         if (!cpdUrl) {
-            throw new Error("'cpdUrl' must be provided to authenticate via PA Proxy");
+            throw new Error("'cpdUrl' must be provided to authenticate via CPD/Cloud Pak for Data");
         }
         const url = `${cpdUrl}/v1/preauth/signin`;
         const headers = { 'Content-Type': 'application/json;charset=UTF-8' };
         const response = await axios.post(url, credentials, {
             headers,
-            ...(this.config.verify === false && {
-                httpsAgent: new https.Agent({ rejectUnauthorized: false })
-            })
+            ...RestService.insecureAgentOption(this.config.verify)
         });
         if (!response.data?.token) {
             throw new Error(`Failed to generate CPD access token from URL: '${url}'`);
@@ -652,21 +672,12 @@ export class RestService {
         const payload = `jwt=${jwt}`;
         const response = await axios.post(authRoot, payload, {
             headers,
-            ...(this.config.verify === false && {
-                httpsAgent: new https.Agent({ rejectUnauthorized: false })
-            })
+            ...RestService.insecureAgentOption(this.config.verify)
         });
-        // Extract ba-sso-csrf cookie and set ba-sso-authenticity header (tm1py parity)
         const setCookie = response.headers['set-cookie'];
-        if (setCookie) {
-            const cookies = Array.isArray(setCookie) ? setCookie : [setCookie];
-            for (const cookie of cookies) {
-                const match = cookie.match(/ba-sso-csrf=([^;]+)/);
-                if (match) {
-                    this.axiosInstance.defaults.headers.common['ba-sso-authenticity'] = match[1];
-                    break;
-                }
-            }
+        const csrfValue = RestService.extractCookieValue(setCookie, 'ba-sso-csrf');
+        if (csrfValue) {
+            this.axiosInstance.defaults.headers.common['ba-sso-authenticity'] = csrfValue;
         }
         this.parseSetCookieHeaders(setCookie);
     }
@@ -713,34 +724,11 @@ export class RestService {
                     ...RestService.HEADERS,
                     'Authorization': `Basic ${basicAuth}`
                 },
-                ...(this.config.verify === false && {
-                    httpsAgent: new https.Agent({ rejectUnauthorized: false })
-                })
+                ...RestService.insecureAgentOption(this.config.verify)
             }
         );
 
-        // Capture session cookies; if normal parsing fails (reverse-proxy domain
-        // mismatch), extract TM1SessionId manually — mirrors tm1py's fallback.
         this.parseSetCookieHeaders(response.headers['set-cookie']);
-        if (!this.getSessionCookieValue()) {
-            const rawCookies = response.headers['set-cookie'];
-            if (rawCookies) {
-                const list = Array.isArray(rawCookies) ? rawCookies : [rawCookies];
-                for (const c of list) {
-                    const match = c.match(/TM1SessionId=([^;]+)/);
-                    if (match?.[1]) {
-                        this.sessionCookies.set('TM1SessionId', match[1]);
-                        console.warn(
-                            'TM1SessionId has failed to be automatically added to the session cookies, ' +
-                            'future requests using this TM1Service will use the session id extracted ' +
-                            'from the first response. Check the tm1-gateway domain settings are correct ' +
-                            'in the container orchestrator.'
-                        );
-                        break;
-                    }
-                }
-            }
-        }
     }
 
     /**
@@ -796,9 +784,8 @@ export class RestService {
 
             case AuthenticationMode.BASIC_API_KEY:
                 if (this.config.user === 'apikey') {
-                    // PaaS-style: Authorization: Basic apikey:<key>
                     this.axiosInstance.defaults.headers.common['Authorization'] =
-                        `Basic ${Buffer.from(`apikey:${this.config.apiKey}`).toString('base64')}`;
+                        RestService._buildAuthorizationTokenBasic('apikey', this.config.apiKey!);
                 } else {
                     this.axiosInstance.defaults.headers.common['API-Key'] = this.config.apiKey!;
                 }
@@ -825,22 +812,13 @@ export class RestService {
                 break;
 
             case AuthenticationMode.CAM_SSO: {
-                if (this.config.gateway) {
-                    const token = await RestService._buildAuthorizationTokenCamSso(
-                        this.config.gateway,
-                        this.config.namespace!,
-                        this.config.verify
-                    );
-                    this.axiosInstance.defaults.headers.common['Authorization'] = token;
-                } else if (this.config.camPassport) {
-                    this.axiosInstance.defaults.headers.common['Authorization'] =
-                        'CAMPassport ' + this.config.camPassport;
-                } else {
-                    this.axiosInstance.defaults.headers.common['Authorization'] =
-                        RestService._buildAuthorizationTokenCam(
-                            this.config.user!, password!, this.config.namespace!
-                        );
-                }
+                // CAM_SSO is only reached when gateway is set (see getAuthenticationMode)
+                const token = await RestService._buildAuthorizationTokenCamSso(
+                    this.config.gateway!,
+                    this.config.namespace!,
+                    this.config.verify
+                );
+                this.axiosInstance.defaults.headers.common['Authorization'] = token;
                 break;
             }
 

--- a/src/services/RestService.ts
+++ b/src/services/RestService.ts
@@ -513,192 +513,370 @@ export class RestService {
         return response.data;
     }
 
+    // =========================================================================
+    // Authentication helpers — mirror tm1py's _build_authorization_token*,
+    // _generate_*_access_token, and _start_session flows
+    // =========================================================================
+
     /**
-     * Set up authentication based on configuration
+     * Decode Base64-encoded password (tm1py parity: b64_decode_password).
      */
-    private async setupAuthentication(): Promise<void> {
-        // Access Token authentication (TM1 12+ with JWT tokens)
-        if (this.config.accessToken) {
-            this.axiosInstance.defaults.headers.common['Authorization'] = `Bearer ${this.config.accessToken}`;
-            return;
-        }
-
-        // API Key authentication (TM1 12+ PAaaS)
-        if (this.config.apiKey) {
-            if (this.config.user === 'apikey') {
-                // IBM Cloud API Key style
-                this.axiosInstance.defaults.headers.common['Authorization'] = `Basic ${Buffer.from(`apikey:${this.config.apiKey}`).toString('base64')}`;
-            } else {
-                // Basic API Key style
-                this.axiosInstance.defaults.headers.common['API-Key'] = this.config.apiKey;
-            }
-            return;
-        }
-
-        // CAM (Cognos Access Manager) authentication
-        if (this.config.authUrl && this.config.camPassport) {
-            await this.setupCamAuthentication();
-            return;
-        }
-
-        // CAM SSO authentication
-        if (this.config.authUrl && this.config.user && this.config.password && this.config.namespace) {
-            await this.setupCamSsoAuthentication();
-            return;
-        }
-
-        // Service-to-Service authentication
-        if (this.config.applicationClientId && this.config.applicationClientSecret) {
-            await this.setupServiceToServiceAuthentication();
-            return;
-        }
-
-        // Basic authentication (default)
-        if (this.config.user && this.config.password) {
-            const credentials = Buffer.from(`${this.config.user}:${this.config.password}`).toString('base64');
-            this.axiosInstance.defaults.headers.common['Authorization'] = `Basic ${credentials}`;
-
-            // Add namespace for TM1 Cloud
-            if (this.config.namespace) {
-                this.axiosInstance.defaults.headers.common['TM1-Namespace'] = this.config.namespace;
-            }
-            return;
-        }
-
-        throw new Error('No valid authentication configuration provided');
+    private static b64DecodePassword(encoded: string): string {
+        return Buffer.from(encoded, 'base64').toString('utf-8');
     }
 
     /**
-     * Set up CAM (Cognos Access Manager) authentication
+     * Build Basic Authorization header.
+     * Mirrors tm1py's _build_authorization_token_basic.
      */
-    private async setupCamAuthentication(): Promise<void> {
-        if (!this.config.authUrl || !this.config.camPassport) {
-            throw new Error('CAM authentication requires authUrl and camPassport');
-        }
+    private static _buildAuthorizationTokenBasic(user: string, password: string): string {
+        return 'Basic ' + Buffer.from(`${user}:${password}`).toString('base64');
+    }
 
-        try {
-            const authResponse = await axios.post(this.config.authUrl, {
-                parameters: [{
-                    name: 'CAMPassport',
-                    value: this.config.camPassport
-                }]
-            }, {
-                headers: {
-                    'Content-Type': 'application/json'
+    /**
+     * Build CAMNamespace Authorization header.
+     * Mirrors tm1py's _build_authorization_token_cam (non-gateway path).
+     */
+    private static _buildAuthorizationTokenCam(
+        user: string,
+        password: string,
+        namespace: string
+    ): string {
+        return 'CAMNamespace ' + Buffer.from(`${user}:${password}:${namespace}`).toString('base64');
+    }
+
+    /**
+     * Build CAMPassport Authorization token via gateway SSO.
+     * Mirrors tm1py's _build_authorization_token_cam (gateway path).
+     * Makes a GET request to the gateway URL with CAMNamespace as a query
+     * parameter and extracts the cam_passport cookie from the response.
+     *
+     * Note: tm1py uses HttpNegotiateAuth (NTLM/Kerberos) for gateway requests,
+     * which is Windows-only. This implementation sends a plain GET and relies on
+     * the gateway being accessible without NTLM. For environments requiring NTLM,
+     * pass a pre-obtained cam_passport via config.camPassport instead.
+     */
+    private static async _buildAuthorizationTokenCamSso(
+        gateway: string,
+        namespace: string,
+        verify?: boolean | string
+    ): Promise<string> {
+        const response = await axios.get(gateway, {
+            params: { CAMNamespace: namespace },
+            ...(verify === false && {
+                httpsAgent: new https.Agent({ rejectUnauthorized: false })
+            })
+        });
+        if (response.status !== 200) {
+            throw new Error(
+                'Failed to authenticate through CAM. Expected status_code 200, received status_code: ' +
+                response.status
+            );
+        }
+        const setCookie = response.headers['set-cookie'];
+        if (!setCookie) {
+            throw new Error(
+                "Failed to authenticate through CAM. HTTP response does not contain 'cam_passport' cookie"
+            );
+        }
+        const cookies = Array.isArray(setCookie) ? setCookie : [setCookie];
+        for (const cookie of cookies) {
+            const match = cookie.match(/cam_passport=([^;]+)/);
+            if (match) {
+                return 'CAMPassport ' + match[1];
+            }
+        }
+        throw new Error(
+            "Failed to authenticate through CAM. HTTP response does not contain 'cam_passport' cookie"
+        );
+    }
+
+    /**
+     * Generate IBM IAM Cloud access token.
+     * Mirrors tm1py's _generate_ibm_iam_cloud_access_token.
+     */
+    private async _generateIbmIamCloudAccessToken(): Promise<string> {
+        const { iamUrl, apiKey } = this.config;
+        if (!iamUrl || !apiKey) {
+            throw new Error("'iamUrl' and 'apiKey' must be provided to generate access token from IBM Cloud");
+        }
+        const payload = `grant_type=urn%3Aibm%3Aparams%3Aoauth%3Agrant-type%3Aapikey&apikey=${encodeURIComponent(apiKey)}`;
+        const headers = {
+            'Accept': 'application/json',
+            'Content-Type': 'application/x-www-form-urlencoded'
+        };
+        const response = await axios.post(iamUrl, payload, {
+            headers,
+            ...(this.config.verify === false && {
+                httpsAgent: new https.Agent({ rejectUnauthorized: false })
+            })
+        });
+        if (!response.data?.access_token) {
+            throw new Error(`Failed to generate access_token from URL: '${iamUrl}'`);
+        }
+        return response.data.access_token;
+    }
+
+    /**
+     * Generate CPD (Cloud Pak for Data) access token.
+     * Mirrors tm1py's _generate_cpd_access_token.
+     */
+    private async _generateCpdAccessToken(
+        credentials: { username: string; password: string }
+    ): Promise<string> {
+        const { cpdUrl } = this.config;
+        if (!cpdUrl) {
+            throw new Error("'cpdUrl' must be provided to authenticate via PA Proxy");
+        }
+        const url = `${cpdUrl}/v1/preauth/signin`;
+        const headers = { 'Content-Type': 'application/json;charset=UTF-8' };
+        const response = await axios.post(url, credentials, {
+            headers,
+            ...(this.config.verify === false && {
+                httpsAgent: new https.Agent({ rejectUnauthorized: false })
+            })
+        });
+        if (!response.data?.token) {
+            throw new Error(`Failed to generate CPD access token from URL: '${url}'`);
+        }
+        return response.data.token;
+    }
+
+    /**
+     * Authenticate with PA Proxy using a CPD JWT token.
+     * Mirrors tm1py's PA_PROXY flow in _start_session.
+     */
+    private async _authenticateWithPaProxy(jwt: string): Promise<void> {
+        const authRoot = this.resolveRoots().authRoot;
+        const headers = { 'Content-Type': 'application/x-www-form-urlencoded' };
+        const payload = `jwt=${jwt}`;
+        const response = await axios.post(authRoot, payload, {
+            headers,
+            ...(this.config.verify === false && {
+                httpsAgent: new https.Agent({ rejectUnauthorized: false })
+            })
+        });
+        // Extract ba-sso-csrf cookie and set ba-sso-authenticity header (tm1py parity)
+        const setCookie = response.headers['set-cookie'];
+        if (setCookie) {
+            const cookies = Array.isArray(setCookie) ? setCookie : [setCookie];
+            for (const cookie of cookies) {
+                const match = cookie.match(/ba-sso-csrf=([^;]+)/);
+                if (match) {
+                    this.axiosInstance.defaults.headers.common['ba-sso-authenticity'] = match[1];
+                    break;
                 }
-            });
-
-            if (authResponse.data && authResponse.data.sessionId) {
-                this.sessionCookies.set(RestService.SESSION_COOKIE_NAMES[0], authResponse.data.sessionId);
-            } else {
-                throw new Error('CAM authentication failed: No session ID returned');
             }
-        } catch (error) {
-            throw new Error(`CAM authentication failed: ${error}`);
         }
+        this.parseSetCookieHeaders(setCookie);
     }
 
     /**
-     * Set up CAM SSO authentication
+     * Authenticate Service-to-Service (v12).
+     * Mirrors tm1py's SERVICE_TO_SERVICE flow in _start_session:
+     * Uses Basic auth with applicationClientId:applicationClientSecret,
+     * then POSTs {"User": user} to the auth endpoint.
      */
-    private async setupCamSsoAuthentication(): Promise<void> {
-        if (!this.config.authUrl || !this.config.user || !this.config.password || !this.config.namespace) {
-            throw new Error('CAM SSO authentication requires authUrl, user, password, and namespace');
+    private async _authenticateServiceToService(): Promise<void> {
+        const { applicationClientId, applicationClientSecret, user } = this.config;
+        if (!applicationClientId || !applicationClientSecret) {
+            throw new Error(
+                'Service-to-Service authentication requires applicationClientId and applicationClientSecret'
+            );
         }
 
-        try {
-            const authPayload = {
-                username: this.config.user,
-                password: this.config.password,
-                namespace: this.config.namespace
-            };
-
-            const authResponse = await axios.post(this.config.authUrl, authPayload, {
-                headers: {
-                    'Content-Type': 'application/json'
-                }
-            });
-
-            if (authResponse.data && authResponse.data.token) {
-                this.axiosInstance.defaults.headers.common['Authorization'] = `Bearer ${authResponse.data.token}`;
-            } else if (authResponse.data && authResponse.data.sessionId) {
-                this.sessionCookies.set(RestService.SESSION_COOKIE_NAMES[0], authResponse.data.sessionId);
-            } else {
-                throw new Error('CAM SSO authentication failed: No token or session ID returned');
-            }
-        } catch (error) {
-            throw new Error(`CAM SSO authentication failed: ${error}`);
-        }
-    }
-
-    /**
-     * Set up Service-to-Service authentication
-     */
-    private async setupServiceToServiceAuthentication(): Promise<void> {
-        if (!this.config.applicationClientId || !this.config.applicationClientSecret) {
-            throw new Error('Service-to-Service authentication requires applicationClientId and applicationClientSecret');
-        }
-
-        // Both v11 and v11-style baseUrl topologies resolve authRoot to
-        // /Configuration/ProductVersion/$value — a metadata probe, not a token
-        // endpoint. Require callers to supply authUrl explicitly in those cases.
-        // Validation lives outside the try/catch so its message is not double-wrapped.
+        // Guard: v11 and plain baseUrl topologies resolve authRoot to a metadata
+        // probe URL, not a token endpoint. Require explicit authUrl in those cases.
         if (!this.config.authUrl) {
             const topo = this.determineTopology();
             const baseUrlIsV12 = topo === 'base_url'
                 && /api\/v1\/Databases/.test(this.config.baseUrl ?? '');
             if (topo === 'v11' || (topo === 'base_url' && !baseUrlIsV12)) {
-                throw new Error("'authUrl' is required for Service-to-Service authentication on v11 topology");
+                throw new Error(
+                    "'authUrl' is required for Service-to-Service authentication on v11 topology"
+                );
             }
         }
 
-        try {
-            const tokenEndpoint = this.config.authUrl || this.resolveRoots().authRoot;
+        const authRoot = this.config.authUrl || this.resolveRoots().authRoot;
+        const basicAuth = Buffer.from(
+            `${applicationClientId}:${applicationClientSecret}`
+        ).toString('base64');
 
-            const tokenPayload = {
-                grant_type: 'client_credentials',
-                client_id: this.config.applicationClientId,
-                client_secret: this.config.applicationClientSecret
-            };
+        this.axiosInstance.defaults.headers.common['Authorization'] = `Basic ${basicAuth}`;
 
-            const tokenResponse = await axios.post(tokenEndpoint, tokenPayload, {
+        const response = await axios.post(
+            authRoot,
+            JSON.stringify({ User: user }),
+            {
                 headers: {
-                    'Content-Type': 'application/x-www-form-urlencoded'
-                }
-            });
-
-            if (tokenResponse.data && tokenResponse.data.access_token) {
-                this.axiosInstance.defaults.headers.common['Authorization'] = `Bearer ${tokenResponse.data.access_token}`;
-            } else {
-                throw new Error('Service-to-Service authentication failed: No access token returned');
+                    ...RestService.HEADERS,
+                    'Authorization': `Basic ${basicAuth}`
+                },
+                ...(this.config.verify === false && {
+                    httpsAgent: new https.Agent({ rejectUnauthorized: false })
+                })
             }
-        } catch (error) {
-            throw new Error(`Service-to-Service authentication failed: ${error}`);
+        );
+
+        // Capture session cookies; if normal parsing fails (reverse-proxy domain
+        // mismatch), extract TM1SessionId manually — mirrors tm1py's fallback.
+        this.parseSetCookieHeaders(response.headers['set-cookie']);
+        if (!this.getSessionCookieValue()) {
+            const rawCookies = response.headers['set-cookie'];
+            if (rawCookies) {
+                const list = Array.isArray(rawCookies) ? rawCookies : [rawCookies];
+                for (const c of list) {
+                    const match = c.match(/TM1SessionId=([^;]+)/);
+                    if (match?.[1]) {
+                        this.sessionCookies.set('TM1SessionId', match[1]);
+                        console.warn(
+                            'TM1SessionId has failed to be automatically added to the session cookies, ' +
+                            'future requests using this TM1Service will use the session id extracted ' +
+                            'from the first response. Check the tm1-gateway domain settings are correct ' +
+                            'in the container orchestrator.'
+                        );
+                        break;
+                    }
+                }
+            }
         }
     }
 
     /**
-     * Get the authentication mode being used
+     * Determine the authentication mode from config.
+     * Mirrors tm1py's _determine_auth_mode, using the URL topology as the
+     * primary discriminator for v12 modes.
      */
     public getAuthenticationMode(): AuthenticationMode {
-        if (this.config.accessToken) {
-            return AuthenticationMode.ACCESS_TOKEN;
+        const topo = this.determineTopology();
+        const c = this.config;
+
+        switch (topo) {
+            case 'ibm_cloud':
+                return AuthenticationMode.IBM_CLOUD_API_KEY;
+            case 'pa_proxy':
+                return AuthenticationMode.PA_PROXY;
+            case 's2s':
+                return AuthenticationMode.SERVICE_TO_SERVICE;
+
+            case 'v11':
+            case 'base_url':
+            default: {
+                // v11 / base_url: check auth-specific config flags
+                if (c.accessToken) return AuthenticationMode.ACCESS_TOKEN;
+                if (c.apiKey) return AuthenticationMode.BASIC_API_KEY;
+                if (c.applicationClientId && c.applicationClientSecret) {
+                    return AuthenticationMode.SERVICE_TO_SERVICE;
+                }
+                if (c.camPassport) return AuthenticationMode.CAM;
+                if (c.gateway) return AuthenticationMode.CAM_SSO;
+                if (c.integratedLogin) return AuthenticationMode.WIA;
+                if (c.namespace) return AuthenticationMode.CAM;
+                return AuthenticationMode.BASIC;
+            }
         }
-        if (this.config.apiKey) {
-            return this.config.user === 'apikey' ?
-                AuthenticationMode.IBM_CLOUD_API_KEY :
-                AuthenticationMode.BASIC_API_KEY;
+    }
+
+    /**
+     * Set up authentication based on configuration.
+     * Mirrors tm1py's _start_session routing.
+     */
+    private async setupAuthentication(): Promise<void> {
+        const authMode = this.getAuthenticationMode();
+        const password = this.config.decodeB64 && this.config.password
+            ? RestService.b64DecodePassword(this.config.password)
+            : this.config.password;
+
+        switch (authMode) {
+            case AuthenticationMode.ACCESS_TOKEN:
+                this.axiosInstance.defaults.headers.common['Authorization'] =
+                    `Bearer ${this.config.accessToken}`;
+                break;
+
+            case AuthenticationMode.BASIC_API_KEY:
+                if (this.config.user === 'apikey') {
+                    // PaaS-style: Authorization: Basic apikey:<key>
+                    this.axiosInstance.defaults.headers.common['Authorization'] =
+                        `Basic ${Buffer.from(`apikey:${this.config.apiKey}`).toString('base64')}`;
+                } else {
+                    this.axiosInstance.defaults.headers.common['API-Key'] = this.config.apiKey!;
+                }
+                break;
+
+            case AuthenticationMode.IBM_CLOUD_API_KEY: {
+                const accessToken = await this._generateIbmIamCloudAccessToken();
+                this.axiosInstance.defaults.headers.common['Authorization'] =
+                    `Bearer ${accessToken}`;
+                break;
+            }
+
+            case AuthenticationMode.PA_PROXY: {
+                const jwt = await this._generateCpdAccessToken({
+                    username: this.config.user!,
+                    password: password!
+                });
+                await this._authenticateWithPaProxy(jwt);
+                break;
+            }
+
+            case AuthenticationMode.SERVICE_TO_SERVICE:
+                await this._authenticateServiceToService();
+                break;
+
+            case AuthenticationMode.CAM_SSO: {
+                if (this.config.gateway) {
+                    const token = await RestService._buildAuthorizationTokenCamSso(
+                        this.config.gateway,
+                        this.config.namespace!,
+                        this.config.verify
+                    );
+                    this.axiosInstance.defaults.headers.common['Authorization'] = token;
+                } else if (this.config.camPassport) {
+                    this.axiosInstance.defaults.headers.common['Authorization'] =
+                        'CAMPassport ' + this.config.camPassport;
+                } else {
+                    this.axiosInstance.defaults.headers.common['Authorization'] =
+                        RestService._buildAuthorizationTokenCam(
+                            this.config.user!, password!, this.config.namespace!
+                        );
+                }
+                break;
+            }
+
+            case AuthenticationMode.CAM: {
+                if (this.config.camPassport) {
+                    this.axiosInstance.defaults.headers.common['Authorization'] =
+                        'CAMPassport ' + this.config.camPassport;
+                } else if (this.config.namespace && this.config.user && password) {
+                    this.axiosInstance.defaults.headers.common['Authorization'] =
+                        RestService._buildAuthorizationTokenCam(
+                            this.config.user, password, this.config.namespace
+                        );
+                } else {
+                    throw new Error(
+                        'CAM authentication requires either camPassport or user/password/namespace'
+                    );
+                }
+                break;
+            }
+
+            case AuthenticationMode.WIA:
+                throw new Error(
+                    'Windows Integrated Authentication (WIA) is not supported in Node.js. ' +
+                    'Use CAM or Basic authentication instead.'
+                );
+
+            case AuthenticationMode.BASIC:
+            default: {
+                if (!this.config.user || !password) {
+                    throw new Error('No valid authentication configuration provided');
+                }
+                this.axiosInstance.defaults.headers.common['Authorization'] =
+                    RestService._buildAuthorizationTokenBasic(this.config.user, password);
+                break;
+            }
         }
-        if (this.config.authUrl && this.config.camPassport) {
-            return AuthenticationMode.CAM;
-        }
-        if (this.config.authUrl && this.config.user && this.config.password && this.config.namespace) {
-            return AuthenticationMode.CAM_SSO;
-        }
-        if (this.config.applicationClientId && this.config.applicationClientSecret) {
-            return AuthenticationMode.SERVICE_TO_SERVICE;
-        }
-        return AuthenticationMode.BASIC;
     }
 
     /**

--- a/src/services/RestService.ts
+++ b/src/services/RestService.ts
@@ -551,9 +551,12 @@ export class RestService {
         raw: string | string[] | undefined,
         name: string
     ): string | undefined {
+        const prefix = name + '=';
         for (const header of RestService.normaliseSetCookie(raw)) {
-            const match = header.match(new RegExp(`${name}=([^;]+)`));
-            if (match?.[1]) return match[1];
+            const segment = header.split(';')[0];
+            if (segment.startsWith(prefix)) {
+                return segment.slice(prefix.length);
+            }
         }
         return undefined;
     }
@@ -758,7 +761,7 @@ export class RestService {
                     return AuthenticationMode.SERVICE_TO_SERVICE;
                 }
                 if (c.camPassport) return AuthenticationMode.CAM;
-                if (c.gateway) return AuthenticationMode.CAM_SSO;
+                if (c.gateway && c.namespace) return AuthenticationMode.CAM_SSO;
                 if (c.integratedLogin) return AuthenticationMode.WIA;
                 if (c.namespace) return AuthenticationMode.CAM;
                 return AuthenticationMode.BASIC;
@@ -799,9 +802,12 @@ export class RestService {
             }
 
             case AuthenticationMode.PA_PROXY: {
+                if (!this.config.user || !password) {
+                    throw new Error('PA Proxy authentication requires user and password');
+                }
                 const jwt = await this._generateCpdAccessToken({
-                    username: this.config.user!,
-                    password: password!
+                    username: this.config.user,
+                    password
                 });
                 await this._authenticateWithPaProxy(jwt);
                 break;

--- a/src/tests/restService.test.ts
+++ b/src/tests/restService.test.ts
@@ -3,7 +3,7 @@
  * Comprehensive tests for TM1 REST API operations with proper mocking
  */
 
-import { RestService } from '../services/RestService';
+import { RestService, AuthenticationMode } from '../services/RestService';
 import axios, { AxiosResponse } from 'axios';
 
 // Mock axios
@@ -966,7 +966,7 @@ describe('RestService authentication flows', () => {
     describe('getAuthenticationMode', () => {
         test('should detect BASIC when only user and password are provided', () => {
             const svc = new RestService({ address: 'host', ssl: true, user: 'admin', password: 'pw' });
-            expect(svc.getAuthenticationMode()).toBe(1); // BASIC
+            expect(svc.getAuthenticationMode()).toBe(AuthenticationMode.BASIC);
         });
 
         test('should detect CAM when namespace is set without gateway', () => {
@@ -974,14 +974,14 @@ describe('RestService authentication flows', () => {
                 address: 'host', ssl: true,
                 user: 'u', password: 'p', namespace: 'LDAP'
             });
-            expect(svc.getAuthenticationMode()).toBe(3); // CAM
+            expect(svc.getAuthenticationMode()).toBe(AuthenticationMode.CAM);
         });
 
         test('should detect CAM when camPassport is set', () => {
             const svc = new RestService({
                 address: 'host', ssl: true, camPassport: 'passport123'
             });
-            expect(svc.getAuthenticationMode()).toBe(3); // CAM
+            expect(svc.getAuthenticationMode()).toBe(AuthenticationMode.CAM);
         });
 
         test('should detect CAM_SSO when gateway is set', () => {
@@ -989,7 +989,7 @@ describe('RestService authentication flows', () => {
                 address: 'host', ssl: true,
                 user: 'u', password: 'p', namespace: 'LDAP', gateway: 'https://gw'
             });
-            expect(svc.getAuthenticationMode()).toBe(4); // CAM_SSO
+            expect(svc.getAuthenticationMode()).toBe(AuthenticationMode.CAM_SSO);
         });
 
         test('should detect IBM_CLOUD_API_KEY when iamUrl is set', () => {
@@ -997,7 +997,7 @@ describe('RestService authentication flows', () => {
                 address: 'pa.ibm.com', tenant: 'T1', database: 'DB1',
                 iamUrl: 'https://iam.cloud.ibm.com', ssl: true, apiKey: 'k'
             });
-            expect(svc.getAuthenticationMode()).toBe(5); // IBM_CLOUD_API_KEY
+            expect(svc.getAuthenticationMode()).toBe(AuthenticationMode.IBM_CLOUD_API_KEY);
         });
 
         test('should detect PA_PROXY when address + user + paUrl (no instance)', () => {
@@ -1005,7 +1005,7 @@ describe('RestService authentication flows', () => {
                 address: 'host', user: 'u', password: 'p',
                 paUrl: 'https://pa', database: 'db', ssl: true
             });
-            expect(svc.getAuthenticationMode()).toBe(7); // PA_PROXY
+            expect(svc.getAuthenticationMode()).toBe(AuthenticationMode.PA_PROXY);
         });
 
         test('should detect SERVICE_TO_SERVICE with instance + database', () => {
@@ -1013,7 +1013,7 @@ describe('RestService authentication flows', () => {
                 address: 'h', instance: 'INST', database: 'DB', ssl: true,
                 applicationClientId: 'id', applicationClientSecret: 'secret'
             });
-            expect(svc.getAuthenticationMode()).toBe(6); // SERVICE_TO_SERVICE
+            expect(svc.getAuthenticationMode()).toBe(AuthenticationMode.SERVICE_TO_SERVICE);
         });
 
         test('should detect SERVICE_TO_SERVICE on v11 when clientId + clientSecret provided', () => {
@@ -1021,21 +1021,21 @@ describe('RestService authentication flows', () => {
                 address: 'host', ssl: true,
                 applicationClientId: 'id', applicationClientSecret: 'secret'
             });
-            expect(svc.getAuthenticationMode()).toBe(6); // SERVICE_TO_SERVICE
+            expect(svc.getAuthenticationMode()).toBe(AuthenticationMode.SERVICE_TO_SERVICE);
         });
 
         test('should detect ACCESS_TOKEN when accessToken is set', () => {
             const svc = new RestService({
                 baseUrl: 'http://x/api/v1', accessToken: 'jwt123'
             });
-            expect(svc.getAuthenticationMode()).toBe(9); // ACCESS_TOKEN
+            expect(svc.getAuthenticationMode()).toBe(AuthenticationMode.ACCESS_TOKEN);
         });
 
         test('should detect BASIC_API_KEY when apiKey is set', () => {
             const svc = new RestService({
                 baseUrl: 'http://x/api/v1', apiKey: 'mykey'
             });
-            expect(svc.getAuthenticationMode()).toBe(8); // BASIC_API_KEY
+            expect(svc.getAuthenticationMode()).toBe(AuthenticationMode.BASIC_API_KEY);
         });
 
         test('should detect WIA when integratedLogin is set', () => {
@@ -1043,7 +1043,7 @@ describe('RestService authentication flows', () => {
                 address: 'host', ssl: true,
                 integratedLogin: true
             });
-            expect(svc.getAuthenticationMode()).toBe(2); // WIA
+            expect(svc.getAuthenticationMode()).toBe(AuthenticationMode.WIA);
         });
     });
 
@@ -1284,7 +1284,7 @@ describe('RestService authentication flows', () => {
                 paUrl: 'https://pa', database: 'db', ssl: true
             });
             await expect((svc as any).setupAuthentication())
-                .rejects.toThrow(/'cpdUrl' must be provided/);
+                .rejects.toThrow(/'cpdUrl' must be provided to authenticate via CPD/);
         });
 
         test('should throw when CPD response lacks token', async () => {
@@ -1328,12 +1328,11 @@ describe('RestService authentication flows', () => {
             expect((svc as any).sessionCookies.get('TM1SessionId')).toBe('s2s-session-id');
         });
 
-        test('should extract TM1SessionId manually when normal cookie parsing fails', async () => {
-            // Simulate a reverse-proxy that corrupts cookie domain
+        test('should capture TM1SessionId from response with wrong domain attribute', async () => {
             (axios.post as jest.Mock).mockResolvedValue({
                 status: 200,
                 headers: {
-                    'set-cookie': ['TM1SessionId=fallback-id; Domain=wrong.domain; Path=/']
+                    'set-cookie': ['TM1SessionId=domain-id; Domain=wrong.domain; Path=/']
                 }
             });
             const svc = new RestService({
@@ -1342,8 +1341,8 @@ describe('RestService authentication flows', () => {
                 user: 'admin'
             });
             await (svc as any).setupAuthentication();
-            // Cookie should be captured via regex fallback even if domain is wrong
-            expect((svc as any).sessionCookies.get('TM1SessionId')).toBe('fallback-id');
+            // parseSetCookieHeaders strips Domain and captures the cookie directly
+            expect((svc as any).sessionCookies.get('TM1SessionId')).toBe('domain-id');
         });
     });
 

--- a/src/tests/restService.test.ts
+++ b/src/tests/restService.test.ts
@@ -910,7 +910,7 @@ describe('RestService URL topology dispatch', () => {
                 applicationClientId: 'id',
                 applicationClientSecret: 'secret'
             });
-            await expect((svc as any).setupServiceToServiceAuthentication()).rejects.toThrow(
+            await expect((svc as any)._authenticateServiceToService()).rejects.toThrow(
                 /'authUrl' is required for Service-to-Service authentication on v11 topology/
             );
         });
@@ -921,7 +921,7 @@ describe('RestService URL topology dispatch', () => {
                 applicationClientId: 'id',
                 applicationClientSecret: 'secret'
             });
-            await expect((svc as any).setupServiceToServiceAuthentication()).rejects.toThrow(
+            await expect((svc as any)._authenticateServiceToService()).rejects.toThrow(
                 /'authUrl' is required for Service-to-Service authentication on v11 topology/
             );
         });
@@ -934,8 +934,486 @@ describe('RestService URL topology dispatch', () => {
                 applicationClientSecret: 'secret'
             });
             // Will reject with network-level error when trying to POST, but NOT the guard error.
-            await expect((svc as any).setupServiceToServiceAuthentication())
+            await expect((svc as any)._authenticateServiceToService())
                 .rejects.not.toThrow(/'authUrl' is required/);
+        });
+    });
+});
+
+// =========================================================================
+// Authentication flow tests — issue #59
+// =========================================================================
+describe('RestService authentication flows', () => {
+    let mockAxiosInstance: any;
+
+    beforeEach(() => {
+        jest.clearAllMocks();
+        mockAxiosInstance = {
+            get: jest.fn(),
+            post: jest.fn(),
+            patch: jest.fn(),
+            delete: jest.fn(),
+            put: jest.fn(),
+            interceptors: {
+                request: { use: jest.fn() },
+                response: { use: jest.fn() }
+            },
+            defaults: { headers: { common: {} as Record<string, string> } }
+        };
+        mockedAxios.create.mockReturnValue(mockAxiosInstance as any);
+    });
+
+    describe('getAuthenticationMode', () => {
+        test('should detect BASIC when only user and password are provided', () => {
+            const svc = new RestService({ address: 'host', ssl: true, user: 'admin', password: 'pw' });
+            expect(svc.getAuthenticationMode()).toBe(1); // BASIC
+        });
+
+        test('should detect CAM when namespace is set without gateway', () => {
+            const svc = new RestService({
+                address: 'host', ssl: true,
+                user: 'u', password: 'p', namespace: 'LDAP'
+            });
+            expect(svc.getAuthenticationMode()).toBe(3); // CAM
+        });
+
+        test('should detect CAM when camPassport is set', () => {
+            const svc = new RestService({
+                address: 'host', ssl: true, camPassport: 'passport123'
+            });
+            expect(svc.getAuthenticationMode()).toBe(3); // CAM
+        });
+
+        test('should detect CAM_SSO when gateway is set', () => {
+            const svc = new RestService({
+                address: 'host', ssl: true,
+                user: 'u', password: 'p', namespace: 'LDAP', gateway: 'https://gw'
+            });
+            expect(svc.getAuthenticationMode()).toBe(4); // CAM_SSO
+        });
+
+        test('should detect IBM_CLOUD_API_KEY when iamUrl is set', () => {
+            const svc = new RestService({
+                address: 'pa.ibm.com', tenant: 'T1', database: 'DB1',
+                iamUrl: 'https://iam.cloud.ibm.com', ssl: true, apiKey: 'k'
+            });
+            expect(svc.getAuthenticationMode()).toBe(5); // IBM_CLOUD_API_KEY
+        });
+
+        test('should detect PA_PROXY when address + user + paUrl (no instance)', () => {
+            const svc = new RestService({
+                address: 'host', user: 'u', password: 'p',
+                paUrl: 'https://pa', database: 'db', ssl: true
+            });
+            expect(svc.getAuthenticationMode()).toBe(7); // PA_PROXY
+        });
+
+        test('should detect SERVICE_TO_SERVICE with instance + database', () => {
+            const svc = new RestService({
+                address: 'h', instance: 'INST', database: 'DB', ssl: true,
+                applicationClientId: 'id', applicationClientSecret: 'secret'
+            });
+            expect(svc.getAuthenticationMode()).toBe(6); // SERVICE_TO_SERVICE
+        });
+
+        test('should detect SERVICE_TO_SERVICE on v11 when clientId + clientSecret provided', () => {
+            const svc = new RestService({
+                address: 'host', ssl: true,
+                applicationClientId: 'id', applicationClientSecret: 'secret'
+            });
+            expect(svc.getAuthenticationMode()).toBe(6); // SERVICE_TO_SERVICE
+        });
+
+        test('should detect ACCESS_TOKEN when accessToken is set', () => {
+            const svc = new RestService({
+                baseUrl: 'http://x/api/v1', accessToken: 'jwt123'
+            });
+            expect(svc.getAuthenticationMode()).toBe(9); // ACCESS_TOKEN
+        });
+
+        test('should detect BASIC_API_KEY when apiKey is set', () => {
+            const svc = new RestService({
+                baseUrl: 'http://x/api/v1', apiKey: 'mykey'
+            });
+            expect(svc.getAuthenticationMode()).toBe(8); // BASIC_API_KEY
+        });
+
+        test('should detect WIA when integratedLogin is set', () => {
+            const svc = new RestService({
+                address: 'host', ssl: true,
+                integratedLogin: true
+            });
+            expect(svc.getAuthenticationMode()).toBe(2); // WIA
+        });
+    });
+
+    describe('setupAuthentication — Basic', () => {
+        test('should set Basic Authorization header', async () => {
+            const svc = new RestService({
+                baseUrl: 'http://x/api/v1', user: 'admin', password: 'apple'
+            });
+            await (svc as any).setupAuthentication();
+            expect(mockAxiosInstance.defaults.headers.common['Authorization'])
+                .toBe('Basic ' + Buffer.from('admin:apple').toString('base64'));
+        });
+
+        test('should decode Base64 password when decodeB64 is true', async () => {
+            const encoded = Buffer.from('mypassword').toString('base64');
+            const svc = new RestService({
+                baseUrl: 'http://x/api/v1', user: 'admin', password: encoded, decodeB64: true
+            });
+            await (svc as any).setupAuthentication();
+            expect(mockAxiosInstance.defaults.headers.common['Authorization'])
+                .toBe('Basic ' + Buffer.from('admin:mypassword').toString('base64'));
+        });
+
+        test('should throw when no user or password for BASIC mode', async () => {
+            const svc = new RestService({ baseUrl: 'http://x/api/v1' });
+            await expect((svc as any).setupAuthentication())
+                .rejects.toThrow('No valid authentication configuration provided');
+        });
+    });
+
+    describe('setupAuthentication — CAM (camPassport)', () => {
+        test('should set CAMPassport Authorization header', async () => {
+            const svc = new RestService({
+                baseUrl: 'http://x/api/v1', camPassport: 'test-passport-value'
+            });
+            await (svc as any).setupAuthentication();
+            expect(mockAxiosInstance.defaults.headers.common['Authorization'])
+                .toBe('CAMPassport test-passport-value');
+        });
+    });
+
+    describe('setupAuthentication — CAM (namespace)', () => {
+        test('should set CAMNamespace Authorization header', async () => {
+            const svc = new RestService({
+                baseUrl: 'http://x/api/v1',
+                user: 'admin', password: 'pass', namespace: 'LDAP'
+            });
+            await (svc as any).setupAuthentication();
+            const expected = 'CAMNamespace ' + Buffer.from('admin:pass:LDAP').toString('base64');
+            expect(mockAxiosInstance.defaults.headers.common['Authorization']).toBe(expected);
+        });
+
+        test('should decode B64 password in CAMNamespace header', async () => {
+            const encoded = Buffer.from('pass').toString('base64');
+            const svc = new RestService({
+                baseUrl: 'http://x/api/v1',
+                user: 'admin', password: encoded, namespace: 'LDAP', decodeB64: true
+            });
+            await (svc as any).setupAuthentication();
+            const expected = 'CAMNamespace ' + Buffer.from('admin:pass:LDAP').toString('base64');
+            expect(mockAxiosInstance.defaults.headers.common['Authorization']).toBe(expected);
+        });
+
+        test('should throw CAM error when namespace set but no user/password/camPassport', async () => {
+            const svc = new RestService({
+                baseUrl: 'http://x/api/v1', namespace: 'LDAP'
+            });
+            await expect((svc as any).setupAuthentication())
+                .rejects.toThrow('CAM authentication requires either camPassport or user/password/namespace');
+        });
+    });
+
+    describe('setupAuthentication — CAM_SSO (gateway)', () => {
+        test('should GET gateway and set CAMPassport header from cam_passport cookie', async () => {
+            (axios.get as jest.Mock).mockResolvedValue({
+                status: 200,
+                headers: {
+                    'set-cookie': ['cam_passport=GW_PASSPORT_VALUE; Path=/; HttpOnly']
+                }
+            });
+            const svc = new RestService({
+                address: 'host', ssl: true,
+                user: 'u', password: 'p', namespace: 'NS', gateway: 'https://gw.example.com'
+            });
+            await (svc as any).setupAuthentication();
+            expect(axios.get).toHaveBeenCalledWith('https://gw.example.com', expect.objectContaining({
+                params: { CAMNamespace: 'NS' }
+            }));
+            expect(mockAxiosInstance.defaults.headers.common['Authorization'])
+                .toBe('CAMPassport GW_PASSPORT_VALUE');
+        });
+
+        test('should throw when gateway response has no cam_passport cookie', async () => {
+            (axios.get as jest.Mock).mockResolvedValue({
+                status: 200,
+                headers: { 'set-cookie': ['other=value; Path=/'] }
+            });
+            const svc = new RestService({
+                address: 'host', ssl: true,
+                user: 'u', password: 'p', namespace: 'NS', gateway: 'https://gw'
+            });
+            await expect((svc as any).setupAuthentication())
+                .rejects.toThrow(/cam_passport/);
+        });
+
+        test('should throw when gateway response has no Set-Cookie header', async () => {
+            (axios.get as jest.Mock).mockResolvedValue({
+                status: 200,
+                headers: {}
+            });
+            const svc = new RestService({
+                address: 'host', ssl: true,
+                user: 'u', password: 'p', namespace: 'NS', gateway: 'https://gw'
+            });
+            await expect((svc as any).setupAuthentication())
+                .rejects.toThrow(/cam_passport/);
+        });
+
+        test('should throw when gateway returns non-200 status', async () => {
+            (axios.get as jest.Mock).mockResolvedValue({
+                status: 403,
+                headers: {}
+            });
+            const svc = new RestService({
+                address: 'host', ssl: true,
+                user: 'u', password: 'p', namespace: 'NS', gateway: 'https://gw'
+            });
+            await expect((svc as any).setupAuthentication())
+                .rejects.toThrow(/Expected status_code 200/);
+        });
+    });
+
+    describe('setupAuthentication — IBM_CLOUD_API_KEY (IAM token exchange)', () => {
+        test('should exchange API key for IAM bearer token', async () => {
+            (axios.post as jest.Mock).mockResolvedValue({
+                data: { access_token: 'iam-bearer-token-123' }
+            });
+            const svc = new RestService({
+                address: 'pa.ibm.com', tenant: 'T1', database: 'DB1',
+                iamUrl: 'https://iam.cloud.ibm.com/identity/token',
+                ssl: true, apiKey: 'test-api-key'
+            });
+            await (svc as any).setupAuthentication();
+            expect(axios.post).toHaveBeenCalledWith(
+                'https://iam.cloud.ibm.com/identity/token',
+                expect.stringContaining('grant_type=urn'),
+                expect.objectContaining({
+                    headers: expect.objectContaining({
+                        'Content-Type': 'application/x-www-form-urlencoded'
+                    })
+                })
+            );
+            expect(mockAxiosInstance.defaults.headers.common['Authorization'])
+                .toBe('Bearer iam-bearer-token-123');
+        });
+
+        test('should include apiKey in URL-encoded payload', async () => {
+            (axios.post as jest.Mock).mockResolvedValue({
+                data: { access_token: 'token' }
+            });
+            const svc = new RestService({
+                address: 'pa.ibm.com', tenant: 'T1', database: 'DB1',
+                iamUrl: 'https://iam.cloud.ibm.com', ssl: true, apiKey: 'my-key'
+            });
+            await (svc as any).setupAuthentication();
+            const calledPayload = (axios.post as jest.Mock).mock.calls[0][1];
+            expect(calledPayload).toContain('apikey=my-key');
+            expect(calledPayload).toContain('grant_type=');
+        });
+
+        test('should throw when IAM response lacks access_token', async () => {
+            (axios.post as jest.Mock).mockResolvedValue({ data: {} });
+            const svc = new RestService({
+                address: 'pa.ibm.com', tenant: 'T1', database: 'DB1',
+                iamUrl: 'https://iam.cloud.ibm.com', ssl: true, apiKey: 'k'
+            });
+            await expect((svc as any).setupAuthentication())
+                .rejects.toThrow(/Failed to generate access_token/);
+        });
+
+        test('should throw when iamUrl is set but apiKey is missing', async () => {
+            const svc = new RestService({
+                address: 'pa.ibm.com', tenant: 'T1', database: 'DB1',
+                iamUrl: 'https://iam.cloud.ibm.com', ssl: true
+            });
+            await expect((svc as any)._generateIbmIamCloudAccessToken())
+                .rejects.toThrow(/'iamUrl' and 'apiKey' must be provided/);
+        });
+    });
+
+    describe('setupAuthentication — PA_PROXY (CPD + proxy auth)', () => {
+        test('should generate CPD token then authenticate with PA Proxy', async () => {
+            (axios.post as jest.Mock)
+                // First call: CPD signin
+                .mockResolvedValueOnce({
+                    data: { token: 'cpd-jwt-token-abc' }
+                })
+                // Second call: PA Proxy auth
+                .mockResolvedValueOnce({
+                    status: 200,
+                    headers: {
+                        'set-cookie': [
+                            'ba-sso-csrf=csrf-value; Path=/',
+                            'paSession=session123; Path=/'
+                        ]
+                    }
+                });
+            const svc = new RestService({
+                address: 'host', user: 'user', password: 'pass',
+                paUrl: 'https://pa', database: 'db', ssl: true,
+                cpdUrl: 'https://cpd.example.com'
+            });
+            await (svc as any).setupAuthentication();
+
+            // Verify CPD signin was called
+            expect(axios.post).toHaveBeenNthCalledWith(1,
+                'https://cpd.example.com/v1/preauth/signin',
+                { username: 'user', password: 'pass' },
+                expect.objectContaining({
+                    headers: expect.objectContaining({ 'Content-Type': 'application/json;charset=UTF-8' })
+                })
+            );
+            // Verify PA Proxy auth was called with jwt
+            expect(axios.post).toHaveBeenNthCalledWith(2,
+                expect.stringContaining('/login'),
+                'jwt=cpd-jwt-token-abc',
+                expect.objectContaining({
+                    headers: expect.objectContaining({ 'Content-Type': 'application/x-www-form-urlencoded' })
+                })
+            );
+            // Verify ba-sso-authenticity header was set
+            expect(mockAxiosInstance.defaults.headers.common['ba-sso-authenticity']).toBe('csrf-value');
+        });
+
+        test('should throw when cpdUrl is missing for PA_PROXY', async () => {
+            const svc = new RestService({
+                address: 'host', user: 'u', password: 'p',
+                paUrl: 'https://pa', database: 'db', ssl: true
+            });
+            await expect((svc as any).setupAuthentication())
+                .rejects.toThrow(/'cpdUrl' must be provided/);
+        });
+
+        test('should throw when CPD response lacks token', async () => {
+            (axios.post as jest.Mock).mockResolvedValue({ data: {} });
+            const svc = new RestService({
+                address: 'host', user: 'u', password: 'p',
+                paUrl: 'https://pa', database: 'db', ssl: true,
+                cpdUrl: 'https://cpd'
+            });
+            await expect((svc as any).setupAuthentication())
+                .rejects.toThrow(/Failed to generate CPD access token/);
+        });
+    });
+
+    describe('setupAuthentication — SERVICE_TO_SERVICE', () => {
+        test('should use Basic auth with clientId:clientSecret and POST {User: user}', async () => {
+            (axios.post as jest.Mock).mockResolvedValue({
+                status: 200,
+                headers: {
+                    'set-cookie': ['TM1SessionId=s2s-session-id; Path=/']
+                }
+            });
+            const svc = new RestService({
+                address: 'h', instance: 'INST', database: 'DB', ssl: true,
+                applicationClientId: 'clientA', applicationClientSecret: 'secretB',
+                user: 'admin'
+            });
+            await (svc as any).setupAuthentication();
+
+            const expectedBasicAuth = 'Basic ' + Buffer.from('clientA:secretB').toString('base64');
+            expect(axios.post).toHaveBeenCalledWith(
+                expect.stringContaining('/auth/v1/session'),
+                JSON.stringify({ User: 'admin' }),
+                expect.objectContaining({
+                    headers: expect.objectContaining({
+                        'Authorization': expectedBasicAuth
+                    })
+                })
+            );
+            // Session cookie should be captured
+            expect((svc as any).sessionCookies.get('TM1SessionId')).toBe('s2s-session-id');
+        });
+
+        test('should extract TM1SessionId manually when normal cookie parsing fails', async () => {
+            // Simulate a reverse-proxy that corrupts cookie domain
+            (axios.post as jest.Mock).mockResolvedValue({
+                status: 200,
+                headers: {
+                    'set-cookie': ['TM1SessionId=fallback-id; Domain=wrong.domain; Path=/']
+                }
+            });
+            const svc = new RestService({
+                address: 'h', instance: 'INST', database: 'DB', ssl: true,
+                applicationClientId: 'id', applicationClientSecret: 'secret',
+                user: 'admin'
+            });
+            await (svc as any).setupAuthentication();
+            // Cookie should be captured via regex fallback even if domain is wrong
+            expect((svc as any).sessionCookies.get('TM1SessionId')).toBe('fallback-id');
+        });
+    });
+
+    describe('setupAuthentication — ACCESS_TOKEN', () => {
+        test('should set Bearer token header', async () => {
+            const svc = new RestService({
+                baseUrl: 'http://x/api/v1', accessToken: 'my-jwt-token'
+            });
+            await (svc as any).setupAuthentication();
+            expect(mockAxiosInstance.defaults.headers.common['Authorization'])
+                .toBe('Bearer my-jwt-token');
+        });
+    });
+
+    describe('setupAuthentication — BASIC_API_KEY', () => {
+        test('should set API-Key header when user is not apikey', async () => {
+            const svc = new RestService({
+                baseUrl: 'http://x/api/v1', apiKey: 'my-api-key'
+            });
+            await (svc as any).setupAuthentication();
+            expect(mockAxiosInstance.defaults.headers.common['API-Key']).toBe('my-api-key');
+        });
+
+        test('should set Basic auth with apikey:key when user is apikey', async () => {
+            const svc = new RestService({
+                baseUrl: 'http://x/api/v1', apiKey: 'my-api-key', user: 'apikey'
+            });
+            await (svc as any).setupAuthentication();
+            const expected = 'Basic ' + Buffer.from('apikey:my-api-key').toString('base64');
+            expect(mockAxiosInstance.defaults.headers.common['Authorization']).toBe(expected);
+        });
+    });
+
+    describe('setupAuthentication — WIA', () => {
+        test('should throw for Windows Integrated Authentication', async () => {
+            const svc = new RestService({
+                address: 'host', ssl: true, integratedLogin: true
+            });
+            await expect((svc as any).setupAuthentication())
+                .rejects.toThrow(/Windows Integrated Authentication.*not supported/);
+        });
+    });
+
+    describe('verify propagation to external auth requests', () => {
+        test('should pass rejectUnauthorized:false to IAM request when verify is false', async () => {
+            (axios.post as jest.Mock).mockResolvedValue({
+                data: { access_token: 'token' }
+            });
+            const svc = new RestService({
+                address: 'pa.ibm.com', tenant: 'T', database: 'D',
+                iamUrl: 'https://iam', ssl: true, apiKey: 'k',
+                verify: false
+            });
+            await (svc as any)._generateIbmIamCloudAccessToken();
+            const callArgs = (axios.post as jest.Mock).mock.calls[0][2];
+            expect(callArgs.httpsAgent).toBeDefined();
+        });
+
+        test('should pass rejectUnauthorized:false to CPD request when verify is false', async () => {
+            (axios.post as jest.Mock).mockResolvedValue({
+                data: { token: 'jwt' }
+            });
+            const svc = new RestService({
+                address: 'h', user: 'u', password: 'p',
+                paUrl: 'https://pa', database: 'db', ssl: true,
+                cpdUrl: 'https://cpd', verify: false
+            });
+            await (svc as any)._generateCpdAccessToken({ username: 'u', password: 'p' });
+            const callArgs = (axios.post as jest.Mock).mock.calls[0][2];
+            expect(callArgs.httpsAgent).toBeDefined();
         });
     });
 });

--- a/src/tests/restService.test.ts
+++ b/src/tests/restService.test.ts
@@ -1038,6 +1038,14 @@ describe('RestService authentication flows', () => {
             expect(svc.getAuthenticationMode()).toBe(AuthenticationMode.BASIC_API_KEY);
         });
 
+        test('should fall through to BASIC when gateway is set without namespace', () => {
+            const svc = new RestService({
+                address: 'host', ssl: true,
+                user: 'u', password: 'p', gateway: 'https://gw'
+            });
+            expect(svc.getAuthenticationMode()).toBe(AuthenticationMode.BASIC);
+        });
+
         test('should detect WIA when integratedLogin is set', () => {
             const svc = new RestService({
                 address: 'host', ssl: true,
@@ -1397,6 +1405,21 @@ describe('RestService authentication flows', () => {
                 verify: false
             });
             await (svc as any)._generateIbmIamCloudAccessToken();
+            const callArgs = (axios.post as jest.Mock).mock.calls[0][2];
+            expect(callArgs.httpsAgent).toBeDefined();
+        });
+
+        test('should pass rejectUnauthorized:false to S2S request when verify is false', async () => {
+            (axios.post as jest.Mock).mockResolvedValue({
+                status: 200,
+                headers: { 'set-cookie': ['TM1SessionId=s; Path=/'] }
+            });
+            const svc = new RestService({
+                address: 'h', instance: 'I', database: 'D', ssl: true,
+                applicationClientId: 'id', applicationClientSecret: 'secret',
+                user: 'admin', verify: false
+            });
+            await (svc as any)._authenticateServiceToService();
             const callArgs = (axios.post as jest.Mock).mock.calls[0][2];
             expect(callArgs.httpsAgent).toBeDefined();
         });


### PR DESCRIPTION
## Summary
- **Fix CAM auth**: Replace JSON POST with `Authorization: CAMPassport` / `CAMNamespace` headers (tm1py parity)
- **Add IBM Cloud IAM token exchange**: POST URL-encoded form to `iamUrl`, receive bearer token (`_generateIbmIamCloudAccessToken`)
- **Add CPD access token generation**: POST JSON credentials to `cpdUrl/v1/preauth/signin` (`_generateCpdAccessToken`)
- **Add gateway SSO**: GET gateway URL with `CAMNamespace` param, extract `cam_passport` cookie (`_buildAuthorizationTokenCamSso`)
- **Add PA Proxy auth flow**: Generate CPD JWT → POST to auth URL → extract `ba-sso-csrf` cookie (`_authenticateWithPaProxy`)
- **Fix Service-to-Service**: Use Basic auth with `clientId:clientSecret`, POST `{User: user}` to auth endpoint
- **Rewrite `getAuthenticationMode()`**: Topology-based dispatch matching tm1py's `_determine_auth_mode`
- **Add `decodeB64` support**: Base64-encoded passwords decoded before token construction
- **Propagate `verify` setting**: All external auth requests honor TLS verification config via `insecureAgentOption()`
- **Extract shared helpers**: `normaliseSetCookie()`, `extractCookieValue()`, `insecureAgentOption()` eliminate duplication
- **40+ new test cases**: All auth flows, mode detection, edge cases, error paths

Closes #59

## Test plan
- [x] `npx tsc --noEmit` — no type errors
- [x] `npx jest src/tests/restService.test.ts` — 119 tests passing (40+ new)
- [x] `npx jest` — full suite passes (4 credential-dependent integration suites expected to skip)
- [ ] Manual verification against a TM1 instance with CAM authentication
- [ ] Manual verification against IBM Cloud with IAM token exchange
- [ ] Manual verification against CPD/PA Proxy environment