### PR TITLE
fix(#66): serialize Cube dimensions as Dimensions@odata.bind

### DIFF
--- a/src/objects/Cube.ts
+++ b/src/objects/Cube.ts
@@ -113,7 +113,7 @@ export class Cube extends TM1Object {
     private constructBody(): any {
         const body: any = {
             Name: this._name,
-            Dimensions: this._dimensions.map(dim => ({ Name: dim }))
+            "Dimensions@odata.bind": this._dimensions.map(dim => `Dimensions('${dim}')`)
         };
 
         if (this._rules) {

--- a/src/objects/Cube.ts
+++ b/src/objects/Cube.ts
@@ -1,5 +1,6 @@
 import { TM1Object } from './TM1Object';
 import { Rules } from './Rules';
+import { buildUrlFriendlyObjectName } from '../utils/Utils';
 
 export class Cube extends TM1Object {
     /** Abstraction of a TM1 Cube
@@ -113,7 +114,7 @@ export class Cube extends TM1Object {
     private constructBody(): any {
         const body: any = {
             Name: this._name,
-            "Dimensions@odata.bind": this._dimensions.map(dim => `Dimensions('${dim}')`)
+            "Dimensions@odata.bind": this._dimensions.map(dim => `Dimensions('${buildUrlFriendlyObjectName(dim)}')`)
         };
 
         if (this._rules) {

--- a/src/tests/objects.improved.test.ts
+++ b/src/tests/objects.improved.test.ts
@@ -269,9 +269,11 @@ describe('Object Model - Improved Coverage', () => {
             const dimensions = ['Time', 'Account'];
             const cube = new Cube('TestCube', dimensions);
             const body = JSON.parse(cube.body);
-            
+
             expect(body.Name).toBe('TestCube');
-            expect(body.Dimensions).toHaveLength(2);
+            expect(body['Dimensions@odata.bind']).toHaveLength(2);
+            expect(body['Dimensions@odata.bind'][0]).toBe("Dimensions('Time')");
+            expect(body['Dimensions@odata.bind'][1]).toBe("Dimensions('Account')");
         });
 
         test('should create cube from dictionary', () => {

--- a/src/tests/objects.improved.test.ts
+++ b/src/tests/objects.improved.test.ts
@@ -276,6 +276,16 @@ describe('Object Model - Improved Coverage', () => {
             expect(body['Dimensions@odata.bind'][1]).toBe("Dimensions('Account')");
         });
 
+        test('should escape special characters in dimension names (parity with tm1py format_url)', () => {
+            const cube = new Cube('TestCube', ["O'Brien", '50%', 'A#B', 'X?Y', 'M&N']);
+            const body = JSON.parse(cube.body);
+            expect(body['Dimensions@odata.bind'][0]).toBe("Dimensions('O''Brien')");
+            expect(body['Dimensions@odata.bind'][1]).toBe("Dimensions('50%25')");
+            expect(body['Dimensions@odata.bind'][2]).toBe("Dimensions('A%23B')");
+            expect(body['Dimensions@odata.bind'][3]).toBe("Dimensions('X%3FY')");
+            expect(body['Dimensions@odata.bind'][4]).toBe("Dimensions('M%26N')");
+        });
+
         test('should create cube from dictionary', () => {
             const cubeDict = {
                 Name: 'TestCube',

--- a/src/utils/Utils.ts
+++ b/src/utils/Utils.ts
@@ -120,6 +120,15 @@ export function escapeODataValue(str: string): string {
     return str.replace(/'/g, "''");
 }
 
+export function buildUrlFriendlyObjectName(objectName: string): string {
+    return objectName
+        .replace(/'/g, "''")
+        .replace(/%/g, "%25")
+        .replace(/#/g, "%23")
+        .replace(/\?/g, "%3F")
+        .replace(/&/g, "%26");
+}
+
 export function formatUrl(template: string, ...args: string[]): string {
     let url = template;
     for (const arg of args) {
@@ -417,6 +426,7 @@ export const Utils = {
     CaseAndSpaceInsensitiveSet,
     caseAndSpaceInsensitiveEquals,
     lowerAndDropSpaces,
+    buildUrlFriendlyObjectName,
     formatUrl,
     extractCellsetCells,
     buildMdxFromAxes,


### PR DESCRIPTION
## Summary
- `Cube.constructBody()` now emits `Dimensions@odata.bind: ["Dimensions('name')"]` instead of inline `Dimensions: [{Name}]`, matching tm1py's `_construct_body` (lines 111-113 of `TM1py/Objects/Cube.py`).
- Adds `buildUrlFriendlyObjectName()` helper to `src/utils/Utils.ts` mirroring tm1py's `build_url_friendly_object_name` (escapes `'` → `''`, `%` → `%25`, `#` → `%23`, `?` → `%3F`, `&` → `%26`). Used when building each bind URL.
- Adds parity test covering all five special characters.

## Parity reference
- `TM1py/Objects/Cube.py` lines 111-113 — `body_as_dict["Dimensions@odata.bind"] = [format_url("Dimensions('{}')", dimension) ...]`
- `TM1py/Utils/Utils.py` line 273 — `build_url_friendly_object_name`

## Test plan
- [x] `tsc --noEmit` clean
- [x] `objects.improved.test.ts` — 36/36 pass (including new special-char escaping test)
- [x] No leaked unrelated files in commit
- [x] External review (Sonnet, round 2): APPROVED

Closes #66