### PR TITLE
fix(#61): UserType string enum, CaseAndSpaceInsensitiveSet casing preservation

### DIFF
--- a/src/objects/User.ts
+++ b/src/objects/User.ts
@@ -9,6 +9,10 @@ export enum UserType {
     OperationsAdmin = 'OperationsAdmin'
 }
 
+const USER_TYPE_LOOKUP = new Map<string, UserType>(
+    Object.entries(UserType).map(([k, v]) => [k.toLowerCase(), v as UserType])
+);
+
 export class User extends TM1Object {
     /** Abstraction of a TM1 User
      * 
@@ -70,16 +74,15 @@ export class User extends TM1Object {
     }
 
     public set userType(value: UserType | string) {
-        const lowerValue = lowerAndDropSpaces(value);
-        const match = Object.entries(UserType).find(([key]) => key.toLowerCase() === lowerValue);
-        if (!match) {
+        const resolved = USER_TYPE_LOOKUP.get(lowerAndDropSpaces(value));
+        if (resolved === undefined) {
             throw new Error(`Invalid user type=${value}`);
         }
-        this._userType = match[1] as UserType;
+        this._userType = resolved;
 
         // update groups as well, since TM1 doesn't react to change in user_type property
         if (this._userType !== UserType.User) {
-            this.addGroup(this._userType.toString());
+            this.addGroup(this._userType);
         }
     }
 

--- a/src/objects/User.ts
+++ b/src/objects/User.ts
@@ -1,12 +1,12 @@
 import { TM1Object } from './TM1Object';
-import { CaseAndSpaceInsensitiveSet, formatUrl } from '../utils/Utils';
+import { CaseAndSpaceInsensitiveSet, formatUrl, lowerAndDropSpaces } from '../utils/Utils';
 
 export enum UserType {
-    User = 0,
-    SecurityAdmin = 1,
-    DataAdmin = 2,
-    Admin = 3,
-    OperationsAdmin = 4
+    User = 'User',
+    SecurityAdmin = 'SecurityAdmin',
+    DataAdmin = 'DataAdmin',
+    Admin = 'Admin',
+    OperationsAdmin = 'OperationsAdmin'
 }
 
 export class User extends TM1Object {
@@ -70,21 +70,12 @@ export class User extends TM1Object {
     }
 
     public set userType(value: UserType | string) {
-        if (typeof value === 'string') {
-            // Parse string to UserType enum
-            const lowerValue = value.replace(/\s+/g, '').toLowerCase();
-            for (const [key, enumValue] of Object.entries(UserType)) {
-                if (key.toLowerCase() === lowerValue) {
-                    this._userType = enumValue as UserType;
-                    break;
-                }
-            }
-            if (this._userType === undefined) {
-                throw new Error(`Invalid element type=${value}`);
-            }
-        } else {
-            this._userType = value;
+        const lowerValue = lowerAndDropSpaces(value);
+        const match = Object.entries(UserType).find(([key]) => key.toLowerCase() === lowerValue);
+        if (!match) {
+            throw new Error(`Invalid user type=${value}`);
         }
+        this._userType = match[1] as UserType;
 
         // update groups as well, since TM1 doesn't react to change in user_type property
         if (this._userType !== UserType.User) {

--- a/src/objects/User.ts
+++ b/src/objects/User.ts
@@ -103,7 +103,7 @@ export class User extends TM1Object {
     }
 
     public get isAdmin(): boolean {
-        return this._groups.has("ADMIN");
+        return this._groups.has("Admin");
     }
 
     public get isDataAdmin(): boolean {
@@ -159,7 +159,7 @@ export class User extends TM1Object {
             userAsDict.Groups.map((group: any) => group.Name),
             userAsDict.FriendlyName,
             undefined, // password not included in dict
-            userAsDict.Type,
+            userAsDict.Type ?? undefined,
             userAsDict.Enabled
         );
     }

--- a/src/tests/objects.improved.test.ts
+++ b/src/tests/objects.improved.test.ts
@@ -316,7 +316,7 @@ describe('Object Model - Improved Coverage', () => {
             const user = new User('TestUser', []);
             user.addGroup('NewGroup');
             
-            expect(user.groups).toContain('newgroup'); // lowercase due to CaseAndSpaceInsensitiveSet
+            expect(user.groups).toContain('NewGroup');
         });
     });
 
@@ -370,15 +370,15 @@ describe('Object Model - Improved Coverage', () => {
             
             // Add to basic group
             user.addGroup('Everyone');
-            expect(user.groups).toContain('everyone'); // lowercase
-            
+            expect(user.groups).toContain('Everyone');
+
             // Promote to power user
             user.addGroup('PowerUser');
             expect(user.groups.length).toBeGreaterThan(1);
-            
+
             // Remove from basic group
             user.removeGroup('Everyone');
-            expect(user.groups).toContain('poweruser'); // remaining group
+            expect(user.groups).toContain('PowerUser');
         });
     });
 });

--- a/src/tests/user.issue61.test.ts
+++ b/src/tests/user.issue61.test.ts
@@ -1,0 +1,206 @@
+import { User, UserType } from '../objects/User';
+import { CaseAndSpaceInsensitiveSet } from '../utils/Utils';
+
+describe('UserType — string enum (issue #61)', () => {
+    test('should produce correct string names from toString()', () => {
+        expect(UserType.User.toString()).toBe('User');
+        expect(UserType.SecurityAdmin.toString()).toBe('SecurityAdmin');
+        expect(UserType.DataAdmin.toString()).toBe('DataAdmin');
+        expect(UserType.Admin.toString()).toBe('Admin');
+        expect(UserType.OperationsAdmin.toString()).toBe('OperationsAdmin');
+    });
+
+    test('should serialize Type field as string name in body', () => {
+        const user = new User('Alice', [], undefined, undefined, UserType.Admin);
+        const body = JSON.parse(user.body);
+        expect(body.Type).toBe('Admin');
+    });
+
+    test('should serialize User type as "User" string in body', () => {
+        const user = new User('Alice', []);
+        const body = JSON.parse(user.body);
+        expect(body.Type).toBe('User');
+    });
+
+    test('should parse string value in userType setter', () => {
+        const user = new User('Alice', []);
+        user.userType = 'Admin';
+        expect(user.userType).toBe(UserType.Admin);
+    });
+
+    test('should parse case-insensitive string in userType setter', () => {
+        const user = new User('Alice', []);
+        user.userType = 'admin';
+        expect(user.userType).toBe(UserType.Admin);
+    });
+
+    test('should throw on invalid userType string', () => {
+        const user = new User('Alice', []);
+        expect(() => { user.userType = 'InvalidType'; }).toThrow();
+    });
+});
+
+describe('User — group auto-detection (issue #61)', () => {
+    test('should detect Admin type from groups', () => {
+        const user = new User('Alice', ['Admin']);
+        expect(user.userType).toBe(UserType.Admin);
+    });
+
+    test('should detect SecurityAdmin type from groups', () => {
+        const user = new User('Alice', ['SecurityAdmin']);
+        expect(user.userType).toBe(UserType.SecurityAdmin);
+    });
+
+    test('should detect DataAdmin type from groups', () => {
+        const user = new User('Alice', ['DataAdmin']);
+        expect(user.userType).toBe(UserType.DataAdmin);
+    });
+
+    test('should detect OperationsAdmin type from groups', () => {
+        const user = new User('Alice', ['OperationsAdmin']);
+        expect(user.userType).toBe(UserType.OperationsAdmin);
+    });
+
+    test('should default to User type when no special groups present', () => {
+        const user = new User('Alice', ['Everyone', 'SomeTeam']);
+        expect(user.userType).toBe(UserType.User);
+    });
+
+    test('should add correct string group when userType set to Admin', () => {
+        const user = new User('Alice', []);
+        user.userType = UserType.Admin;
+        expect(user.groups).toContain('Admin');
+    });
+
+    test('should not add a group when userType set to User', () => {
+        const user = new User('Alice', []);
+        user.userType = UserType.User;
+        expect(user.groups).toHaveLength(0);
+    });
+});
+
+describe('User — isXxxAdmin getters (issue #61)', () => {
+    test('should return true for isAdmin when Admin group present', () => {
+        const user = new User('Alice', ['Admin']);
+        expect(user.isAdmin).toBe(true);
+    });
+
+    test('should return false for isAdmin when Admin group absent', () => {
+        const user = new User('Alice', ['Everyone']);
+        expect(user.isAdmin).toBe(false);
+    });
+
+    test('should return true for isDataAdmin when Admin group present', () => {
+        const user = new User('Alice', ['Admin']);
+        expect(user.isDataAdmin).toBe(true);
+    });
+
+    test('should return true for isDataAdmin when DataAdmin group present', () => {
+        const user = new User('Alice', ['DataAdmin']);
+        expect(user.isDataAdmin).toBe(true);
+    });
+
+    test('should return true for isSecurityAdmin when SecurityAdmin group present', () => {
+        const user = new User('Alice', ['SecurityAdmin']);
+        expect(user.isSecurityAdmin).toBe(true);
+    });
+
+    test('should return true for isOpsAdmin when OperationsAdmin group present', () => {
+        const user = new User('Alice', ['OperationsAdmin']);
+        expect(user.isOpsAdmin).toBe(true);
+    });
+});
+
+describe('User.fromDict — Type field parsing (issue #61)', () => {
+    test('should parse Type string field from API response dict', () => {
+        const dict = {
+            Name: 'Alice',
+            FriendlyName: 'Alice',
+            Groups: [{ Name: 'Admin' }],
+            Type: 'Admin',
+            Enabled: true,
+        };
+        const user = User.fromDict(dict);
+        expect(user.userType).toBe(UserType.Admin);
+    });
+
+    test('should parse SecurityAdmin Type field from API response dict', () => {
+        const dict = {
+            Name: 'Bob',
+            FriendlyName: 'Bob',
+            Groups: [{ Name: 'SecurityAdmin' }],
+            Type: 'SecurityAdmin',
+            Enabled: true,
+        };
+        const user = User.fromDict(dict);
+        expect(user.userType).toBe(UserType.SecurityAdmin);
+    });
+});
+
+describe('CaseAndSpaceInsensitiveSet — casing preservation (issue #61)', () => {
+    test('should preserve original casing of first insertion', () => {
+        const set = new CaseAndSpaceInsensitiveSet();
+        set.add('Admin');
+        set.add('ADMIN');
+        set.add('admin');
+        expect(set.size).toBe(1);
+        expect(Array.from(set)).toEqual(['Admin']);
+    });
+
+    test('should find by any casing variant', () => {
+        const set = new CaseAndSpaceInsensitiveSet();
+        set.add('HelloWorld');
+        expect(set.has('helloworld')).toBe(true);
+        expect(set.has('HELLOWORLD')).toBe(true);
+        expect(set.has('Hello World')).toBe(true);
+        expect(set.has('hello world')).toBe(true);
+    });
+
+    test('should return first-inserted casing during iteration', () => {
+        const set = new CaseAndSpaceInsensitiveSet();
+        set.add('MyGroup');
+        set.add('mygroup');
+        set.add('MYGROUP');
+        expect(Array.from(set)).toEqual(['MyGroup']);
+    });
+
+    test('should delete by any casing variant', () => {
+        const set = new CaseAndSpaceInsensitiveSet();
+        set.add('Admin');
+        expect(set.delete('ADMIN')).toBe(true);
+        expect(set.size).toBe(0);
+        expect(set.has('Admin')).toBe(false);
+    });
+
+    test('should return false when deleting non-existent entry', () => {
+        const set = new CaseAndSpaceInsensitiveSet();
+        expect(set.delete('NonExistent')).toBe(false);
+    });
+
+    test('should maintain correct size after operations', () => {
+        const set = new CaseAndSpaceInsensitiveSet();
+        set.add('A');
+        set.add('B');
+        set.add('a'); // duplicate — ignored
+        expect(set.size).toBe(2);
+        set.delete('A');
+        expect(set.size).toBe(1);
+    });
+
+    test('should clear all entries', () => {
+        const set = new CaseAndSpaceInsensitiveSet();
+        set.add('A');
+        set.add('B');
+        set.clear();
+        expect(set.size).toBe(0);
+        expect(set.has('A')).toBe(false);
+    });
+
+    test('should handle values with spaces', () => {
+        const set = new CaseAndSpaceInsensitiveSet();
+        set.add('Data Admin');
+        expect(set.has('dataadmin')).toBe(true);
+        expect(set.has('DataAdmin')).toBe(true);
+        expect(Array.from(set)).toEqual(['Data Admin']);
+    });
+});

--- a/src/utils/Utils.ts
+++ b/src/utils/Utils.ts
@@ -92,8 +92,8 @@ export class CaseAndSpaceInsensitiveSet extends Set<string> {
 
     delete(value: string): boolean {
         const key = lowerAndDropSpaces(value);
-        if (!this._normalizedMap.has(key)) return false;
-        const original = this._normalizedMap.get(key)!;
+        const original = this._normalizedMap.get(key);
+        if (original === undefined) return false;
         this._normalizedMap.delete(key);
         return super.delete(original);
     }

--- a/src/utils/Utils.ts
+++ b/src/utils/Utils.ts
@@ -65,20 +65,42 @@ export class CaseAndSpaceInsensitiveMap<T> extends Map<string, T> {
 }
 
 export class CaseAndSpaceInsensitiveSet extends Set<string> {
-    private normalizeValue(value: string): string {
-        return value.toLowerCase().replace(/\s+/g, '');
+    private _normalizedMap: Map<string, string>;
+
+    constructor(values?: Iterable<string>) {
+        super();
+        this._normalizedMap = new Map<string, string>();
+        if (values) {
+            for (const v of values) {
+                this.add(v);
+            }
+        }
     }
 
     add(value: string): this {
-        return super.add(this.normalizeValue(value));
+        const key = lowerAndDropSpaces(value);
+        if (!this._normalizedMap.has(key)) {
+            this._normalizedMap.set(key, value);
+            super.add(value);
+        }
+        return this;
     }
 
     has(value: string): boolean {
-        return super.has(this.normalizeValue(value));
+        return this._normalizedMap.has(lowerAndDropSpaces(value));
     }
 
     delete(value: string): boolean {
-        return super.delete(this.normalizeValue(value));
+        const key = lowerAndDropSpaces(value);
+        if (!this._normalizedMap.has(key)) return false;
+        const original = this._normalizedMap.get(key)!;
+        this._normalizedMap.delete(key);
+        return super.delete(original);
+    }
+
+    clear(): void {
+        this._normalizedMap.clear();
+        super.clear();
     }
 }
 


### PR DESCRIPTION
## Summary

- Convert `UserType` from numeric enum to string enum so `.toString()` returns `"Admin"` instead of `"3"`, fixing body serialization and group auto-detection
- Rewrite `CaseAndSpaceInsensitiveSet` to preserve first-inserted casing during iteration while maintaining case+space-insensitive membership tests (`has`, `delete`)
- Add explicit constructor so callers that pass an iterable (e.g. `new CaseAndSpaceInsensitiveSet(descendants)` in `HierarchyService`) work correctly
- Simplify `userType` setter with module-level `USER_TYPE_LOOKUP` map (O(1) lookup, no per-call allocation)
- Fix `isAdmin` getter to use consistent casing (`"Admin"`) matching sibling getters
- Fix `User.fromDict` to coerce `null` Type to `undefined` so constructor falls back to group-based auto-detection instead of crashing

## Test plan

- [x] `src/tests/user.issue61.test.ts` — 29 new tests covering string enum serialization, case-insensitive setter parsing, group auto-detection, `isXxxAdmin` getters, `fromDict` parsing, and all `CaseAndSpaceInsensitiveSet` operations
- [x] `src/tests/objects.improved.test.ts` — updated 3 assertions to expect original casing (old assertions expected lowercase due to the now-fixed normalization bug)
- [x] `tsc --noEmit` passes with zero errors
- [x] Full unit suite: 1,467 tests passing, 0 new failures

Closes #61