### PR TITLE
feat(#82): wire up 13 missing services on TM1Service

### DIFF
--- a/src/services/TM1Service.ts
+++ b/src/services/TM1Service.ts
@@ -8,6 +8,19 @@ import { BulkService } from './BulkService';
 import { AsyncOperationService } from './AsyncOperationService';
 import { PowerBiService } from './PowerBiService';
 import { ApplicationService } from './ApplicationService';
+import { AnnotationService } from './AnnotationService';
+import { ChoreService } from './ChoreService';
+import { GitService } from './GitService';
+import { SandboxService } from './SandboxService';
+import { JobService } from './JobService';
+import { UserService } from './UserService';
+import { ThreadService } from './ThreadService';
+import { TransactionLogService } from './TransactionLogService';
+import { MessageLogService } from './MessageLogService';
+import { ConfigurationService } from './ConfigurationService';
+import { AuditLogService } from './AuditLogService';
+import { LoggerService } from './LoggerService';
+import { User } from '../objects/User';
 import {
     CubeService,
     ElementService,
@@ -26,6 +39,20 @@ export class TM1Service {
     private _server?: ServerService;
     private _monitoring?: MonitoringService;
 
+    private _annotations?: AnnotationService;
+    private _chores?: ChoreService;
+    private _git?: GitService;
+    private _applications?: ApplicationService;
+    private _sandboxes?: SandboxService;
+    private _jobs?: JobService;
+    private _users?: UserService;
+    private _threads?: ThreadService;
+    private _transactionLogs?: TransactionLogService;
+    private _messageLogs?: MessageLogService;
+    private _configuration?: ConfigurationService;
+    private _auditLogs?: AuditLogService;
+    private _loggers?: LoggerService;
+
     public dimensions: DimensionService;
     public hierarchies: HierarchyService;
     public subsets: SubsetService;
@@ -42,7 +69,6 @@ export class TM1Service {
     public bulk: BulkService;
     public asyncOperations: AsyncOperationService;
     public powerbi: PowerBiService;
-    public applications: ApplicationService;
 
     constructor(config: RestServiceConfig) {
         this._tm1Rest = new RestService(config);
@@ -69,7 +95,6 @@ export class TM1Service {
         this.debugger = new DebuggerService(this._tm1Rest);
         this.bulk = new BulkService(this._tm1Rest, this.cells, this.views);
         this.powerbi = new PowerBiService(this._tm1Rest);
-        this.applications = new ApplicationService(this._tm1Rest);
     }
 
     public async connect(): Promise<void> {
@@ -98,9 +123,99 @@ export class TM1Service {
         return this._monitoring;
     }
 
-    public async whoami(): Promise<string> {
-        const user = await this.security.getCurrentUser();
-        return user.name;
+    public get annotations(): AnnotationService {
+        if (!this._annotations) {
+            this._annotations = new AnnotationService(this._tm1Rest);
+        }
+        return this._annotations;
+    }
+
+    public get chores(): ChoreService {
+        if (!this._chores) {
+            this._chores = new ChoreService(this._tm1Rest);
+        }
+        return this._chores;
+    }
+
+    public get git(): GitService {
+        if (!this._git) {
+            this._git = new GitService(this._tm1Rest);
+        }
+        return this._git;
+    }
+
+    public get applications(): ApplicationService {
+        if (!this._applications) {
+            this._applications = new ApplicationService(this._tm1Rest);
+        }
+        return this._applications;
+    }
+
+    public get sandboxes(): SandboxService {
+        if (!this._sandboxes) {
+            this._sandboxes = new SandboxService(this._tm1Rest);
+        }
+        return this._sandboxes;
+    }
+
+    public get jobs(): JobService {
+        if (!this._jobs) {
+            this._jobs = new JobService(this._tm1Rest);
+        }
+        return this._jobs;
+    }
+
+    public get users(): UserService {
+        if (!this._users) {
+            this._users = new UserService(this._tm1Rest);
+        }
+        return this._users;
+    }
+
+    public get threads(): ThreadService {
+        if (!this._threads) {
+            this._threads = new ThreadService(this._tm1Rest);
+        }
+        return this._threads;
+    }
+
+    public get transactionLogs(): TransactionLogService {
+        if (!this._transactionLogs) {
+            this._transactionLogs = new TransactionLogService(this._tm1Rest);
+        }
+        return this._transactionLogs;
+    }
+
+    public get messageLogs(): MessageLogService {
+        if (!this._messageLogs) {
+            this._messageLogs = new MessageLogService(this._tm1Rest);
+        }
+        return this._messageLogs;
+    }
+
+    public get configuration(): ConfigurationService {
+        if (!this._configuration) {
+            this._configuration = new ConfigurationService(this._tm1Rest);
+        }
+        return this._configuration;
+    }
+
+    public get auditLogs(): AuditLogService {
+        if (!this._auditLogs) {
+            this._auditLogs = new AuditLogService(this._tm1Rest);
+        }
+        return this._auditLogs;
+    }
+
+    public get loggers(): LoggerService {
+        if (!this._loggers) {
+            this._loggers = new LoggerService(this._tm1Rest);
+        }
+        return this._loggers;
+    }
+
+    public async whoami(): Promise<User> {
+        return await this.security.getCurrentUser();
     }
 
     public async getMetadata(): Promise<any> {
@@ -108,9 +223,12 @@ export class TM1Service {
         return response.data;
     }
 
+    public get version(): string | undefined {
+        return this._tm1Rest.version;
+    }
+
     public async getVersion(): Promise<string> {
-        const response = await this._tm1Rest.get('/Configuration/ProductVersion');
-        return response.data.value;
+        return await this._tm1Rest.getVersion();
     }
 
     public get connection(): RestService {
@@ -133,9 +251,13 @@ export class TM1Service {
         return this._tm1Rest.isLoggedIn();
     }
 
-    public async reAuthenticate(): Promise<void> {
+    public async reConnect(): Promise<void> {
         await this._tm1Rest.disconnect();
         await this._tm1Rest.connect();
+    }
+
+    public async reAuthenticate(): Promise<void> {
+        await this.reConnect();
     }
 
     // For use with try-with pattern in async contexts

--- a/src/services/TM1Service.ts
+++ b/src/services/TM1Service.ts
@@ -124,6 +124,12 @@ export class TM1Service {
         return this._monitoring;
     }
 
+    // The following services (annotations..loggers) are exposed as lazy,
+    // read-only getters per the issue #82 spec. This diverges from tm1py,
+    // which eagerly initialises writable attributes in `__init__`. Keeping
+    // them lazy avoids paying construction cost for services a caller never
+    // touches; readers who need to inject a test double should mock the
+    // service module itself (see src/tests/tm1Service.test.ts).
     public get annotations(): AnnotationService {
         if (!this._annotations) {
             this._annotations = new AnnotationService(this._tm1Rest);
@@ -245,11 +251,20 @@ export class TM1Service {
         return this._tm1Rest.isLoggedIn();
     }
 
+    /**
+     * Tear down the current session and re-authenticate.
+     *
+     * Intentionally diverges from tm1py's `re_connect()` (which only calls
+     * `connect()` without disconnecting first) per the issue #82 spec, which
+     * asks for a full teardown + re-authenticate. If `disconnect()` throws,
+     * `connect()` is not attempted and the caller is left disconnected.
+     */
     public async reConnect(): Promise<void> {
         await this._tm1Rest.disconnect();
         await this._tm1Rest.connect();
     }
 
+    /** Backward-compatible alias for {@link reConnect}. */
     public async reAuthenticate(): Promise<void> {
         await this.reConnect();
     }

--- a/src/services/TM1Service.ts
+++ b/src/services/TM1Service.ts
@@ -124,12 +124,6 @@ export class TM1Service {
         return this._monitoring;
     }
 
-    // The following services (annotations..loggers) are exposed as lazy,
-    // read-only getters per the issue #82 spec. This diverges from tm1py,
-    // which eagerly initialises writable attributes in `__init__`. Keeping
-    // them lazy avoids paying construction cost for services a caller never
-    // touches; readers who need to inject a test double should mock the
-    // service module itself (see src/tests/tm1Service.test.ts).
     public get annotations(): AnnotationService {
         if (!this._annotations) {
             this._annotations = new AnnotationService(this._tm1Rest);
@@ -251,20 +245,12 @@ export class TM1Service {
         return this._tm1Rest.isLoggedIn();
     }
 
-    /**
-     * Re-establish the REST session. Matches tm1py's `re_connect()`, which
-     * only calls `connect()` without tearing down the existing session.
-     * Use {@link reAuthenticate} for a full teardown + re-auth.
-     */
+    /** Reconnects without teardown. Use reAuthenticate() for full disconnect+reconnect. */
     public async reConnect(): Promise<void> {
         await this._tm1Rest.connect();
     }
 
-    /**
-     * Tear down the current session and re-authenticate. Unlike {@link reConnect}
-     * this calls `disconnect()` before `connect()`; if `disconnect()` throws,
-     * `connect()` is not attempted and the caller is left disconnected.
-     */
+    /** Full teardown + reconnect. If disconnect() throws, connect() is not attempted. */
     public async reAuthenticate(): Promise<void> {
         await this._tm1Rest.disconnect();
         await this._tm1Rest.connect();

--- a/src/services/TM1Service.ts
+++ b/src/services/TM1Service.ts
@@ -42,7 +42,6 @@ export class TM1Service {
     private _annotations?: AnnotationService;
     private _chores?: ChoreService;
     private _git?: GitService;
-    private _applications?: ApplicationService;
     private _sandboxes?: SandboxService;
     private _jobs?: JobService;
     private _users?: UserService;
@@ -69,6 +68,7 @@ export class TM1Service {
     public bulk: BulkService;
     public asyncOperations: AsyncOperationService;
     public powerbi: PowerBiService;
+    public applications: ApplicationService;
 
     constructor(config: RestServiceConfig) {
         this._tm1Rest = new RestService(config);
@@ -95,6 +95,7 @@ export class TM1Service {
         this.debugger = new DebuggerService(this._tm1Rest);
         this.bulk = new BulkService(this._tm1Rest, this.cells, this.views);
         this.powerbi = new PowerBiService(this._tm1Rest);
+        this.applications = new ApplicationService(this._tm1Rest);
     }
 
     public async connect(): Promise<void> {
@@ -142,13 +143,6 @@ export class TM1Service {
             this._git = new GitService(this._tm1Rest);
         }
         return this._git;
-    }
-
-    public get applications(): ApplicationService {
-        if (!this._applications) {
-            this._applications = new ApplicationService(this._tm1Rest);
-        }
-        return this._applications;
     }
 
     public get sandboxes(): SandboxService {

--- a/src/services/TM1Service.ts
+++ b/src/services/TM1Service.ts
@@ -252,21 +252,22 @@ export class TM1Service {
     }
 
     /**
-     * Tear down the current session and re-authenticate.
-     *
-     * Intentionally diverges from tm1py's `re_connect()` (which only calls
-     * `connect()` without disconnecting first) per the issue #82 spec, which
-     * asks for a full teardown + re-authenticate. If `disconnect()` throws,
-     * `connect()` is not attempted and the caller is left disconnected.
+     * Re-establish the REST session. Matches tm1py's `re_connect()`, which
+     * only calls `connect()` without tearing down the existing session.
+     * Use {@link reAuthenticate} for a full teardown + re-auth.
      */
     public async reConnect(): Promise<void> {
-        await this._tm1Rest.disconnect();
         await this._tm1Rest.connect();
     }
 
-    /** Backward-compatible alias for {@link reConnect}. */
+    /**
+     * Tear down the current session and re-authenticate. Unlike {@link reConnect}
+     * this calls `disconnect()` before `connect()`; if `disconnect()` throws,
+     * `connect()` is not attempted and the caller is left disconnected.
+     */
     public async reAuthenticate(): Promise<void> {
-        await this.reConnect();
+        await this._tm1Rest.disconnect();
+        await this._tm1Rest.connect();
     }
 
     // For use with try-with pattern in async contexts

--- a/src/tests/tm1Service.test.ts
+++ b/src/tests/tm1Service.test.ts
@@ -6,6 +6,7 @@
 
 import { TM1Service } from '../services/TM1Service';
 import { RestService, RestServiceConfig } from '../services/RestService';
+import { User, UserType } from '../objects/User';
 
 // Mock all service dependencies
 jest.mock('../services/RestService');
@@ -22,6 +23,19 @@ jest.mock('../services/FileService');
 jest.mock('../services/SessionService');
 jest.mock('../services/ServerService');
 jest.mock('../services/MonitoringService');
+jest.mock('../services/AnnotationService');
+jest.mock('../services/ChoreService');
+jest.mock('../services/GitService');
+jest.mock('../services/ApplicationService');
+jest.mock('../services/SandboxService');
+jest.mock('../services/JobService');
+jest.mock('../services/UserService');
+jest.mock('../services/ThreadService');
+jest.mock('../services/TransactionLogService');
+jest.mock('../services/MessageLogService');
+jest.mock('../services/ConfigurationService');
+jest.mock('../services/AuditLogService');
+jest.mock('../services/LoggerService');
 
 describe('TM1Service', () => {
     let tm1Service: TM1Service;
@@ -61,6 +75,8 @@ describe('TM1Service', () => {
             setSandbox: jest.fn(),
             getSandbox: jest.fn().mockReturnValue('test-sandbox'),
             isLoggedIn: jest.fn().mockReturnValue(true),
+            getVersion: jest.fn().mockResolvedValue('12.0.0'),
+            version: undefined,
         } as any;
 
         // Mock RestService constructor
@@ -145,16 +161,18 @@ describe('TM1Service', () => {
     });
 
     describe('User and Authentication', () => {
-        test('should get current user with whoami', async () => {
-            // Mock security service getCurrentUser method
+        test('should get current user as User object with whoami', async () => {
+            const expectedUser = new User('test-user', ['ADMIN'], 'Test User', undefined, UserType.Admin, true);
             const mockSecurityService = {
-                getCurrentUser: jest.fn().mockResolvedValue({ name: 'test-user' })
+                getCurrentUser: jest.fn().mockResolvedValue(expectedUser)
             };
             (tm1Service.security as any) = mockSecurityService;
 
             const result = await tm1Service.whoami();
-            
-            expect(result).toBe('test-user');
+
+            expect(result).toBeInstanceOf(User);
+            expect(result.name).toBe('test-user');
+            expect(result).toBe(expectedUser);
             expect(mockSecurityService.getCurrentUser).toHaveBeenCalledTimes(1);
         });
 
@@ -191,13 +209,13 @@ describe('TM1Service', () => {
             expect(mockRestService.get).toHaveBeenCalledWith('/$metadata');
         });
 
-        test('should get TM1 version', async () => {
-            mockRestService.get.mockResolvedValueOnce(mockResponse({ value: '12.0.0' }));
+        test('should get TM1 version via cached RestService.getVersion', async () => {
+            mockRestService.getVersion.mockResolvedValueOnce('12.0.0');
 
             const result = await tm1Service.getVersion();
-            
+
             expect(result).toBe('12.0.0');
-            expect(mockRestService.get).toHaveBeenCalledWith('/Configuration/ProductVersion');
+            expect(mockRestService.getVersion).toHaveBeenCalledTimes(1);
         });
 
         test('should handle metadata retrieval errors', async () => {
@@ -209,7 +227,7 @@ describe('TM1Service', () => {
 
         test('should handle version retrieval errors', async () => {
             const versionError = new Error('Version not available');
-            mockRestService.get.mockRejectedValueOnce(versionError);
+            mockRestService.getVersion.mockRejectedValueOnce(versionError);
 
             await expect(tm1Service.getVersion()).rejects.toThrow('Version not available');
         });
@@ -356,6 +374,85 @@ describe('TM1Service', () => {
 
             expect(server1).toBe(server2);
             expect(monitoring1).toBe(monitoring2);
+        });
+    });
+
+    describe('Lazy Services (Issue #82)', () => {
+        const lazyServiceNames: Array<keyof TM1Service> = [
+            'annotations',
+            'chores',
+            'git',
+            'applications',
+            'sandboxes',
+            'jobs',
+            'users',
+            'threads',
+            'transactionLogs',
+            'messageLogs',
+            'configuration',
+            'auditLogs',
+            'loggers',
+        ];
+
+        test.each(lazyServiceNames)('should lazy-initialize %s service', (serviceName) => {
+            const instance = tm1Service[serviceName];
+            expect(instance).toBeDefined();
+        });
+
+        test.each(lazyServiceNames)('should cache %s service instance across accesses', (serviceName) => {
+            const first = tm1Service[serviceName];
+            const second = tm1Service[serviceName];
+            expect(second).toBe(first);
+        });
+    });
+
+    describe('Version Getter (Issue #82)', () => {
+        test('should expose cached version via sync getter', () => {
+            Object.defineProperty(mockRestService, 'version', {
+                get: () => '11.8.0',
+                configurable: true,
+            });
+
+            expect(tm1Service.version).toBe('11.8.0');
+        });
+
+        test('should return undefined when version has not been fetched yet', () => {
+            Object.defineProperty(mockRestService, 'version', {
+                get: () => undefined,
+                configurable: true,
+            });
+
+            expect(tm1Service.version).toBeUndefined();
+        });
+    });
+
+    describe('reConnect (Issue #82)', () => {
+        test('should disconnect then connect', async () => {
+            await tm1Service.reConnect();
+
+            expect(mockRestService.disconnect).toHaveBeenCalledTimes(1);
+            expect(mockRestService.connect).toHaveBeenCalledTimes(1);
+
+            const disconnectOrder = mockRestService.disconnect.mock.invocationCallOrder[0];
+            const connectOrder = mockRestService.connect.mock.invocationCallOrder[0];
+            expect(disconnectOrder).toBeLessThan(connectOrder);
+        });
+
+        test('should not call connect when disconnect fails', async () => {
+            const disconnectError = new Error('Disconnect failed');
+            mockRestService.disconnect.mockRejectedValueOnce(disconnectError);
+
+            await expect(tm1Service.reConnect()).rejects.toThrow('Disconnect failed');
+            expect(mockRestService.connect).not.toHaveBeenCalled();
+        });
+
+        test('should reject when connect fails after successful disconnect', async () => {
+            mockRestService.disconnect.mockResolvedValueOnce(void 0);
+            mockRestService.connect.mockRejectedValueOnce(new Error('Connect failed'));
+
+            await expect(tm1Service.reConnect()).rejects.toThrow('Connect failed');
+            expect(mockRestService.disconnect).toHaveBeenCalledTimes(1);
+            expect(mockRestService.connect).toHaveBeenCalledTimes(1);
         });
     });
 });

--- a/src/tests/tm1Service.test.ts
+++ b/src/tests/tm1Service.test.ts
@@ -194,9 +194,17 @@ describe('TM1Service', () => {
 
         test('should re-authenticate successfully', async () => {
             await tm1Service.reAuthenticate();
-            
+
             expect(mockRestService.disconnect).toHaveBeenCalledTimes(1);
             expect(mockRestService.connect).toHaveBeenCalledTimes(1);
+        });
+
+        test('reAuthenticate should delegate to reConnect', async () => {
+            const spy = jest.spyOn(tm1Service, 'reConnect').mockResolvedValueOnce();
+
+            await tm1Service.reAuthenticate();
+
+            expect(spy).toHaveBeenCalledTimes(1);
         });
     });
 

--- a/src/tests/tm1Service.test.ts
+++ b/src/tests/tm1Service.test.ts
@@ -199,13 +199,6 @@ describe('TM1Service', () => {
             expect(mockRestService.connect).toHaveBeenCalledTimes(1);
         });
 
-        test('reAuthenticate should delegate to reConnect', async () => {
-            const spy = jest.spyOn(tm1Service, 'reConnect').mockResolvedValueOnce();
-
-            await tm1Service.reAuthenticate();
-
-            expect(spy).toHaveBeenCalledTimes(1);
-        });
     });
 
     describe('Metadata and Version', () => {
@@ -435,31 +428,17 @@ describe('TM1Service', () => {
     });
 
     describe('reConnect (Issue #82)', () => {
-        test('should disconnect then connect', async () => {
+        test('should call connect without disconnecting (tm1py parity)', async () => {
             await tm1Service.reConnect();
 
-            expect(mockRestService.disconnect).toHaveBeenCalledTimes(1);
             expect(mockRestService.connect).toHaveBeenCalledTimes(1);
-
-            const disconnectOrder = mockRestService.disconnect.mock.invocationCallOrder[0];
-            const connectOrder = mockRestService.connect.mock.invocationCallOrder[0];
-            expect(disconnectOrder).toBeLessThan(connectOrder);
+            expect(mockRestService.disconnect).not.toHaveBeenCalled();
         });
 
-        test('should not call connect when disconnect fails', async () => {
-            const disconnectError = new Error('Disconnect failed');
-            mockRestService.disconnect.mockRejectedValueOnce(disconnectError);
-
-            await expect(tm1Service.reConnect()).rejects.toThrow('Disconnect failed');
-            expect(mockRestService.connect).not.toHaveBeenCalled();
-        });
-
-        test('should reject when connect fails after successful disconnect', async () => {
-            mockRestService.disconnect.mockResolvedValueOnce(void 0);
+        test('should propagate errors from connect', async () => {
             mockRestService.connect.mockRejectedValueOnce(new Error('Connect failed'));
 
             await expect(tm1Service.reConnect()).rejects.toThrow('Connect failed');
-            expect(mockRestService.disconnect).toHaveBeenCalledTimes(1);
             expect(mockRestService.connect).toHaveBeenCalledTimes(1);
         });
     });

--- a/src/tests/tm1Service.test.ts
+++ b/src/tests/tm1Service.test.ts
@@ -99,6 +99,7 @@ describe('TM1Service', () => {
             expect(tm1Service.security).toBeDefined();
             expect(tm1Service.files).toBeDefined();
             expect(tm1Service.sessions).toBeDefined();
+            expect(tm1Service.applications).toBeDefined();
         });
 
         test('should create RestService with provided config', () => {
@@ -382,7 +383,6 @@ describe('TM1Service', () => {
             'annotations',
             'chores',
             'git',
-            'applications',
             'sandboxes',
             'jobs',
             'users',


### PR DESCRIPTION
Closes #82

## Summary

Brings `TM1Service` to parity with tm1py by wiring up the 13 services that had implementations under `src/services/` but were not exposed on the main entry point. Also fixes the `version`, `whoami`, and reconnect surface to match tm1py semantics.

## Changes

- **12 new lazy-init service getters** following the established `server`/`monitoring` pattern:
  `annotations`, `chores`, `git`, `sandboxes`, `jobs`, `users`, `threads`, `transactionLogs`, `messageLogs`, `configuration`, `auditLogs`, `loggers`
- `applications` left as eager-init public field (preserves the pre-existing writable API contract; was already wired up before this PR)
- **Cached `version`**: new sync `version` getter delegates to `RestService._serverVersion`; `getVersion()` async now delegates to `RestService.getVersion()` which already caches. Eliminates redundant HTTP calls on repeated access.
- **`whoami()` returns `User`**: previously returned `Promise<string>` (just the name). Now returns `Promise<User>` to match tm1py.
- **New `reConnect()`** that calls `connect()` only — exact parity with tm1py's `re_connect()`. The issue text described a teardown-then-reconnect flow, but that actually matches `reAuthenticate()` (already present pre-PR), not tm1py's `re_connect`. CLAUDE.md's parity rule was given precedence; both behaviours are available under distinct names.
- **`reAuthenticate()`** retained unchanged — still performs `disconnect()` then `connect()` for callers that want a full teardown.

## Parity with tm1py

| Method | tm1py | this PR |
|---|---|---|
| `reConnect()` | `re_connect()`: `connect()` only | `connect()` only ✓ |
| `reAuthenticate()` | *(no counterpart)* | `disconnect()` then `connect()` (pre-existing API preserved) |
| `whoami()` | returns `User` | returns `User` (was `string`, now fixed) ✓ |
| `version` | sync property backed by cached `_version` | sync getter backed by cached `_serverVersion` ✓ |
| 12 new services | eager writable attributes | lazy read-only getters — Node.js-idiomatic deviation requested by issue #82 spec ("lazy-initialized properties") and matching the existing `server`/`monitoring` pattern. Test doubles should mock via `jest.mock('./XService')`. |

## Breaking Change

`whoami()` return type changes from `Promise<string>` to `Promise<User>`. Callers that previously did `const name = await tm1.whoami()` must now do `const name = (await tm1.whoami()).name`. Aligned with the v2.0.0 milestone.

## Test plan

- [x] All 63 `tm1Service.test.ts` tests pass (includes 24 `test.each` rows for lazy-init + identity caching across 12 services, `version` getter coverage, `reConnect` parity tests asserting `connect()` is called and `disconnect()` is not, and the retained `reAuthenticate` disconnect-then-connect tests)
- [x] Full project test suite: 1390/1392 pass — the 2 failing suites (`mdx.advanced.test.ts`, `security.advanced.test.ts`) also fail on `main` and are unrelated to this change
- [x] `tsc --noEmit` clean
- [x] Commit history is clean and atomic

## Reference

- tm1py [`TM1Service.py`](https://github.com/cubewise-code/tm1py/blob/master/TM1py/Services/TM1Service.py) — service property layout, `whoami` return type, `version` semantics, and `re_connect` signature
