### PR TITLE
fix(#70): align AnonymousSubset.fromDict with tm1py exactly (incl. bug)

### DIFF
--- a/src/objects/Subset.ts
+++ b/src/objects/Subset.ts
@@ -241,7 +241,7 @@ export class AnonymousSubset extends Subset {
             const hierarchyOdata = subsetAsDict["Hierarchy@odata.bind"];
             const segments = parseODataBindUrl(hierarchyOdata);
 
-            if (segments.length < 2 || !segments[0] || !segments[1]) {
+            if (segments.length < 2) {
                 throw new Error(
                     `Unexpected value for 'Hierarchy@odata.bind' property in subset dict: '${hierarchyOdata}'`
                 );

--- a/src/objects/Subset.ts
+++ b/src/objects/Subset.ts
@@ -1,5 +1,5 @@
 import { TM1Object } from './TM1Object';
-import { formatUrl, readObjectNameFromUrl } from '../utils/Utils';
+import { formatUrl, parseODataBindUrl } from '../utils/Utils';
 
 export class Subset extends TM1Object {
     /** Abstraction of the TM1 Subset (dynamic and static)
@@ -239,15 +239,16 @@ export class AnonymousSubset extends Subset {
             hierarchyName = subsetAsDict["Hierarchy"]["Name"];
         } else if ("Hierarchy@odata.bind" in subsetAsDict) {
             const hierarchyOdata = subsetAsDict["Hierarchy@odata.bind"];
+            const segments = parseODataBindUrl(hierarchyOdata);
 
-            dimensionName = readObjectNameFromUrl(hierarchyOdata);
-            hierarchyName = readObjectNameFromUrl(hierarchyOdata);
-
-            if (!dimensionName || !hierarchyName) {
+            if (segments.length < 2 || !segments[0] || !segments[1]) {
                 throw new Error(
                     `Unexpected value for 'Hierarchy@odata.bind' property in subset dict: '${hierarchyOdata}'`
                 );
             }
+
+            dimensionName = segments[0];
+            hierarchyName = segments[1];
         } else {
             throw new Error("Subset dict must contain 'Hierarchy' or 'Hierarchy@odata.bind' as key");
         }

--- a/src/objects/Subset.ts
+++ b/src/objects/Subset.ts
@@ -1,5 +1,5 @@
 import { TM1Object } from './TM1Object';
-import { formatUrl, parseODataBindUrl } from '../utils/Utils';
+import { formatUrl, readObjectNameFromUrl } from '../utils/Utils';
 
 export class Subset extends TM1Object {
     /** Abstraction of the TM1 Subset (dynamic and static)
@@ -239,16 +239,29 @@ export class AnonymousSubset extends Subset {
             hierarchyName = subsetAsDict["Hierarchy"]["Name"];
         } else if ("Hierarchy@odata.bind" in subsetAsDict) {
             const hierarchyOdata = subsetAsDict["Hierarchy@odata.bind"];
-            const segments = parseODataBindUrl(hierarchyOdata);
 
-            if (segments.length < 2) {
+            // tm1py parity (TM1py/Objects/Subset.py): two read_object_name_from_url
+            // calls with these exact regex patterns. Both return match.group(1) (the
+            // first capture group), so both names resolve to the dimension. This
+            // mirrors tm1py's behavior — including the latent bug where a non-default
+            // hierarchy name in the URL is dropped. Do NOT "fix" without tm1py.
+            const dimResult = readObjectNameFromUrl(
+                hierarchyOdata,
+                /^Dimensions\('(.*?)'\)\/Hierarchies\('(.+?)'\)/
+            );
+            const hierResult = readObjectNameFromUrl(
+                hierarchyOdata,
+                /^Dimensions\('(.+?)'\)\/Hierarchies\('(.*?)'\)/
+            );
+
+            if (!dimResult || !hierResult) {
                 throw new Error(
                     `Unexpected value for 'Hierarchy@odata.bind' property in subset dict: '${hierarchyOdata}'`
                 );
             }
 
-            dimensionName = segments[0];
-            hierarchyName = segments[1];
+            dimensionName = dimResult;
+            hierarchyName = hierResult;
         } else {
             throw new Error("Subset dict must contain 'Hierarchy' or 'Hierarchy@odata.bind' as key");
         }

--- a/src/tests/objectModelParity.test.ts
+++ b/src/tests/objectModelParity.test.ts
@@ -10,6 +10,7 @@ import { MDXView } from '../objects/MDXView';
 import { Hierarchy } from '../objects/Hierarchy';
 import { Element, ElementType } from '../objects/Element';
 import { ElementAttribute, ElementAttributeType } from '../objects/ElementAttribute';
+import { readObjectNameFromUrl } from '../utils/Utils';
 
 // ---------------------------------------------------------------------------
 // Bug 1 & 2 (Axis.ts): ViewAxisSelection.fromDict and ViewTitleSelection.fromDict
@@ -656,5 +657,44 @@ describe('ViewAxisSelection.fromDict — anonymous subset with non-default hiera
         const anon = sel.subset as AnonymousSubset;
         expect(anon.dimensionName).toBe('Region');
         expect(anon.hierarchyName).toBe('Region');
+    });
+});
+
+describe('readObjectNameFromUrl — tm1py parity (#70)', () => {
+    test('with pattern: URL-decodes percent-encoded names (mirrors urllib.parse.unquote)', () => {
+        const result = readObjectNameFromUrl(
+            "Dimensions('My%20Dim')/Hierarchies('H')",
+            /^Dimensions\('(.+?)'\)/
+        );
+        expect(result).toBe('My Dim');
+    });
+
+    test('with pattern: passes through malformed %XX (urllib.unquote permissive parity)', () => {
+        // Python: urllib.parse.unquote('Bad%ZZName') === 'Bad%ZZName'
+        // JS decodeURIComponent throws on malformed %XX — we catch and pass through.
+        const result = readObjectNameFromUrl(
+            "Dimensions('Bad%ZZName')/Hierarchies('H')",
+            /^Dimensions\('(.+?)'\)/
+        );
+        expect(result).toBe('Bad%ZZName');
+    });
+
+    test('with pattern: returns null on no match (mirrors re.match returning None)', () => {
+        const result = readObjectNameFromUrl(
+            "Foo('A')/Bar('B')",
+            /^Dimensions\('(.+?)'\)/
+        );
+        expect(result).toBeNull();
+    });
+
+    test('without pattern: preserves existing string return type (no API break)', () => {
+        // Type-level guarantee via overload — runtime check that result is still a string.
+        const result: string = readObjectNameFromUrl("Dimensions('Region')");
+        expect(result).toBe('Region');
+    });
+
+    test('without pattern: returns empty string on no match (backward compat)', () => {
+        const result: string = readObjectNameFromUrl('');
+        expect(result).toBe('');
     });
 });

--- a/src/tests/objectModelParity.test.ts
+++ b/src/tests/objectModelParity.test.ts
@@ -572,3 +572,72 @@ describe('ElementAttribute.equals', () => {
         expect(a.equals(b)).toBe(false);
     });
 });
+
+// ---------------------------------------------------------------------------
+// Issue #70 (Subset.ts): AnonymousSubset.fromDict URL parsing
+// ---------------------------------------------------------------------------
+
+describe('AnonymousSubset.fromDict — Hierarchy@odata.bind parsing (#70)', () => {
+    test('parses dimension and hierarchy separately when names match', () => {
+        const sub = AnonymousSubset.fromDict({
+            'Hierarchy@odata.bind': "Dimensions('Region')/Hierarchies('Region')",
+            Elements: [{ Name: 'North' }]
+        });
+        expect(sub.dimensionName).toBe('Region');
+        expect(sub.hierarchyName).toBe('Region');
+    });
+
+    test('parses non-default hierarchy name (the bug from #70)', () => {
+        const sub = AnonymousSubset.fromDict({
+            'Hierarchy@odata.bind': "Dimensions('Region')/Hierarchies('Region_Alt')",
+            Expression: '{[Region].[Region_Alt].Members}'
+        });
+        expect(sub.dimensionName).toBe('Region');
+        expect(sub.hierarchyName).toBe('Region_Alt');
+    });
+
+    test('parses Hierarchy entity form correctly', () => {
+        const sub = AnonymousSubset.fromDict({
+            Hierarchy: { Name: 'Region_Alt', Dimension: { Name: 'Region' } },
+            Elements: [{ Name: 'North' }]
+        });
+        expect(sub.dimensionName).toBe('Region');
+        expect(sub.hierarchyName).toBe('Region_Alt');
+    });
+
+    test('throws for malformed URL missing Hierarchies segment', () => {
+        expect(() => AnonymousSubset.fromDict({
+            'Hierarchy@odata.bind': "Dimensions('Region')"
+        })).toThrow(/Unexpected value for 'Hierarchy@odata.bind'/);
+    });
+
+    test('throws when neither Hierarchy nor Hierarchy@odata.bind present', () => {
+        expect(() => AnonymousSubset.fromDict({})).toThrow(/must contain 'Hierarchy'/);
+    });
+
+    test('round-trip: fromDict preserves alt hierarchy through bodyAsDict', () => {
+        const sub = AnonymousSubset.fromDict({
+            'Hierarchy@odata.bind': "Dimensions('Region')/Hierarchies('Region_Alt')",
+            Elements: [{ Name: 'North' }]
+        });
+        const body = sub.bodyAsDict;
+        expect(body['Hierarchy@odata.bind']).toContain("Dimensions('Region')");
+        expect(body['Hierarchy@odata.bind']).toContain("Hierarchies('Region_Alt')");
+    });
+});
+
+describe('ViewAxisSelection.fromDict — anonymous subset with non-default hierarchy (#70)', () => {
+    test('preserves non-default hierarchy through ViewAxisSelection path', () => {
+        const dict = {
+            Subset: {
+                'Hierarchy@odata.bind': "Dimensions('Region')/Hierarchies('Region_Alt')",
+                Elements: [{ Name: 'North' }]
+            }
+        };
+        const sel = ViewAxisSelection.fromDict(dict);
+        expect(sel.dimensionName).toBe('Region');
+        const anon = sel.subset as AnonymousSubset;
+        expect(anon.dimensionName).toBe('Region');
+        expect(anon.hierarchyName).toBe('Region_Alt');
+    });
+});

--- a/src/tests/objectModelParity.test.ts
+++ b/src/tests/objectModelParity.test.ts
@@ -575,10 +575,15 @@ describe('ElementAttribute.equals', () => {
 
 // ---------------------------------------------------------------------------
 // Issue #70 (Subset.ts): AnonymousSubset.fromDict URL parsing
+//
+// These tests lock in tm1py's literal behavior — INCLUDING the latent bug
+// where read_object_name_from_url always returns match.group(1), causing both
+// segments to resolve to the dimension name. Do NOT "fix" these tests to
+// reflect more "correct" behavior — see CLAUDE.md "Strict tm1py Parity".
 // ---------------------------------------------------------------------------
 
 describe('AnonymousSubset.fromDict — Hierarchy@odata.bind parsing (#70)', () => {
-    test('parses dimension and hierarchy separately when names match', () => {
+    test('parses dimension and hierarchy when names match', () => {
         const sub = AnonymousSubset.fromDict({
             'Hierarchy@odata.bind': "Dimensions('Region')/Hierarchies('Region')",
             Elements: [{ Name: 'North' }]
@@ -587,13 +592,15 @@ describe('AnonymousSubset.fromDict — Hierarchy@odata.bind parsing (#70)', () =
         expect(sub.hierarchyName).toBe('Region');
     });
 
-    test('parses non-default hierarchy name (the bug from #70)', () => {
+    test('non-default hierarchy resolves to dimension name (tm1py bug parity)', () => {
+        // tm1py's read_object_name_from_url returns match.group(1) twice, both
+        // capturing the dimension. Hierarchy name in the URL is silently lost.
         const sub = AnonymousSubset.fromDict({
             'Hierarchy@odata.bind': "Dimensions('Region')/Hierarchies('Region_Alt')",
             Expression: '{[Region].[Region_Alt].Members}'
         });
         expect(sub.dimensionName).toBe('Region');
-        expect(sub.hierarchyName).toBe('Region_Alt');
+        expect(sub.hierarchyName).toBe('Region');
     });
 
     test('parses Hierarchy entity form correctly', () => {
@@ -605,9 +612,16 @@ describe('AnonymousSubset.fromDict — Hierarchy@odata.bind parsing (#70)', () =
         expect(sub.hierarchyName).toBe('Region_Alt');
     });
 
-    test('throws for malformed URL missing Hierarchies segment', () => {
+    test('throws for URL missing Hierarchies segment', () => {
         expect(() => AnonymousSubset.fromDict({
             'Hierarchy@odata.bind': "Dimensions('Region')"
+        })).toThrow(/Unexpected value for 'Hierarchy@odata.bind'/);
+    });
+
+    test('throws for non-Dimensions/Hierarchies URL shape (tm1py shape validation)', () => {
+        // tm1py's regex anchors on Dimensions(...)/Hierarchies(...) — other shapes fail.
+        expect(() => AnonymousSubset.fromDict({
+            'Hierarchy@odata.bind': "Foo('A')/Bar('B')"
         })).toThrow(/Unexpected value for 'Hierarchy@odata.bind'/);
     });
 
@@ -615,19 +629,22 @@ describe('AnonymousSubset.fromDict — Hierarchy@odata.bind parsing (#70)', () =
         expect(() => AnonymousSubset.fromDict({})).toThrow(/must contain 'Hierarchy'/);
     });
 
-    test('round-trip: fromDict preserves alt hierarchy through bodyAsDict', () => {
+    test('round-trip: alt hierarchy in URL is dropped via tm1py-equivalent parsing', () => {
+        // Input has Hierarchies('Region_Alt') but tm1py's parsing collapses both
+        // to the dimension name, so bodyAsDict reflects Hierarchies('Region').
         const sub = AnonymousSubset.fromDict({
             'Hierarchy@odata.bind': "Dimensions('Region')/Hierarchies('Region_Alt')",
             Elements: [{ Name: 'North' }]
         });
         const body = sub.bodyAsDict;
-        expect(body['Hierarchy@odata.bind']).toContain("Dimensions('Region')");
-        expect(body['Hierarchy@odata.bind']).toContain("Hierarchies('Region_Alt')");
+        expect(body['Hierarchy@odata.bind']).toBe(
+            "Dimensions('Region')/Hierarchies('Region')"
+        );
     });
 });
 
 describe('ViewAxisSelection.fromDict — anonymous subset with non-default hierarchy (#70)', () => {
-    test('preserves non-default hierarchy through ViewAxisSelection path', () => {
+    test('hierarchy in URL collapses to dimension name (tm1py bug parity)', () => {
         const dict = {
             Subset: {
                 'Hierarchy@odata.bind': "Dimensions('Region')/Hierarchies('Region_Alt')",
@@ -638,6 +655,6 @@ describe('ViewAxisSelection.fromDict — anonymous subset with non-default hiera
         expect(sel.dimensionName).toBe('Region');
         const anon = sel.subset as AnonymousSubset;
         expect(anon.dimensionName).toBe('Region');
-        expect(anon.hierarchyName).toBe('Region_Alt');
+        expect(anon.hierarchyName).toBe('Region');
     });
 });

--- a/src/utils/Utils.ts
+++ b/src/utils/Utils.ts
@@ -358,8 +358,19 @@ export function verifyVersion(actualVersion: string, requiredVersion: string): b
     return true; // Equal versions
 }
 
-export function readObjectNameFromUrl(url: string): string {
-    // Extract object name from URL like "/Dimensions('DimName')" -> "DimName"
+export function readObjectNameFromUrl(url: string, pattern?: string | RegExp): string | null {
+    // tm1py parity: when `pattern` is provided, behave like
+    // `re.match(pattern, url)` + `unquote(match.group(1))` — anchored at start,
+    // URL-decodes the first capture group, returns null on no match.
+    if (pattern !== undefined) {
+        const re = typeof pattern === 'string'
+            ? new RegExp(pattern.startsWith('^') ? pattern : '^' + pattern)
+            : pattern;
+        const m = url.match(re);
+        if (!m || m[1] === undefined) return null;
+        return decodeURIComponent(m[1]);
+    }
+    // Backward-compat: extract first ('name') segment, return '' on no match
     const match = url.match(/\('([^']+)'\)/);
     return match ? match[1] : '';
 }

--- a/src/utils/Utils.ts
+++ b/src/utils/Utils.ts
@@ -358,6 +358,10 @@ export function verifyVersion(actualVersion: string, requiredVersion: string): b
     return true; // Equal versions
 }
 
+// Overloads preserve the narrow `string` return for the existing no-pattern form
+// (published npm API — widening to `string | null` would break downstream consumers).
+export function readObjectNameFromUrl(url: string): string;
+export function readObjectNameFromUrl(url: string, pattern: string | RegExp): string | null;
 export function readObjectNameFromUrl(url: string, pattern?: string | RegExp): string | null {
     // tm1py parity: when `pattern` is provided, behave like
     // `re.match(pattern, url)` + `unquote(match.group(1))` — anchored at start,
@@ -368,7 +372,13 @@ export function readObjectNameFromUrl(url: string, pattern?: string | RegExp): s
             : pattern;
         const m = url.match(re);
         if (!m || m[1] === undefined) return null;
-        return decodeURIComponent(m[1]);
+        try {
+            return decodeURIComponent(m[1]);
+        } catch {
+            // tm1py parity: urllib.parse.unquote is permissive on malformed %XX
+            // (returns the original string). decodeURIComponent throws — fall back.
+            return m[1];
+        }
     }
     // Backward-compat: extract first ('name') segment, return '' on no match
     const match = url.match(/\('([^']+)'\)/);


### PR DESCRIPTION
## Summary

Closes #70.

`AnonymousSubset.fromDict` previously called `readObjectNameFromUrl(url)` twice with no pattern argument, returning the first `('name')` segment for both. tm1py's `AnonymousSubset.from_dict` does **almost** the same thing — but with stricter URL shape validation via two anchored `Dimensions(...)/Hierarchies(...)` regex patterns. This PR brings tm1npm into byte-for-byte parity with tm1py.

### What tm1py actually does (verified against tm1py master)

```python
dimension_name = read_object_name_from_url(
    url=hierarchy_odata, pattern=r"Dimensions\('(.*?)'\)/Hierarchies\('(.+?)'\)"
)
hierarchy_name = read_object_name_from_url(
    url=hierarchy_odata, pattern=r"Dimensions\('(.+?)'\)/Hierarchies\('(.*?)'\)"
)
if not all([dimension_name, hierarchy_name]):
    raise ValueError(...)
```

`read_object_name_from_url` always returns `match.group(1)` — the first capture group — which in BOTH patterns is the **dimension** name. So both `dimension_name` and `hierarchy_name` resolve to the dimension. The hierarchy name in the URL is silently dropped. **This is a known latent bug in tm1py.**

Per CLAUDE.md `⛔ CRITICAL: Strict tm1py Parity — Including Bugs`, tm1npm must replicate this behavior exactly. Earlier commits in this PR diverged to "correctly" extract the hierarchy — that divergence has now been reverted.

## Changes

- **`src/utils/Utils.ts`** — Add optional `pattern?: string | RegExp` argument to `readObjectNameFromUrl`, matching tm1py's `read_object_name_from_url(url, pattern)` signature. With pattern: anchored match (mirrors `re.match`), `decodeURIComponent` (mirrors `unquote`), returns `null` on no match. Without pattern: existing behavior preserved (no breaking change for `edgeCases.test.ts`).
- **`src/objects/Subset.ts`** — `AnonymousSubset.fromDict` now calls `readObjectNameFromUrl` twice with tm1py's two exact regex patterns. Restores `if (!dim || !hier) throw` validation. Inline comment documents the parity choice.
- **`src/tests/objectModelParity.test.ts`** — 7 tests locking in tm1py's literal behavior, including the bug:
  - `non-default hierarchy resolves to dimension name (tm1py bug parity)` — asserts `hierarchyName === 'Region'` for a URL with `Hierarchies('Region_Alt')`
  - `throws for non-Dimensions/Hierarchies URL shape (tm1py shape validation)` — `Foo('A')/Bar('B')` now throws (matches tm1py's regex anchoring)
  - `round-trip: alt hierarchy in URL is dropped via tm1py-equivalent parsing` — body output reflects the collapsed names
  - Header comment warns future contributors not to "fix" these tests

## Commit history

- `61d3904` (initial fix using `parseODataBindUrl`) — superseded
- `7ae8031` (refactor: drop redundant non-empty checks) — superseded
- `d81e694` (parity revert: align with tm1py exactly, incl. bug) — **the actual change**

The earlier commits remain in history as a record of the divergence and its correction.

## Test plan

- [x] `node_modules/.bin/tsc --noEmit` — clean
- [x] `node_modules/.bin/jest src/tests/objectModelParity.test.ts` — passes (with new parity-locking assertions)
- [x] `node_modules/.bin/jest src/tests/edgeCases.test.ts` — passes (backward compat preserved)
- [x] Related suites (subset, view, nativeView, edgeCases): **148/148 passing**
- [x] Verified against tm1py master `TM1py/Objects/Subset.py` (lines 217–244) and `TM1py/Utils/Utils.py` (`read_object_name_from_url`)