### PR TITLE
fix(#75): align NativeView fromDict, remove*, and substituteTitle with tm1py

### DIFF
--- a/src/objects/Axis.ts
+++ b/src/objects/Axis.ts
@@ -102,6 +102,10 @@ export class ViewTitleSelection {
         return this._subset;
     }
 
+    public set subset(value: Subset | AnonymousSubset) {
+        this._subset = value;
+    }
+
     public get dimensionName(): string {
         return this._dimensionName;
     }

--- a/src/objects/NativeView.ts
+++ b/src/objects/NativeView.ts
@@ -163,86 +163,70 @@ export class NativeView extends View {
         this._rows.push(row);
     }
 
-    public removeTitle(dimensionName: string): boolean {
-        const index = this._titles.findIndex(t =>
-            caseAndSpaceInsensitiveEquals(t.dimensionName, dimensionName));
-        if (index !== -1) {
-            this._titles.splice(index, 1);
-            return true;
-        }
-        return false;
+    public removeTitle(dimensionName: string): void {
+        this._titles = this._titles.filter(
+            t => !caseAndSpaceInsensitiveEquals(t.dimensionName, dimensionName));
     }
 
-    public removeColumn(dimensionName: string): boolean {
-        const index = this._columns.findIndex(c =>
-            caseAndSpaceInsensitiveEquals(c.subset.dimensionName, dimensionName));
-        if (index !== -1) {
-            this._columns.splice(index, 1);
-            return true;
-        }
-        return false;
+    public removeColumn(dimensionName: string): void {
+        this._columns = this._columns.filter(
+            c => !caseAndSpaceInsensitiveEquals(c.dimensionName, dimensionName));
     }
 
-    public removeRow(dimensionName: string): boolean {
-        const index = this._rows.findIndex(r =>
-            caseAndSpaceInsensitiveEquals(r.subset.dimensionName, dimensionName));
-        if (index !== -1) {
-            this._rows.splice(index, 1);
-            return true;
-        }
-        return false;
+    public removeRow(dimensionName: string): void {
+        this._rows = this._rows.filter(
+            r => !caseAndSpaceInsensitiveEquals(r.dimensionName, dimensionName));
     }
 
     public substituteTitle(dimension: string, element: string): void {
-        /** Substitute the title element for a given dimension
-         *
-         * :param dimension: str, name of dimension
-         * :param element: str, name of element
-         */
         for (const title of this._titles) {
             if (caseAndSpaceInsensitiveEquals(title.dimensionName, dimension)) {
+                title.subset = new AnonymousSubset(dimension, dimension, undefined, [element]);
                 title.selected = element;
                 return;
             }
         }
-        throw new Error(`No title with dimension: '${dimension}'`);
+        throw new Error(`Dimension '${dimension}' not found in titles`);
     }
 
-    public static fromJSON(viewAsJson: string, cubeName: string): NativeView {
+    public static fromJSON(viewAsJson: string, cubeName?: string): NativeView {
         const viewAsDict = JSON.parse(viewAsJson);
         return NativeView.fromDict(viewAsDict, cubeName);
     }
 
-    public static fromDict(viewAsDict: any, cubeName: string): NativeView {
+    public static fromDict(viewAsDict: any, cubeName?: string): NativeView {
+        let resolvedCube = cubeName;
+        if (!resolvedCube) {
+            const ctx: string = viewAsDict["@odata.context"];
+            resolvedCube = ctx.substring(20, ctx.indexOf("')/"));
+        }
+
         const view = new NativeView(
-            cubeName,
+            resolvedCube,
             viewAsDict.Name,
             viewAsDict.SuppressEmptyColumns || false,
             viewAsDict.SuppressEmptyRows || false,
             viewAsDict.FormatString || "0.#########"
         );
 
-        // Parse titles
         if (viewAsDict.Titles) {
             for (const titleDict of viewAsDict.Titles) {
-                const title = ViewTitleSelection.fromDict(titleDict);
-                view.addTitle(title);
+                if (!('Selected' in titleDict) && !('Selected@odata.bind' in titleDict)) {
+                    throw new Error("View Title dict must contain 'Selected' or 'Selected@odata.bind' as key");
+                }
+                view.addTitle(ViewTitleSelection.fromDict(titleDict));
             }
         }
 
-        // Parse columns
         if (viewAsDict.Columns) {
             for (const columnDict of viewAsDict.Columns) {
-                const column = ViewAxisSelection.fromDict(columnDict);
-                view.addColumn(column);
+                view.addColumn(ViewAxisSelection.fromDict(columnDict));
             }
         }
 
-        // Parse rows
         if (viewAsDict.Rows) {
             for (const rowDict of viewAsDict.Rows) {
-                const row = ViewAxisSelection.fromDict(rowDict);
-                view.addRow(row);
+                view.addRow(ViewAxisSelection.fromDict(rowDict));
             }
         }
 

--- a/src/tests/objectModelParity.test.ts
+++ b/src/tests/objectModelParity.test.ts
@@ -288,6 +288,139 @@ describe('NativeView.fromDict', () => {
 });
 
 // ---------------------------------------------------------------------------
+// Issue #75: NativeView fromDict, remove methods, substituteTitle parity
+// ---------------------------------------------------------------------------
+
+describe('NativeView.fromDict — title validation (issue #75)', () => {
+    test("throws when title dict lacks both 'Selected' and 'Selected@odata.bind'", () => {
+        const dict = {
+            Name: 'V',
+            SuppressEmptyColumns: false,
+            SuppressEmptyRows: false,
+            FormatString: '0.#',
+            Titles: [
+                {
+                    'Subset@odata.bind': "Dimensions('Region')/Hierarchies('Region')/Subsets('All')"
+                }
+            ],
+            Columns: [],
+            Rows: []
+        };
+        expect(() => NativeView.fromDict(dict, 'Cube')).toThrow(
+            "View Title dict must contain 'Selected' or 'Selected@odata.bind' as key"
+        );
+    });
+});
+
+describe('NativeView.fromDict — cubeName from @odata.context (issue #75)', () => {
+    test('extracts cubeName from @odata.context when not provided', () => {
+        const dict = {
+            '@odata.context': "../$metadata#Cubes('SalesCube')/Views/$entity",
+            Name: 'V',
+            SuppressEmptyColumns: false,
+            SuppressEmptyRows: false,
+            FormatString: '0.#',
+            Titles: [],
+            Columns: [],
+            Rows: []
+        };
+        const view = NativeView.fromDict(dict);
+        expect(view.cube).toBe('SalesCube');
+    });
+
+    test('prefers explicit cubeName over @odata.context', () => {
+        const dict = {
+            '@odata.context': "../$metadata#Cubes('WrongCube')/Views/$entity",
+            Name: 'V',
+            SuppressEmptyColumns: false,
+            SuppressEmptyRows: false,
+            FormatString: '0.#',
+            Titles: [],
+            Columns: [],
+            Rows: []
+        };
+        const view = NativeView.fromDict(dict, 'CorrectCube');
+        expect(view.cube).toBe('CorrectCube');
+    });
+});
+
+describe('NativeView.removeColumn / removeRow / removeTitle — remove ALL matches (issue #75)', () => {
+    test('removeColumn removes all matching columns', () => {
+        const view = new NativeView('Cube', 'View');
+        view.addColumn(new ViewAxisSelection('Region', new AnonymousSubset('Region', 'Region', undefined, ['North'])));
+        view.addColumn(new ViewAxisSelection('Region', new AnonymousSubset('Region', 'Region', undefined, ['South'])));
+        view.addColumn(new ViewAxisSelection('Month', new AnonymousSubset('Month', 'Month', undefined, ['Jan'])));
+        view.removeColumn('Region');
+        expect(view.columns).toHaveLength(1);
+        expect(view.columns[0].dimensionName).toBe('Month');
+    });
+
+    test('removeRow removes all matching rows', () => {
+        const view = new NativeView('Cube', 'View');
+        view.addRow(new ViewAxisSelection('Region', new AnonymousSubset('Region', 'Region', undefined, ['North'])));
+        view.addRow(new ViewAxisSelection('Region', new AnonymousSubset('Region', 'Region', undefined, ['South'])));
+        view.addRow(new ViewAxisSelection('Month', new AnonymousSubset('Month', 'Month', undefined, ['Jan'])));
+        view.removeRow('Region');
+        expect(view.rows).toHaveLength(1);
+        expect(view.rows[0].dimensionName).toBe('Month');
+    });
+
+    test('removeTitle removes all matching titles', () => {
+        const view = new NativeView('Cube', 'View');
+        const sub = new AnonymousSubset('Region', 'Region', undefined, ['North']);
+        view.addTitle(new ViewTitleSelection('Region', sub, 'North'));
+        view.addTitle(new ViewTitleSelection('Region', sub, 'South'));
+        view.addTitle(new ViewTitleSelection('Month', new AnonymousSubset('Month', 'Month', undefined, ['Jan']), 'Jan'));
+        view.removeTitle('Region');
+        expect(view.titles).toHaveLength(1);
+        expect(view.titles[0].dimensionName).toBe('Month');
+    });
+
+    test('removeColumn is case and space insensitive', () => {
+        const view = new NativeView('Cube', 'View');
+        view.addColumn(new ViewAxisSelection('Region', new AnonymousSubset('Region', 'Region', undefined, ['North'])));
+        view.removeColumn(' region ');
+        expect(view.columns).toHaveLength(0);
+    });
+});
+
+describe('NativeView.substituteTitle — replaces subset and selected (issue #75)', () => {
+    test('replaces subset with AnonymousSubset(dim, dim, [element]) and updates selected', () => {
+        const view = new NativeView('Cube', 'View');
+        view.addTitle(new ViewTitleSelection(
+            'Region',
+            new AnonymousSubset('Region', 'Region', undefined, ['North', 'South']),
+            'North'
+        ));
+        view.substituteTitle('Region', 'South');
+        expect(view.titles[0].selected).toBe('South');
+        const newSubset = view.titles[0].subset as AnonymousSubset;
+        expect(newSubset).toBeInstanceOf(AnonymousSubset);
+        expect(newSubset.elements).toEqual(['South']);
+    });
+
+    test('new subset uses caller-provided dimension as both dimension and hierarchy', () => {
+        const view = new NativeView('Cube', 'View');
+        view.addTitle(new ViewTitleSelection(
+            'Region',
+            new AnonymousSubset('Region', 'AltHierarchy', undefined, ['North']),
+            'North'
+        ));
+        view.substituteTitle('Region', 'South');
+        const newSubset = view.titles[0].subset as AnonymousSubset;
+        expect(newSubset.dimensionName).toBe('Region');
+        expect(newSubset.hierarchyName).toBe('Region');
+    });
+
+    test("throws \"Dimension '...' not found in titles\" when dimension missing", () => {
+        const view = new NativeView('Cube', 'View');
+        expect(() => view.substituteTitle('NonExistent', 'Value')).toThrow(
+            "Dimension 'NonExistent' not found in titles"
+        );
+    });
+});
+
+// ---------------------------------------------------------------------------
 // Bug 4 & 5 (Hierarchy.ts): Edge key type + traversal methods
 // ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## Summary

Closes #75 — four `NativeView` parity fixes against tm1py master `Objects/NativeView.py`.

- `removeColumn` / `removeRow` / `removeTitle` now filter ALL matches and key on the axis selection's `dimensionName` (matches tm1py `column.dimension_name`); return `void` to mirror tm1py.
- `substituteTitle` replaces `_subset` with `new AnonymousSubset(dim, dim, [element])` AND updates `_selected`, raising tm1py's exact error text `Dimension '<x>' not found in titles`.
- `fromDict` validates each Title has `Selected` or `Selected@odata.bind` and throws tm1py's exact error text otherwise.
- `fromDict` / `fromJSON` make `cubeName` optional; when omitted, derived from `@odata.context` via the same `[20:find("')/")]` slice tm1py uses.
- `Axis.ts`: added public `set subset(value)` on `ViewTitleSelection` so the parity-correct subset replacement is possible (mirrors Python's mutable `_subset` attribute).

## Files Changed

- `src/objects/NativeView.ts` (+26 / −42)
- `src/objects/Axis.ts` (+4)
- `src/tests/objectModelParity.test.ts` (+133, 10 new tests)

## Parity Notes

Other parity gaps surfaced during review (silent defaults for `SuppressEmptyColumns`/`Rows`, `Subset`-with-`Name` distinction in `Axis.fromDict`, malformed `Selected@odata.bind` validation, `dynamic_properties` parsing) are intentionally **out of scope** for this issue and deferred to dedicated follow-up issues per the strict-parity rule.

## Test plan

- [x] `tsc --noEmit` clean
- [x] `jest src/tests/objectModelParity.test.ts` — 102/102 passing (10 new tests for #75)
- [x] Full suite: only pre-existing flaky integration suites unrelated to NativeView fail
- [x] Plan + internal reviewer + external reviewer all APPROVED with 0 P0 / 0 P1
