### PR TITLE
fix(#77): correct Hierarchy element key normalization and elementNames getter

### DIFF
--- a/src/objects/Hierarchy.ts
+++ b/src/objects/Hierarchy.ts
@@ -1,7 +1,7 @@
 import { TM1Object } from './TM1Object';
 import { Element, ElementType } from './Element';
 import { ElementAttribute } from './ElementAttribute';
-import { lowerAndDropSpaces } from '../utils/Utils';
+import { lowerAndDropSpaces, caseAndSpaceInsensitiveEquals } from '../utils/Utils';
 
 export class Hierarchy extends TM1Object {
     private _name: string;
@@ -29,7 +29,7 @@ export class Hierarchy extends TM1Object {
 
         if (elements) {
             for (const elem of elements) {
-                this._elements.set(elem.name.toLowerCase(), elem);
+                this._elements.set(lowerAndDropSpaces(elem.name), elem);
             }
         }
 
@@ -98,7 +98,7 @@ export class Hierarchy extends TM1Object {
     }
 
     public get elementNames(): string[] {
-        return Array.from(this._elements.keys());
+        return Array.from(this._elements.values()).map(e => e.name);
     }
 
     public get elementAttributes(): ElementAttribute[] {
@@ -172,19 +172,19 @@ export class Hierarchy extends TM1Object {
     }
 
     public addElement(element: Element): void {
-        this._elements.set(element.name.toLowerCase(), element);
+        this._elements.set(lowerAndDropSpaces(element.name), element);
     }
 
     public removeElement(elementName: string): boolean {
-        return this._elements.delete(elementName.toLowerCase());
+        return this._elements.delete(lowerAndDropSpaces(elementName));
     }
 
     public getElement(elementName: string): Element | undefined {
-        return this._elements.get(elementName.toLowerCase());
+        return this._elements.get(lowerAndDropSpaces(elementName));
     }
 
     public hasElement(elementName: string): boolean {
-        return this._elements.has(elementName.toLowerCase());
+        return this._elements.has(lowerAndDropSpaces(elementName));
     }
 
     public addEdge(parentName: string, componentName: string, weight: number = 1): void {
@@ -216,7 +216,7 @@ export class Hierarchy extends TM1Object {
 
     public removeElementAttribute(attributeName: string): boolean {
         const index = this._elementAttributes.findIndex(ea =>
-            ea.name.toLowerCase() === attributeName.toLowerCase());
+            caseAndSpaceInsensitiveEquals(ea.name, attributeName));
 
         if (index !== -1) {
             this._elementAttributes.splice(index, 1);
@@ -227,12 +227,12 @@ export class Hierarchy extends TM1Object {
 
     public getElementAttribute(attributeName: string): ElementAttribute | undefined {
         return this._elementAttributes.find(ea =>
-            ea.name.toLowerCase() === attributeName.toLowerCase());
+            caseAndSpaceInsensitiveEquals(ea.name, attributeName));
     }
 
     public hasElementAttribute(attributeName: string): boolean {
         return this._elementAttributes.some(ea =>
-            ea.name.toLowerCase() === attributeName.toLowerCase());
+            caseAndSpaceInsensitiveEquals(ea.name, attributeName));
     }
 
     public getAncestors(elementName: string, recursive: boolean = false): string[] {
@@ -337,7 +337,7 @@ export class Hierarchy extends TM1Object {
             const element = this._elements.get(oldKey)!;
             element.name = newName;
             this._elements.delete(oldKey);
-            this._elements.set(newName.toLowerCase(), element);
+            this._elements.set(lowerAndDropSpaces(newName), element);
         }
 
         // Rebuild edges replacing all occurrences of oldName

--- a/src/tests/objects.improved.test.ts
+++ b/src/tests/objects.improved.test.ts
@@ -95,7 +95,7 @@ describe('Object Model - Improved Coverage', () => {
             const hierarchy = new Hierarchy('TestHierarchy', 'TestDimension', elements);
             
             expect(hierarchy.elements).toHaveLength(2);
-            expect(hierarchy.elementNames).toEqual(['element1', 'element2']);
+            expect(hierarchy.elementNames).toEqual(['Element1', 'Element2']);
         });
 
         test('should get hierarchy body', () => {


### PR DESCRIPTION
## Summary
Descoped to ship only the two real-world bugs, deferring pure-parity changes to a future PR.

**Bug 1 — Element key normalization:** `_elements` lookups used `.toLowerCase()` only, missing space stripping. Names like `"Total Sales"` could not be matched against `"totalsales"` in case+space insensitive lookups. All `_elements` set/get/has/delete operations, the `replaceElement` rename, and element-attribute lookups (`removeElementAttribute` / `getElementAttribute` / `hasElementAttribute`) now use `lowerAndDropSpaces` / `caseAndSpaceInsensitiveEquals` — matching tm1py's `CaseAndSpaceInsensitiveDict`.

**Bug 2 — `elementNames` getter:** returned normalized (lowercased, despaced) keys instead of original `Element.name` values. Any caller passing those names back to TM1 REST endpoints would have sent wrong names. Now returns original names via `_elements.values().map(e => e.name)`, matching tm1py's `CaseAndSpaceInsensitiveDict.__iter__` which yields original-cased keys.

## Deferred (out of scope for this PR)
- Edge structure refactor to flat `Map<compositeKey, EdgeEntry>` — internal-only change with no observable bug today.
- Conditional `ElementAttributes` in `constructBody` — pure parity, no observable functional impact.

These can be addressed in a follow-up if/when the strict-parity surface area is needed.

## Parity reference
- `TM1py/Objects/Hierarchy.py` — `CaseAndSpaceInsensitiveDict` element storage
- `TM1py/Utils/Utils.py` `lower_and_drop_spaces`

## Test plan
- [x] `tsc --noEmit` clean
- [x] `objects.improved.test.ts` + `objectModelParity.test.ts` — 104/104 pass
- [x] No remaining `.toLowerCase()` calls in `Hierarchy.ts`
- [x] Public API (`hierarchy.edges`) untouched

Closes #77