### PR TITLE
fix(#73): align Chore.reschedule contract with tm1py

### DIFF
--- a/src/objects/Chore.ts
+++ b/src/objects/Chore.ts
@@ -148,11 +148,11 @@ export class Chore extends TM1Object {
         return body;
     }
 
-    public reschedule(frequency: ChoreFrequency, startTime?: ChoreStartTime): void {
-        /** Reschedule the chore
+    public setFrequency(frequency: ChoreFrequency, startTime?: ChoreStartTime): void {
+        /** Replace the chore frequency (and optionally start time)
          *
          * :param frequency: new ChoreFrequency
-         * :param start_time: new ChoreStartTime (optional)
+         * :param startTime: new ChoreStartTime (optional)
          */
         this._frequency = frequency;
         if (startTime) {
@@ -197,22 +197,15 @@ export class Chore extends TM1Object {
         return { [this._name]: processNames };
     }
 
-    public rescheduleByTime(days: number = 0, hours: number = 0, minutes: number = 0, seconds: number = 0): void {
-        /** Programmatically reschedule a chore by adding time to current start time
+    public reschedule(days: number = 0, hours: number = 0, minutes: number = 0, seconds: number = 0): void {
+        /** Reschedule the chore by adding time to the current start time.
+         *
          * :param days: Days to add
          * :param hours: Hours to add
          * :param minutes: Minutes to add
          * :param seconds: Seconds to add
          */
-        if (this._startTime.datetime) {
-            const newDateTime = new Date(this._startTime.datetime);
-            newDateTime.setDate(newDateTime.getDate() + days);
-            newDateTime.setHours(newDateTime.getHours() + hours);
-            newDateTime.setMinutes(newDateTime.getMinutes() + minutes);
-            newDateTime.setSeconds(newDateTime.getSeconds() + seconds);
-
-            this._startTime = new ChoreStartTime(newDateTime, this._startTime.tz);
-        }
+        this._startTime.add(days, hours, minutes, seconds);
     }
 
     public static fromJson(choreAsJson: string): Chore {

--- a/src/tests/objectModelParity.test.ts
+++ b/src/tests/objectModelParity.test.ts
@@ -10,6 +10,9 @@ import { MDXView } from '../objects/MDXView';
 import { Hierarchy } from '../objects/Hierarchy';
 import { Element, ElementType } from '../objects/Element';
 import { ElementAttribute, ElementAttributeType } from '../objects/ElementAttribute';
+import { Chore } from '../objects/Chore';
+import { ChoreFrequency } from '../objects/ChoreFrequency';
+import { ChoreStartTime } from '../objects/ChoreStartTime';
 
 // ---------------------------------------------------------------------------
 // Bug 1 & 2 (Axis.ts): ViewAxisSelection.fromDict and ViewTitleSelection.fromDict
@@ -570,5 +573,126 @@ describe('ElementAttribute.equals', () => {
         const a = new ElementAttribute('Revenue', ElementAttributeType.NUMERIC);
         const b = new Element('Revenue', 'Numeric');
         expect(a.equals(b)).toBe(false);
+    });
+});
+
+describe('ChoreStartTime.add (Issue #73)', () => {
+    const buildStartTime = () =>
+        new ChoreStartTime(2020, 1, 1, 0, 0, 0);
+
+    test('adds positive days hours minutes seconds to start time', () => {
+        const st = buildStartTime();
+        st.add(1, 2, 3, 4);
+        expect(st.datetime.getFullYear()).toBe(2020);
+        expect(st.datetime.getMonth()).toBe(0);
+        expect(st.datetime.getDate()).toBe(2);
+        expect(st.datetime.getHours()).toBe(2);
+        expect(st.datetime.getMinutes()).toBe(3);
+        expect(st.datetime.getSeconds()).toBe(4);
+    });
+
+    test('default arguments are all zero (no mutation)', () => {
+        const st = buildStartTime();
+        const originalMs = st.datetime.getTime();
+        st.add();
+        expect(st.datetime.getTime()).toBe(originalMs);
+    });
+
+    test('negative values subtract time', () => {
+        const st = new ChoreStartTime(2020, 1, 2, 0, 0, 0);
+        st.add(-1, 0, 0, 0);
+        expect(st.datetime.getFullYear()).toBe(2020);
+        expect(st.datetime.getMonth()).toBe(0);
+        expect(st.datetime.getDate()).toBe(1);
+    });
+
+    test('hours overflow into days (parity with Python timedelta normalization)', () => {
+        const st = buildStartTime();
+        st.add(0, 25, 0, 0);
+        expect(st.datetime.getDate()).toBe(2);
+        expect(st.datetime.getHours()).toBe(1);
+    });
+
+    test('seconds overflow into minutes', () => {
+        const st = buildStartTime();
+        st.add(0, 0, 0, 75);
+        expect(st.datetime.getMinutes()).toBe(1);
+        expect(st.datetime.getSeconds()).toBe(15);
+    });
+});
+
+describe('Chore.reschedule (Issue #73)', () => {
+    const buildChore = () =>
+        new Chore(
+            'TestChore',
+            new ChoreStartTime(2020, 1, 1, 0, 0, 0),
+            false,
+            true,
+            Chore.SINGLE_COMMIT,
+            new ChoreFrequency(0, 0, 0, 0),
+            []
+        );
+
+    test('reschedule(days, hours, minutes, seconds) mutates start time and leaves frequency unchanged', () => {
+        const chore = buildChore();
+        const originalFrequency = chore.frequency;
+        chore.reschedule(1, 2, 3, 4);
+        expect(chore.startTime.datetime.getDate()).toBe(2);
+        expect(chore.startTime.datetime.getHours()).toBe(2);
+        expect(chore.startTime.datetime.getMinutes()).toBe(3);
+        expect(chore.startTime.datetime.getSeconds()).toBe(4);
+        expect(chore.frequency).toBe(originalFrequency);
+    });
+
+    test('reschedule defaults all components to 0 (no-op)', () => {
+        const chore = buildChore();
+        const originalMs = chore.startTime.datetime.getTime();
+        chore.reschedule();
+        expect(chore.startTime.datetime.getTime()).toBe(originalMs);
+    });
+
+    test('reschedule with negative values subtracts from start time', () => {
+        const chore = new Chore(
+            'TestChore',
+            new ChoreStartTime(2020, 1, 2, 0, 0, 0),
+            false,
+            true,
+            Chore.SINGLE_COMMIT,
+            new ChoreFrequency(0, 0, 0, 0),
+            []
+        );
+        chore.reschedule(-1, 0, 0, 0);
+        expect(chore.startTime.datetime.getDate()).toBe(1);
+    });
+});
+
+describe('Chore.setFrequency (tm1npm-only helper, Issue #73)', () => {
+    const buildChore = () =>
+        new Chore(
+            'TestChore',
+            new ChoreStartTime(2020, 1, 1, 0, 0, 0),
+            false,
+            true,
+            Chore.SINGLE_COMMIT,
+            new ChoreFrequency(1, 2, 3, 4),
+            []
+        );
+
+    test('replaces frequency without changing start time when startTime omitted', () => {
+        const chore = buildChore();
+        const originalStartMs = chore.startTime.datetime.getTime();
+        const newFreq = new ChoreFrequency(5, 6, 7, 8);
+        chore.setFrequency(newFreq);
+        expect(chore.frequency).toBe(newFreq);
+        expect(chore.startTime.datetime.getTime()).toBe(originalStartMs);
+    });
+
+    test('replaces both frequency and start time when startTime provided', () => {
+        const chore = buildChore();
+        const newFreq = new ChoreFrequency(5, 6, 7, 8);
+        const newStart = new ChoreStartTime(2025, 6, 15, 12, 0, 0);
+        chore.setFrequency(newFreq, newStart);
+        expect(chore.frequency).toBe(newFreq);
+        expect(chore.startTime).toBe(newStart);
     });
 });


### PR DESCRIPTION
## Summary
- Renames the previous `reschedule(frequency, startTime?)` (which simply replaced frequency) to `setFrequency(...)` — kept as a tm1npm-only helper.
- Implements a new `reschedule(days, hours, minutes, seconds)` matching tm1py's contract: adds the time delta to `_startTime` via `ChoreStartTime.add(...)`, leaves frequency untouched, returns void.
- Adds 10 parity tests covering positive/negative/zero deltas, hour/second overflow, frequency-unchanged guarantee, and `setFrequency` retention behavior.

## Parity reference
- `TM1py/Objects/Chore.py` line 156 — `Chore.reschedule`
- `TM1py/Objects/ChoreStartTime.py` line 84 — `ChoreStartTime.add`

```python
def reschedule(self, days=0, hours=0, minutes=0, seconds=0):
    self._start_time.add(days=days, hours=hours, minutes=minutes, seconds=seconds)
```

## Test plan
- [x] `tsc --noEmit` clean
- [x] `objectModelParity.test.ts` — 66/66 pass (10 new tests)
- [x] No callers of the old `reschedule` signature exist in the repo (verified via grep)
- [x] External review (Sonnet, round 2): APPROVED

Closes #73