### PR TITLE
fix(#69): align CellService with tm1py — remove fabricated endpoints

### DIFF
--- a/src/services/CellService.ts
+++ b/src/services/CellService.ts
@@ -185,6 +185,26 @@ export class CellService {
         try { await this.deleteCellset(cellsetId, sandboxName); } catch (_) { /* best-effort cleanup */ }
     }
 
+    /**
+     * Fetch a cellset with the expand/select shape required by _cellsetToTupleDict —
+     * notably Members.UniqueName and Hierarchies.Dimension.Name. Mirrors the elem/member
+     * properties that tm1py's extract_cellset_raw requests for element_unique_names=True.
+     */
+    private async _extractCellsetForTupleDict(cellsetId: string, sandboxName?: string): Promise<any> {
+        const expand =
+            'Cells,' +
+            'Axes($expand=' +
+                'Tuples($expand=Members($select=Name,UniqueName;$expand=Element($select=UniqueName))),' +
+                'Hierarchies($select=Name;$expand=Dimension($select=Name))' +
+            ')';
+        const params = new URLSearchParams();
+        params.append('$expand', expand);
+        if (sandboxName) params.append('$sandbox', sandboxName);
+        const url = `/Cellsets('${cellsetId}')?${params.toString()}`;
+        const response = await this.rest.get(url);
+        return response.data;
+    }
+
     private static _cellsetToTupleDict(cellset: any, cubeDimensions?: readonly string[]): Map<string, any> {
         const result = new Map<string, any>();
         if (!cellset?.Cells || !cellset?.Axes) return result;
@@ -1026,7 +1046,7 @@ export class CellService {
             options.sandbox_name
         );
         try {
-            const cellset = await this.extractCellset(cellsetId, true, options.sandbox_name);
+            const cellset = await this._extractCellsetForTupleDict(cellsetId, options.sandbox_name);
             const cubeDims = await this.getDimensionNamesForWriting(cubeName);
             return CellService._cellsetToTupleDict(cellset, cubeDims);
         } finally {
@@ -1964,13 +1984,18 @@ END;
             const targetCube = referenceCube || cube;
             const refBindings = referenceUniqueElementNames.map(unique => {
                 const [dim, hier, elem] = CellService._parseUniqueElementName(unique);
-                return formatUrl("Dimensions('{}')/Hierarchies('{}')/Elements('{}')", dim, hier, elem);
+                return formatUrl(
+                    "Dimensions('{}')/Hierarchies('{}')/Elements('{}')",
+                    escapeODataValue(dim),
+                    escapeODataValue(hier),
+                    escapeODataValue(elem),
+                );
             });
             const payload = {
                 BeginOrdinal: 0,
                 Value: 'RP' + String(value),
                 'ReferenceCell@odata.bind': refBindings,
-                'ReferenceCube@odata.bind': formatUrl("Cubes('{}')", targetCube),
+                'ReferenceCube@odata.bind': formatUrl("Cubes('{}')", escapeODataValue(targetCube)),
             };
             let url = formatUrl("/Cellsets('{}')/tm1.Update", cellsetId);
             if (sandboxName) url += `?!sandbox=${encodeURIComponent(sandboxName)}`;
@@ -2047,7 +2072,12 @@ END;
         const updates = Object.entries(cellsetAsDict).map(([tupleKey, value]) => ({
             Cells: [{
                 'Tuple@odata.bind': tupleKey.split(',').map((elem, i) =>
-                    formatUrl("Dimensions('{}')/Hierarchies('{}')/Elements('{}')", dims[i], dims[i], elem)
+                    formatUrl(
+                        "Dimensions('{}')/Hierarchies('{}')/Elements('{}')",
+                        escapeODataValue(dims[i]),
+                        escapeODataValue(dims[i]),
+                        escapeODataValue(elem),
+                    )
                 ),
             }],
             Value: value || '',
@@ -2230,7 +2260,7 @@ END;
     ): Promise<Map<string, any>> {
         const cellsetId = await this.createCellset(mdx, options.sandbox_name);
         try {
-            const cellset = await this.extractCellset(cellsetId, true, options.sandbox_name);
+            const cellset = await this._extractCellsetForTupleDict(cellsetId, options.sandbox_name);
             const cubeDims = options.cubeName
                 ? await this.getDimensionNamesForWriting(options.cubeName)
                 : undefined;

--- a/src/services/CellService.ts
+++ b/src/services/CellService.ts
@@ -185,7 +185,7 @@ export class CellService {
         try { await this.deleteCellset(cellsetId, sandboxName); } catch (_) { /* best-effort cleanup */ }
     }
 
-    private static _cellsetToTupleDict(cellset: any): Map<string, any> {
+    private static _cellsetToTupleDict(cellset: any, cubeDimensions?: readonly string[]): Map<string, any> {
         const result = new Map<string, any>();
         if (!cellset?.Cells || !cellset?.Axes) return result;
         const cardinalities: number[] = cellset.Axes.map((a: any) => a.Cardinality ?? 0);
@@ -197,9 +197,17 @@ export class CellService {
                 (t.Members || []).map((m: any) => m.Element?.UniqueName ?? m.UniqueName ?? m.Name)
             )
         );
-        // Cells are row-major: ordinal index decomposes as (ord % cardA0, ord/cardA0 % cardA1, ...);
-        // tuple key joins members axis-by-axis; tm1py reorders by cube dimensions, which is a
-        // documented parity gap (see IMPLEMENTATION_PLAN.md).
+        // Per-axis dimension names — used to reorder tuple parts to match the cube's natural
+        // dimension order (parity with tm1py's sort_coordinates / Cube.dimensions order).
+        const axisDimNames: string[][] = cellset.Axes.map((axis: any) => {
+            const hier = axis.Hierarchies || [];
+            return hier.map((h: any) => h?.Dimension?.Name ?? h?.Name ?? '');
+        });
+        const dimToCubeIdx = new Map<string, number>();
+        if (cubeDimensions) {
+            cubeDimensions.forEach((dim, i) => dimToCubeIdx.set(lowerAndDropSpaces(dim), i));
+        }
+        // Cells are row-major: ordinal index decomposes as (ord % cardA0, ord/cardA0 % cardA1, ...).
         cellset.Cells.forEach((cell: any, ordinal: number) => {
             const idxByAxis: number[] = [];
             let n = ordinal;
@@ -208,12 +216,24 @@ export class CellService {
                 idxByAxis.push(n % card);
                 n = Math.floor(n / card);
             }
-            const parts: string[] = [];
+            // Collect (dimensionName, memberUniqueName) pairs across all axes.
+            const partsWithDim: Array<{ dim: string; member: string }> = [];
             for (let a = idxByAxis.length - 1; a >= 0; a--) {
                 const tuple = tuplesByAxis[a]?.[idxByAxis[a]] || [];
-                for (const member of tuple) parts.push(member);
+                const dims = axisDimNames[a] || [];
+                tuple.forEach((member: string, i: number) => {
+                    partsWithDim.push({ dim: dims[i] ?? '', member });
+                });
             }
-            result.set(parts.join(','), cell.Value);
+            // If the caller supplied cube dimensions, sort by that order; else preserve axis order.
+            if (cubeDimensions) {
+                partsWithDim.sort((x, y) => {
+                    const xi = dimToCubeIdx.get(lowerAndDropSpaces(x.dim)) ?? Number.MAX_SAFE_INTEGER;
+                    const yi = dimToCubeIdx.get(lowerAndDropSpaces(y.dim)) ?? Number.MAX_SAFE_INTEGER;
+                    return xi - yi;
+                });
+            }
+            result.set(partsWithDim.map(p => p.member).join(','), cell.Value);
         });
         return result;
     }
@@ -989,7 +1009,10 @@ export class CellService {
      * - tm1py's options (cell_properties, top, skip, skip_*, element_unique_names, etc.) are
      *   not yet wired through extractCellset and are deliberately omitted from this signature
      *   so misuse is a compile-time error.
-     * - Tuple-key element order follows axis order, not cube dimension order.
+     * - Tuple-key parts are reordered by cube dimensions (parity with tm1py.sort_coordinates).
+     * - Calls createCellsetFromView, which is itself pre-existing on main and currently
+     *   targets a fabricated /tm1.CreateCellset endpoint (out of #69 scope; tracked
+     *   separately for a future fix to use /Cubes/{}/Views/{}/tm1.Execute per tm1py).
      */
     public async execute_view_async(
         cubeName: string,
@@ -1004,7 +1027,8 @@ export class CellService {
         );
         try {
             const cellset = await this.extractCellset(cellsetId, true, options.sandbox_name);
-            return CellService._cellsetToTupleDict(cellset);
+            const cubeDims = await this.getDimensionNamesForWriting(cubeName);
+            return CellService._cellsetToTupleDict(cellset, cubeDims);
         } finally {
             await this._safeDeleteCellset(cellsetId, options.sandbox_name);
         }
@@ -1933,7 +1957,7 @@ END;
         referenceUniqueElementNames: readonly string[],
         referenceCube?: string,
         sandboxName?: string
-    ): Promise<void> {
+    ): Promise<any> {
         const mdx = `SELECT { ${uniqueElementNames.join('}*{')} } ON 0 FROM [${cube}]`;
         const cellsetId = await this.createCellset(mdx, sandboxName);
         try {
@@ -1950,7 +1974,7 @@ END;
             };
             let url = formatUrl("/Cellsets('{}')/tm1.Update", cellsetId);
             if (sandboxName) url += `?!sandbox=${encodeURIComponent(sandboxName)}`;
-            await this.rest.post(url, JSON.stringify(payload));
+            return await this.rest.post(url, JSON.stringify(payload));
         } finally {
             await this._safeDeleteCellset(cellsetId, sandboxName);
         }
@@ -2197,16 +2221,20 @@ END;
      *   not yet wired through extractCellset. To prevent silent option-drop, those parameters
      *   are deliberately omitted from this signature so misuse is a compile-time error rather
      *   than a runtime no-op. Add them back when the underlying extractor supports them.
-     * - Tuple-key element order follows axis order, not cube dimension order.
+     * - Optional `cubeName` lets the caller request tm1py-compatible tuple-key ordering by
+     *   cube dimensions. When omitted, parts are joined in axis order (tm1py-divergent).
      */
     public async executeMdxAsync(
         mdx: string,
-        options: { sandbox_name?: string } = {}
+        options: { sandbox_name?: string; cubeName?: string } = {}
     ): Promise<Map<string, any>> {
         const cellsetId = await this.createCellset(mdx, options.sandbox_name);
         try {
             const cellset = await this.extractCellset(cellsetId, true, options.sandbox_name);
-            return CellService._cellsetToTupleDict(cellset);
+            const cubeDims = options.cubeName
+                ? await this.getDimensionNamesForWriting(options.cubeName)
+                : undefined;
+            return CellService._cellsetToTupleDict(cellset, cubeDims);
         } finally {
             await this._safeDeleteCellset(cellsetId, options.sandbox_name);
         }

--- a/src/services/CellService.ts
+++ b/src/services/CellService.ts
@@ -8,9 +8,12 @@ import { v4 as uuidv4 } from 'uuid';
 import { RestService } from './RestService';
 import { ProcessService } from './ProcessService';
 import { ViewService } from './ViewService';
+import { SandboxService } from './SandboxService';
 import { OperationStatus, OperationType } from './AsyncOperationService';
+import { MDXView } from '../objects/MDXView';
+import { Process } from '../objects/Process';
 import { TM1Exception } from '../exceptions/TM1Exception';
-import { formatUrl, escapeODataValue } from '../utils/Utils';
+import { formatUrl, escapeODataValue, lowerAndDropSpaces } from '../utils/Utils';
 
 export interface CellsetDict {
     [coordinates: string]: string | number | boolean | null | undefined;
@@ -103,6 +106,105 @@ export class CellService {
         this.rest = rest;
         this.processService = processService;
         this.viewService = viewService;
+    }
+
+    public async sandboxExists(sandboxName: string): Promise<boolean> {
+        const sandboxService = new SandboxService(this.rest);
+        return await sandboxService.exists(sandboxName);
+    }
+
+    public async generateEnableSandboxTi(sandboxName?: string): Promise<string> {
+        if (sandboxName) {
+            if (!(await this.sandboxExists(sandboxName))) {
+                throw new Error(`Sandbox '${sandboxName}' does not exist`);
+            }
+            return `ServerActiveSandboxSet('${sandboxName}');SetUseActiveSandboxProperty(1);`;
+        }
+        return `ServerActiveSandboxSet('');SetUseActiveSandboxProperty(0);`;
+    }
+
+    private static _abbreviateMdx(mdx: string, maxLen: number = 100): string {
+        return mdx.length > maxLen ? mdx.slice(0, maxLen) + '...' : mdx;
+    }
+
+    private static _parseUniqueElementName(uniqueName: string): [string, string, string] {
+        const matches = uniqueName.match(/^\[([^\]]+)\]\.\[([^\]]+)\]\.\[([^\]]+)\]$/);
+        if (matches) {
+            return [matches[1], matches[2], matches[3]];
+        }
+        const twoPart = uniqueName.match(/^\[([^\]]+)\]\.\[([^\]]+)\]$/);
+        if (twoPart) {
+            return [twoPart[1], twoPart[1], twoPart[2]];
+        }
+        throw new Error(`Invalid element unique name: '${uniqueName}'`);
+    }
+
+    private static _parseCsvLine(line: string, separator: string): string[] {
+        const fields: string[] = [];
+        let current = '';
+        let inQuotes = false;
+        for (let i = 0; i < line.length; i++) {
+            const ch = line[i];
+            if (inQuotes) {
+                if (ch === '"' && line[i + 1] === '"') { current += '"'; i++; }
+                else if (ch === '"') { inQuotes = false; }
+                else { current += ch; }
+            } else {
+                if (ch === '"') inQuotes = true;
+                else if (ch === separator) { fields.push(current); current = ''; }
+                else { current += ch; }
+            }
+        }
+        fields.push(current);
+        return fields;
+    }
+
+    private static _extractStringSetFromRowsAndValues(
+        rowsAndValues: { rows: any[][]; values: any[] },
+        excludeEmptyCells: boolean
+    ): Set<string> {
+        const result = new Set<string>();
+        const seen = new Set<string>();
+        const add = (val: any) => {
+            if (typeof val !== 'string') return;
+            if (excludeEmptyCells && val === '') return;
+            const key = lowerAndDropSpaces(val);
+            if (!seen.has(key)) { seen.add(key); result.add(val); }
+        };
+        for (const row of rowsAndValues.rows) for (const elem of row) add(elem);
+        for (const v of rowsAndValues.values) add(v);
+        return result;
+    }
+
+    private async _safeDeleteCellset(cellsetId: string, sandboxName?: string): Promise<void> {
+        try { await this.deleteCellset(cellsetId, sandboxName); } catch (_) { /* best-effort cleanup */ }
+    }
+
+    private static _cellsetToTupleDict(cellset: any): Map<string, any> {
+        const result = new Map<string, any>();
+        if (!cellset?.Cells || !cellset?.Axes) return result;
+        const cardinalities: number[] = cellset.Axes.map((a: any) => a.Cardinality ?? 0);
+        const tuplesByAxis: string[][][] = cellset.Axes.map((axis: any) =>
+            (axis.Tuples || []).map((t: any) => (t.Members || []).map((m: any) => m.Name))
+        );
+        // Cells are row-major: ordinal index decomposes as (ord % cardA0, ord/cardA0 % cardA1, ...);
+        // tuple key is members joined high-axis-first to match tm1py's CaseAndSpaceInsensitiveTuplesDict ordering.
+        cellset.Cells.forEach((cell: any, ordinal: number) => {
+            const idxByAxis: number[] = [];
+            let n = ordinal;
+            for (let a = 0; a < cardinalities.length; a++) {
+                const card = cardinalities[a] || 1;
+                idxByAxis.push(n % card);
+                n = Math.floor(n / card);
+            }
+            const parts: string[] = [];
+            for (let a = idxByAxis.length - 1; a >= 0; a--) {
+                const tuple = tuplesByAxis[a]?.[idxByAxis[a]] || [];
+                for (const member of tuple) parts.push(member);
+            }
+            result.set(parts.join(','), cell.Value);
+        });
+        return result;
     }
 
     /**
@@ -366,34 +468,35 @@ export class CellService {
     }
 
     /**
-     * Clear cube data with MDX filter
+     * Clear cube data with MDX filter.
+     * Reimplements via temporary MDXView + ViewZeroOut TI process (parity with tm1py.clear_with_mdx).
      */
-    public async clearWithMdx(cubeName: string, mdx: string, sandbox_name?: string): Promise<void> {
+    public async clearWithMdx(cubeName: string, mdx: string, sandboxName?: string): Promise<void> {
+        const viewService = this.viewService || new ViewService(this.rest);
+        const enableSandbox = await this.generateEnableSandboxTi(sandboxName);
+
         const viewName = `}TM1py${uuidv4()}`;
 
-        let viewUrl = formatUrl("/Cubes('{}')/Views", cubeName);
-        if (sandbox_name) {
-            viewUrl += `?$sandbox=${sandbox_name}`;
-        }
-        const viewBody = {
-            '@odata.type': 'ibm.tm1.api.v1.MDXView',
-            Name: viewName,
-            MDX: mdx
-        };
-        await this.rest.post(viewUrl, JSON.stringify(viewBody));
+        await viewService.create(new MDXView(cubeName, viewName, mdx), false);
 
         try {
-            let clearUrl = formatUrl("/Cubes('{}')/Views('{}')/tm1.ClearCellValues", cubeName, viewName);
-            if (sandbox_name) {
-                clearUrl += `?$sandbox=${sandbox_name}`;
+            const process = new Process('');
+            process.prologProcedure = enableSandbox;
+            process.epilogProcedure = `ViewZeroOut('${escapeODataValue(cubeName)}','${escapeODataValue(viewName)}');`;
+
+            const url = '/ExecuteProcessWithReturn?$expand=*';
+            const payload = { Process: process.bodyAsDict };
+            const response = await this.rest.post(url, JSON.stringify(payload));
+            const status = (response as any)?.data?.ProcessExecuteStatusCode;
+            if (status !== 'CompletedSuccessfully') {
+                throw new TM1Exception(
+                    `Failed to clear cube: '${cubeName}' with mdx: '${CellService._abbreviateMdx(mdx, 100)}'`
+                );
             }
-            await this.rest.post(clearUrl);
         } finally {
-            try {
-                const deleteUrl = formatUrl("/Cubes('{}')/Views('{}')", cubeName, viewName);
-                await this.rest.delete(deleteUrl);
-            } catch (_) {
-                // Cleanup failure should not mask the original error
+            const exists = await viewService.exists(cubeName, viewName, false);
+            if (exists) {
+                await viewService.delete(cubeName, viewName, false);
             }
         }
     }
@@ -569,33 +672,40 @@ export class CellService {
     }
 
     /**
-     * Write data asynchronously
+     * Write data asynchronously by chunking and dispatching to writeThroughBlob
+     * (parity with tm1py.write_async, which uses ThreadPoolExecutor + write(use_blob=True)).
+     *
+     * Aggregates per-chunk failures into a TM1Exception describing how many chunks failed
+     * (tm1py raises TM1pyWritePartialFailureException; that exception type is not yet ported).
      */
     public async writeAsync(
         cubeName: string,
         cellsetAsDict: CellsetDict,
-        dimensions?: string[],
-        options: WriteOptions = {}
-    ): Promise<string> {
-        const cells = Object.entries(cellsetAsDict).map(([coordinates, value]) => {
-            const elementArray = coordinates.split(',').map(s => s.trim());
-            return {
-                Coordinates: elementArray.map(element => ({ Name: element })),
-                Value: value
-            };
-        });
-
-        let url = `/Cubes('${cubeName}')/tm1.UpdateAsync`;
-        
-        if (options.sandbox_name) {
-            url += `?$sandbox=${options.sandbox_name}`;
+        options: WriteOptions & { slice_size?: number; max_workers?: number; dimensions?: string[] } = {}
+    ): Promise<string | undefined> {
+        const sliceSize = options.slice_size ?? 250_000;
+        const maxWorkers = options.max_workers ?? 8;
+        const entries = Object.entries(cellsetAsDict);
+        const chunks: CellsetDict[] = [];
+        for (let i = 0; i < entries.length; i += sliceSize) {
+            chunks.push(Object.fromEntries(entries.slice(i, i + sliceSize)));
         }
 
-        const body = { Cells: cells };
-        const response = await this.rest.patch(url, body);
-        
-        // Return async operation ID
-        return response.data.ID || response.headers['async-id'] || '';
+        const failures: any[] = [];
+        for (let i = 0; i < chunks.length; i += maxWorkers) {
+            const batch = chunks.slice(i, i + maxWorkers);
+            const results = await Promise.allSettled(
+                batch.map(c => this.writeThroughBlob(cubeName, c, { ...options, use_blob: true }))
+            );
+            for (const r of results) if (r.status === 'rejected') failures.push(r.reason);
+        }
+        if (failures.length) {
+            throw new TM1Exception(
+                `writeAsync partial failure: ${failures.length}/${chunks.length} chunks failed: ` +
+                failures.map(f => f?.message || String(f)).join('; ')
+            );
+        }
+        return undefined;
     }
 
     /**
@@ -707,21 +817,54 @@ export class CellService {
     }
 
     /**
-     * Execute MDX and return cell count
+     * Execute MDX and return row element names + string cell values as a case-and-space-insensitive
+     * deduplicated set (parity with tm1py.execute_mdx_rows_and_values_string_set).
+     */
+    public async executeMdxRowsAndValuesStringSet(
+        mdx: string,
+        excludeEmptyCells: boolean = true,
+        sandboxName?: string
+    ): Promise<Set<string>> {
+        const rav = await this.executeMdxRowsAndValues(mdx, {
+            sandbox_name: sandboxName,
+            element_unique_names: false,
+        });
+        return CellService._extractStringSetFromRowsAndValues(rav, excludeEmptyCells);
+    }
+
+    /**
+     * Execute view and return row element names + string cell values as a case-and-space-insensitive
+     * deduplicated set (parity with tm1py.execute_view_rows_and_values_string_set).
+     */
+    public async executeViewRowsAndValuesStringSet(
+        cubeName: string,
+        viewName: string,
+        isPrivate: boolean = false,
+        excludeEmptyCells: boolean = true,
+        sandboxName?: string
+    ): Promise<Set<string>> {
+        const rav = await this.executeViewRowsAndValues(cubeName, viewName, {
+            sandbox_name: sandboxName,
+            private: isPrivate,
+            element_unique_names: false,
+        });
+        return CellService._extractStringSetFromRowsAndValues(rav, excludeEmptyCells);
+    }
+
+    /**
+     * Execute MDX and return cell count (parity with tm1py.execute_mdx_cellcount).
+     * Uses createCellset + /Cellsets/{id}/Cells/$count.
      */
     public async executeMdxCellcount(
         mdx: string,
         options: MDXViewOptions = {}
     ): Promise<number> {
-        let url = '/ExecuteMDXCellCount';
-
-        if (options.sandbox_name) {
-            url += `?$sandbox=${options.sandbox_name}`;
+        const cellsetId = await this.createCellset(mdx, options.sandbox_name);
+        try {
+            return await this.getCellsetCellsCount(cellsetId, options.sandbox_name);
+        } finally {
+            await this._safeDeleteCellset(cellsetId, options.sandbox_name);
         }
-
-        const body = { MDX: mdx };
-        const response = await this.rest.post(url, body);
-        return response.data.value || response.data.CellCount || 0;
     }
 
     /**
@@ -817,34 +960,41 @@ export class CellService {
     /**
      * Execute view asynchronously
      */
+    /**
+     * Execute view via cellset extraction (parity with tm1py.execute_view_async).
+     * Returns a Map keyed by comma-joined element names.
+     *
+     * tm1py achieves async by parallel-chunked cellset extraction (extract_cellset_async).
+     * That parallelization helper is not yet ported, so this delegates to a serial extract.
+     * Output dict shape is identical; max_workers/async_axis are accepted for API parity.
+     */
     public async execute_view_async(
         cubeName: string,
         viewName: string,
-        options: MDXViewOptions = {}
-    ): Promise<string> {
-        /** Execute view asynchronously and return execution ID
-         *
-         * :param cubeName: name of the cube
-         * :param viewName: name of the view
-         * :param options: view execution options including sandbox_name
-         * :return: execution ID for tracking async operation
-         */
-        let url = `/Cubes('${cubeName}')/Views('${viewName}')/tm1.ExecuteAsync`;
-
-        const params = new URLSearchParams();
-        if (options.private !== undefined) params.append('$private', options.private.toString());
-        if (options.sandbox_name) params.append('$sandbox', options.sandbox_name);
-        if (options.element_unique_names !== undefined) params.append('$element_unique_names', options.element_unique_names.toString());
-        if (options.skip_zeros !== undefined) params.append('$skip_zeros', options.skip_zeros.toString());
-        if (options.skip_consolidated !== undefined) params.append('$skip_consolidated', options.skip_consolidated.toString());
-        if (options.skip_rule_derived !== undefined) params.append('$skip_rule_derived', options.skip_rule_derived.toString());
-
-        if (params.toString()) {
-            url += `?${params.toString()}`;
+        options: MDXViewOptions & {
+            cell_properties?: string[];
+            top?: number;
+            skip_contexts?: boolean;
+            skip?: number;
+            skip_consolidated_cells?: boolean;
+            skip_rule_derived_cells?: boolean;
+            skip_cell_properties?: boolean;
+            max_workers?: number;
+            async_axis?: number;
+        } = {}
+    ): Promise<Map<string, any>> {
+        const cellsetId = await this.createCellsetFromView(
+            cubeName,
+            viewName,
+            options.private || false,
+            options.sandbox_name
+        );
+        try {
+            const cellset = await this.extractCellset(cellsetId, true, options.sandbox_name);
+            return CellService._cellsetToTupleDict(cellset);
+        } finally {
+            await this._safeDeleteCellset(cellsetId, options.sandbox_name);
         }
-
-        const response = await this.rest.post(url);
-        return response.data.ID || response.data.ExecutionId || `view_async_${Date.now()}`;
     }
 
     /**
@@ -1699,22 +1849,33 @@ END;
     }
 
     /**
-     * Execute MDX and return element-value dictionary
+     * Execute MDX and return element-value dictionary (parity with tm1py.execute_mdx_elements_value_dict).
+     * Delegates to executeMdxCsv and parses CSV with header skip + quoted-field support.
      */
     public async executeMdxElementsValueDict(
         mdx: string,
-        sandbox_name?: string
-    ): Promise<{ [element: string]: any }> {
-        let url = '/ExecuteMDXElementsValue';
-        
-        if (sandbox_name) {
-            url += `?$sandbox=${sandbox_name}`;
+        elementSeparator: string = '|',
+        sandboxName?: string,
+        options: { skipZeros?: boolean; skipConsolidatedCells?: boolean; skipRuleDerivedCells?: boolean } = {}
+    ): Promise<{ [key: string]: any }> {
+        const csv = await this.executeMdxCsv(mdx, {
+            sandbox_name: sandboxName,
+            skip_zeros: options.skipZeros !== false,
+            skip_consolidated: options.skipConsolidatedCells,
+            skip_rule_derived: options.skipRuleDerivedCells,
+        });
+        if (!csv) return {};
+        const lines = csv.split(/\r?\n/).filter(l => l.length > 0);
+        if (lines.length <= 1) return {};
+        const result: { [key: string]: any } = {};
+        // Skip header (matches tm1py's `next(reader, None)`).
+        for (let i = 1; i < lines.length; i++) {
+            const fields = CellService._parseCsvLine(lines[i], elementSeparator);
+            if (fields.length < 2) continue;
+            const key = fields.slice(0, -1).join(elementSeparator);
+            result[key] = fields[fields.length - 1];
         }
-
-        const body = { MDX: mdx };
-        const response = await this.rest.post(url, body);
-        
-        return response.data || {};
+        return result;
     }
 
     /**
@@ -1738,22 +1899,42 @@ END;
     }
 
     /**
-     * Execute proportional spread
+     * Execute relative proportional spread (parity with tm1py.relative_proportional_spread).
+     * @param value value to be spread
+     * @param cube name of the cube
+     * @param uniqueElementNames target cell coordinates as unique element names (e.g. ["[d1].[c1]","[d2].[e3]"])
+     * @param referenceUniqueElementNames reference cell coordinates as unique element names
+     * @param referenceCube name of the reference cube. If omitted, defaults to `cube`.
+     * @param sandboxName optional sandbox name
      */
     public async relativeProportionalSpread(
-        cubeName: string,
-        targetCoordinates: string[],
         value: number,
-        options: MDXViewOptions = {}
+        cube: string,
+        uniqueElementNames: readonly string[],
+        referenceUniqueElementNames: readonly string[],
+        referenceCube?: string,
+        sandboxName?: string
     ): Promise<void> {
-        const coordinateString = targetCoordinates.map(c => `'${c}'`).join(',');
-        let url = `/Cubes('${cubeName}')/tm1.ProportionalSpread(coordinates=[${coordinateString}],value=${value})`;
-        
-        if (options.sandbox_name) {
-            url += `?$sandbox=${options.sandbox_name}`;
+        const mdx = `SELECT { ${uniqueElementNames.join('}*{')} } ON 0 FROM [${cube}]`;
+        const cellsetId = await this.createCellset(mdx, sandboxName);
+        try {
+            const targetCube = referenceCube || cube;
+            const refBindings = referenceUniqueElementNames.map(unique => {
+                const [dim, hier, elem] = CellService._parseUniqueElementName(unique);
+                return formatUrl("Dimensions('{}')/Hierarchies('{}')/Elements('{}')", dim, hier, elem);
+            });
+            const payload = {
+                BeginOrdinal: 0,
+                Value: 'RP' + String(value),
+                'ReferenceCell@odata.bind': refBindings,
+                'ReferenceCube@odata.bind': formatUrl("Cubes('{}')", targetCube),
+            };
+            let url = formatUrl("/Cellsets('{}')/tm1.Update", cellsetId);
+            if (sandboxName) url += `?$sandbox=${encodeURIComponent(sandboxName)}`;
+            await this.rest.post(url, JSON.stringify(payload));
+        } finally {
+            await this._safeDeleteCellset(cellsetId, sandboxName);
         }
-
-        await this.rest.post(url);
     }
 
     /**
@@ -1793,20 +1974,43 @@ END;
         return response.data.value === true;
     }
     /**
-     * Write multiple cell values to a cube (legacy method name for compatibility)
+     * Write multiple cell values to a cube (parity with tm1py.write_values).
+     *
+     * Tuple keys are comma-separated dimension elements (e.g. "2024,USA,Books").
+     * Callers must avoid leading/trailing whitespace around commas; element names
+     * are not trimmed in order to preserve fidelity with Python tuple semantics.
+     *
+     * @param cubeName name of the cube
+     * @param cellsetAsDict {tupleKey: value} where tupleKey is comma-joined element names
+     * @param dimensions optional dimension names in natural order (skips a fetch)
+     * @param sandboxName optional sandbox name
+     * @param changeset optional changeset id
+     * @returns the changeset argument (for parity with tm1py)
      */
-    public async writeValues(cubeName: string, cellset: { [key: string]: any }): Promise<void> {
-        const cells = Object.entries(cellset).map(([key, value]) => {
-            const coordinates = key.split(':');
-            return {
-                Coordinates: coordinates.map(c => ({ Name: c })),
-                Value: value
-            };
-        });
+    public async writeValues(
+        cubeName: string,
+        cellsetAsDict: { [tupleKey: string]: any },
+        dimensions?: string[],
+        sandboxName?: string,
+        changeset?: string
+    ): Promise<string | undefined> {
+        const dims = dimensions || await this.getDimensionNamesForWriting(cubeName);
+        let url = formatUrl("/Cubes('{}')/tm1.Update", cubeName);
+        const params: string[] = [];
+        if (sandboxName) params.push(`!sandbox=${encodeURIComponent(sandboxName)}`);
+        if (changeset) params.push(`!ChangeSet=${encodeURIComponent(changeset)}`);
+        if (params.length) url += `?${params.join('&')}`;
 
-        const url = `/Cubes('${cubeName}')/tm1.Update`;
-        const body = { Cells: cells };
-        await this.rest.patch(url, body);
+        const updates = Object.entries(cellsetAsDict).map(([tupleKey, value]) => ({
+            Cells: [{
+                'Tuple@odata.bind': tupleKey.split(',').map((elem, i) =>
+                    formatUrl("Dimensions('{}')/Hierarchies('{}')/Elements('{}')", dims[i], dims[i], elem)
+                ),
+            }],
+            Value: value || '',
+        }));
+        await this.rest.post(url, JSON.stringify(updates));
+        return changeset;
     }
 
     /**
@@ -1820,24 +2024,43 @@ END;
     }
 
     /**
-     * Clear all data in a cube (alias for compatibility)
+     * Clear cube data (parity with tm1py.clear).
+     * Builds NON EMPTY column-axis MDX from optional dimension expressions and delegates
+     * to clearWithMdx (which uses MDXView + ViewZeroOut TI). Unmapped dimensions default
+     * to TM1FILTERBYLEVEL({TM1SUBSETALL([dim])},0).
      */
-    public async clear(cubeName: string, sandbox_name?: string): Promise<void> {
-        let url = `/Cubes('${cubeName}')/tm1.Clear`;
+    public async clear(
+        cubeName: string,
+        dimensionExpressions: Record<string, string> = {},
+        sandboxName?: string
+    ): Promise<void> {
+        const dimensionNames = await this.getDimensionNamesForWriting(cubeName);
+        const normToActual = new Map<string, string>();
+        for (const dim of dimensionNames) normToActual.set(lowerAndDropSpaces(dim), dim);
 
-        if (sandbox_name) {
-            url += `?$sandbox=${sandbox_name}`;
+        const exprByDim: Record<string, string> = {};
+        for (const [key, expr] of Object.entries(dimensionExpressions)) {
+            const actual = normToActual.get(lowerAndDropSpaces(key));
+            if (actual) {
+                const wrapped = expr.trim().startsWith('{') ? expr : `{${expr}}`;
+                exprByDim[actual] = wrapped;
+            }
         }
-
-        await this.rest.post(url);
+        for (const dim of dimensionNames) {
+            if (!(dim in exprByDim)) {
+                exprByDim[dim] = `{TM1FILTERBYLEVEL({TM1SUBSETALL([${dim}])},0)}`;
+            }
+        }
+        const sets = dimensionNames.map(d => exprByDim[d]).join(' * ');
+        const mdx = `SELECT NON EMPTY {${sets}} ON 0 FROM [${cubeName}]`;
+        return this.clearWithMdx(cubeName, mdx, sandboxName);
     }
 
     /**
-     * Clear all data in a cube
+     * Clear all data in a cube (delegates to clear with no expressions).
      */
-    public async clearCube(cubeName: string): Promise<void> {
-        const url = `/Cubes('${cubeName}')/tm1.Clear`;
-        await this.rest.post(url);
+    public async clearCube(cubeName: string, sandboxName?: string): Promise<void> {
+        return this.clear(cubeName, {}, sandboxName);
     }
 
     /**
@@ -1943,23 +2166,39 @@ END;
     }
 
     /**
-     * Execute MDX query asynchronously
+     * Execute MDX via cellset extraction (parity with tm1py.execute_mdx_async).
+     * Returns a Map keyed by comma-joined element names.
+     *
+     * tm1py achieves async by parallel-chunked cellset extraction (extract_cellset_async).
+     * That parallelization helper is not yet ported, so this delegates to a serial extract.
+     * Output dict shape is identical; max_workers/async_axis are accepted for API parity.
      */
-    public async executeMdxAsync(mdx: string, sandbox_name?: string): Promise<string> {
-        /** Execute MDX query asynchronously and return execution ID
-         *
-         * :param mdx: MDX query to execute
-         * :param sandbox_name: optional sandbox name
-         * :return: execution ID for tracking async operation
-         */
-        const url = '/ExecuteMDXAsync';
-        const body = { 
-            MDX: mdx,
-            sandbox_name: sandbox_name 
-        };
-        
-        const response = await this.rest.post(url, body);
-        return response.data.ID || response.data.ExecutionId || `async_${Date.now()}`;
+    public async executeMdxAsync(
+        mdx: string,
+        options: {
+            cell_properties?: string[];
+            top?: number;
+            skip_contexts?: boolean;
+            skip?: number;
+            skip_zeros?: boolean;
+            skip_consolidated_cells?: boolean;
+            skip_rule_derived_cells?: boolean;
+            sandbox_name?: string;
+            element_unique_names?: boolean;
+            skip_cell_properties?: boolean;
+            use_compact_json?: boolean;
+            skip_sandbox_dimension?: boolean;
+            max_workers?: number;
+            async_axis?: number;
+        } = {}
+    ): Promise<Map<string, any>> {
+        const cellsetId = await this.createCellset(mdx, options.sandbox_name);
+        try {
+            const cellset = await this.extractCellset(cellsetId, true, options.sandbox_name);
+            return CellService._cellsetToTupleDict(cellset);
+        } finally {
+            await this._safeDeleteCellset(cellsetId, options.sandbox_name);
+        }
     }
 
     /**

--- a/src/services/CellService.ts
+++ b/src/services/CellService.ts
@@ -184,11 +184,12 @@ export class CellService {
         const result = new Map<string, any>();
         if (!cellset?.Cells || !cellset?.Axes) return result;
         const cardinalities: number[] = cellset.Axes.map((a: any) => a.Cardinality ?? 0);
-        // Prefer UniqueName (matches tm1py default element_unique_names=True);
-        // fall back to Name for cellsets that omit UniqueName.
+        // Prefer Element.UniqueName, then top-level UniqueName, then Name —
+        // matches tm1py's extract_unique_names_from_members fallback order
+        // (Utils.py: m["Element"]["UniqueName"] if Element else m["UniqueName"]).
         const tuplesByAxis: string[][][] = cellset.Axes.map((axis: any) =>
             (axis.Tuples || []).map((t: any) =>
-                (t.Members || []).map((m: any) => m.UniqueName ?? m.Element?.UniqueName ?? m.Name)
+                (t.Members || []).map((m: any) => m.Element?.UniqueName ?? m.UniqueName ?? m.Name)
             )
         );
         // Cells are row-major: ordinal index decomposes as (ord % cardA0, ord/cardA0 % cardA1, ...);

--- a/src/services/CellService.ts
+++ b/src/services/CellService.ts
@@ -182,7 +182,14 @@ export class CellService {
     }
 
     private async _safeDeleteCellset(cellsetId: string, sandboxName?: string): Promise<void> {
-        try { await this.deleteCellset(cellsetId, sandboxName); } catch (_) { /* best-effort cleanup */ }
+        // Mirror tm1py's @tidy_cellset (CellService.py:80-99): suppress 404 (already gone),
+        // re-raise every other status so server-side errors during cleanup are visible.
+        try {
+            await this.deleteCellset(cellsetId, sandboxName);
+        } catch (err: any) {
+            const status = err?.statusCode ?? err?.status ?? err?.response?.status;
+            if (status !== 404) throw err;
+        }
     }
 
     /**
@@ -199,7 +206,9 @@ export class CellService {
             ')';
         const params = new URLSearchParams();
         params.append('$expand', expand);
-        if (sandboxName) params.append('$sandbox', sandboxName);
+        // Cellset endpoints use TM1's write-side !sandbox= form (parity with tm1py's
+        // add_url_parameters("!sandbox", ...) at CellService.py:5064-5073).
+        if (sandboxName) params.append('!sandbox', sandboxName);
         const url = `/Cellsets('${cellsetId}')?${params.toString()}`;
         const response = await this.rest.get(url);
         return response.data;
@@ -1919,13 +1928,15 @@ END;
         mdx: string,
         elementSeparator: string = '|',
         sandboxName?: string,
-        options: { skipZeros?: boolean; skipConsolidatedCells?: boolean; skipRuleDerivedCells?: boolean } = {}
+        options: { skipZeros?: boolean } = {}
     ): Promise<{ [key: string]: any }> {
+        // skip_consolidated_cells / skip_rule_derived_cells are not yet wired through
+        // executeMdxCsv to TM1's URL params, so they are deliberately omitted from this
+        // signature (compile-time enforcement matches the pattern used by executeMdxAsync /
+        // execute_view_async). Add them back when executeMdxCsv accepts them.
         const csv = await this.executeMdxCsv(mdx, {
             sandbox_name: sandboxName,
             skip_zeros: options.skipZeros !== false,
-            skip_consolidated: options.skipConsolidatedCells,
-            skip_rule_derived: options.skipRuleDerivedCells,
         });
         if (!csv) return {};
         const lines = csv.split(/\r?\n/).filter(l => l.length > 0);

--- a/src/services/CellService.ts
+++ b/src/services/CellService.ts
@@ -184,11 +184,16 @@ export class CellService {
         const result = new Map<string, any>();
         if (!cellset?.Cells || !cellset?.Axes) return result;
         const cardinalities: number[] = cellset.Axes.map((a: any) => a.Cardinality ?? 0);
+        // Prefer UniqueName (matches tm1py default element_unique_names=True);
+        // fall back to Name for cellsets that omit UniqueName.
         const tuplesByAxis: string[][][] = cellset.Axes.map((axis: any) =>
-            (axis.Tuples || []).map((t: any) => (t.Members || []).map((m: any) => m.Name))
+            (axis.Tuples || []).map((t: any) =>
+                (t.Members || []).map((m: any) => m.UniqueName ?? m.Element?.UniqueName ?? m.Name)
+            )
         );
         // Cells are row-major: ordinal index decomposes as (ord % cardA0, ord/cardA0 % cardA1, ...);
-        // tuple key is members joined high-axis-first to match tm1py's CaseAndSpaceInsensitiveTuplesDict ordering.
+        // tuple key joins members axis-by-axis; tm1py reorders by cube dimensions, which is a
+        // documented parity gap (see IMPLEMENTATION_PLAN.md).
         cellset.Cells.forEach((cell: any, ordinal: number) => {
             const idxByAxis: number[] = [];
             let n = ordinal;
@@ -962,11 +967,17 @@ export class CellService {
      */
     /**
      * Execute view via cellset extraction (parity with tm1py.execute_view_async).
-     * Returns a Map keyed by comma-joined element names.
+     * Returns a Map keyed by comma-joined element unique-names (or Names if UniqueName missing).
      *
      * tm1py achieves async by parallel-chunked cellset extraction (extract_cellset_async).
      * That parallelization helper is not yet ported, so this delegates to a serial extract.
-     * Output dict shape is identical; max_workers/async_axis are accepted for API parity.
+     *
+     * Documented parity gaps (see IMPLEMENTATION_PLAN.md):
+     * - max_workers / async_axis accepted for API parity but no parallelization performed.
+     * - The following options are accepted but currently dropped: cell_properties, top, skip,
+     *   skip_contexts, skip_zeros, skip_consolidated_cells, skip_rule_derived_cells,
+     *   skip_cell_properties, element_unique_names.
+     * - Tuple-key element order follows axis order, not cube dimension order.
      */
     public async execute_view_async(
         cubeName: string,
@@ -1930,7 +1941,7 @@ END;
                 'ReferenceCube@odata.bind': formatUrl("Cubes('{}')", targetCube),
             };
             let url = formatUrl("/Cellsets('{}')/tm1.Update", cellsetId);
-            if (sandboxName) url += `?$sandbox=${encodeURIComponent(sandboxName)}`;
+            if (sandboxName) url += `?!sandbox=${encodeURIComponent(sandboxName)}`;
             await this.rest.post(url, JSON.stringify(payload));
         } finally {
             await this._safeDeleteCellset(cellsetId, sandboxName);
@@ -2167,11 +2178,17 @@ END;
 
     /**
      * Execute MDX via cellset extraction (parity with tm1py.execute_mdx_async).
-     * Returns a Map keyed by comma-joined element names.
+     * Returns a Map keyed by comma-joined element unique-names (or Names if UniqueName missing).
      *
      * tm1py achieves async by parallel-chunked cellset extraction (extract_cellset_async).
      * That parallelization helper is not yet ported, so this delegates to a serial extract.
-     * Output dict shape is identical; max_workers/async_axis are accepted for API parity.
+     *
+     * Documented parity gaps (see IMPLEMENTATION_PLAN.md):
+     * - max_workers / async_axis accepted for API parity but no parallelization performed.
+     * - The following options are accepted but currently dropped: cell_properties, top, skip,
+     *   skip_contexts, skip_zeros, skip_consolidated_cells, skip_rule_derived_cells,
+     *   skip_cell_properties, use_compact_json, skip_sandbox_dimension, element_unique_names.
+     * - Tuple-key element order follows axis order, not cube dimension order.
      */
     public async executeMdxAsync(
         mdx: string,

--- a/src/services/CellService.ts
+++ b/src/services/CellService.ts
@@ -128,15 +128,20 @@ export class CellService {
     }
 
     private static _parseUniqueElementName(uniqueName: string): [string, string, string] {
-        const matches = uniqueName.match(/^\[([^\]]+)\]\.\[([^\]]+)\]\.\[([^\]]+)\]$/);
-        if (matches) {
-            return [matches[1], matches[2], matches[3]];
+        // Mirror tm1py's substring-based parser exactly (Utils.py:821-844). Non-throwing,
+        // returns 3 strings even for malformed input. Element-name segment unescapes ']]' → ']'.
+        const firstSep = uniqueName.indexOf('].[');
+        const lastSep = uniqueName.lastIndexOf('].[');
+        const dimension = uniqueName.slice(1, firstSep);
+        const elementRaw = uniqueName.slice(lastSep + 3, -1);
+        const element = elementRaw.replace(/\]\]/g, ']');
+        // count occurrences of "]." separator
+        const sepCount = uniqueName.split('].[').length - 1;
+        if (sepCount === 1) {
+            return [dimension, dimension, element];
         }
-        const twoPart = uniqueName.match(/^\[([^\]]+)\]\.\[([^\]]+)\]$/);
-        if (twoPart) {
-            return [twoPart[1], twoPart[1], twoPart[2]];
-        }
-        throw new Error(`Invalid element unique name: '${uniqueName}'`);
+        const hierarchy = uniqueName.slice(firstSep + 3, lastSep);
+        return [dimension, hierarchy, element];
     }
 
     private static _parseCsvLine(line: string, separator: string): string[] {
@@ -488,7 +493,8 @@ export class CellService {
         try {
             const process = new Process('');
             process.prologProcedure = enableSandbox;
-            process.epilogProcedure = `ViewZeroOut('${escapeODataValue(cubeName)}','${escapeODataValue(viewName)}');`;
+            // Mirror tm1py's f-string interpolation exactly — no quote escaping in TI body.
+            process.epilogProcedure = `ViewZeroOut('${cubeName}','${viewName}');`;
 
             const url = '/ExecuteProcessWithReturn?$expand=*';
             const payload = { Process: process.bodyAsDict };
@@ -681,13 +687,20 @@ export class CellService {
      * Write data asynchronously by chunking and dispatching to writeThroughBlob
      * (parity with tm1py.write_async, which uses ThreadPoolExecutor + write(use_blob=True)).
      *
-     * Aggregates per-chunk failures into a TM1Exception describing how many chunks failed
-     * (tm1py raises TM1pyWritePartialFailureException; that exception type is not yet ported).
+     * Documented parity gaps (see IMPLEMENTATION_PLAN.md):
+     * - Only options honored by the underlying writeThroughBlob (sandbox_name, increment,
+     *   deactivate/reactivate_transaction_log, use_blob, use_changeset) flow through. tm1py's
+     *   `dimensions`, `precision`, `measure_dimension_elements`, `skip_non_updateable`, and
+     *   transaction-log toggles are not yet wired through writeThroughBlob and are deliberately
+     *   omitted from this signature so misuse is caught at compile time.
+     * - Per-chunk failures aggregate into a TM1Exception with chunk count (tm1py raises a
+     *   structured TM1pyWritePartialFailureException; that exception type is not yet ported).
      */
     public async writeAsync(
         cubeName: string,
         cellsetAsDict: CellsetDict,
-        options: WriteOptions & { slice_size?: number; max_workers?: number; dimensions?: string[] } = {}
+        options: Pick<WriteOptions, 'sandbox_name' | 'increment' | 'deactivate_transaction_log' | 'reactivate_transaction_log' | 'use_changeset'>
+            & { slice_size?: number; max_workers?: number } = {}
     ): Promise<string | undefined> {
         const sliceSize = options.slice_size ?? 250_000;
         const maxWorkers = options.max_workers ?? 8;
@@ -970,30 +983,18 @@ export class CellService {
      * Execute view via cellset extraction (parity with tm1py.execute_view_async).
      * Returns a Map keyed by comma-joined element unique-names (or Names if UniqueName missing).
      *
-     * tm1py achieves async by parallel-chunked cellset extraction (extract_cellset_async).
-     * That parallelization helper is not yet ported, so this delegates to a serial extract.
-     *
      * Documented parity gaps (see IMPLEMENTATION_PLAN.md):
-     * - max_workers / async_axis accepted for API parity but no parallelization performed.
-     * - The following options are accepted but currently dropped: cell_properties, top, skip,
-     *   skip_contexts, skip_zeros, skip_consolidated_cells, skip_rule_derived_cells,
-     *   skip_cell_properties, element_unique_names.
+     * - tm1py uses extract_cellset_async with parallel-chunked retrieval. Not yet ported;
+     *   this delegates to a serial extractCellset.
+     * - tm1py's options (cell_properties, top, skip, skip_*, element_unique_names, etc.) are
+     *   not yet wired through extractCellset and are deliberately omitted from this signature
+     *   so misuse is a compile-time error.
      * - Tuple-key element order follows axis order, not cube dimension order.
      */
     public async execute_view_async(
         cubeName: string,
         viewName: string,
-        options: MDXViewOptions & {
-            cell_properties?: string[];
-            top?: number;
-            skip_contexts?: boolean;
-            skip?: number;
-            skip_consolidated_cells?: boolean;
-            skip_rule_derived_cells?: boolean;
-            skip_cell_properties?: boolean;
-            max_workers?: number;
-            async_axis?: number;
-        } = {}
+        options: { private?: boolean; sandbox_name?: string } = {}
     ): Promise<Map<string, any>> {
         const cellsetId = await this.createCellsetFromView(
             cubeName,
@@ -1863,6 +1864,12 @@ END;
     /**
      * Execute MDX and return element-value dictionary (parity with tm1py.execute_mdx_elements_value_dict).
      * Delegates to executeMdxCsv and parses CSV with header skip + quoted-field support.
+     *
+     * Parity divergence: tm1py forwards `element_separator` as both the CSV delimiter and the
+     * key-join separator (so the underlying TM1 CSV is regenerated with that delimiter). tm1npm's
+     * underlying executeMdxCsv does not yet accept a custom delimiter, so we parse the comma-
+     * delimited CSV that TM1 returns and only use `elementSeparator` as the key-join separator.
+     * Output dict keys/values still match tm1py for the default `'|'` separator.
      */
     public async executeMdxElementsValueDict(
         mdx: string,
@@ -1882,7 +1889,7 @@ END;
         const result: { [key: string]: any } = {};
         // Skip header (matches tm1py's `next(reader, None)`).
         for (let i = 1; i < lines.length; i++) {
-            const fields = CellService._parseCsvLine(lines[i], elementSeparator);
+            const fields = CellService._parseCsvLine(lines[i], ',');
             if (fields.length < 2) continue;
             const key = fields.slice(0, -1).join(elementSeparator);
             result[key] = fields[fields.length - 1];
@@ -2054,8 +2061,10 @@ END;
         for (const [key, expr] of Object.entries(dimensionExpressions)) {
             const actual = normToActual.get(lowerAndDropSpaces(key));
             if (actual) {
-                const wrapped = expr.trim().startsWith('{') ? expr : `{${expr}}`;
-                exprByDim[actual] = wrapped;
+                // Mirror tm1py's wrap_in_curly_braces (Utils.py:1693): independent open/close checks.
+                const open = expr.startsWith('{') ? '' : '{';
+                const close = expr.endsWith('}') ? '' : '}';
+                exprByDim[actual] = `${open}${expr}${close}`;
             }
         }
         for (const dim of dimensionNames) {
@@ -2181,34 +2190,18 @@ END;
      * Execute MDX via cellset extraction (parity with tm1py.execute_mdx_async).
      * Returns a Map keyed by comma-joined element unique-names (or Names if UniqueName missing).
      *
-     * tm1py achieves async by parallel-chunked cellset extraction (extract_cellset_async).
-     * That parallelization helper is not yet ported, so this delegates to a serial extract.
-     *
      * Documented parity gaps (see IMPLEMENTATION_PLAN.md):
-     * - max_workers / async_axis accepted for API parity but no parallelization performed.
-     * - The following options are accepted but currently dropped: cell_properties, top, skip,
-     *   skip_contexts, skip_zeros, skip_consolidated_cells, skip_rule_derived_cells,
-     *   skip_cell_properties, use_compact_json, skip_sandbox_dimension, element_unique_names.
+     * - tm1py uses extract_cellset_async with parallel-chunked retrieval. That helper is not
+     *   yet ported; this implementation delegates to a serial extractCellset.
+     * - tm1py's options (cell_properties, top, skip, skip_*, element_unique_names, etc.) are
+     *   not yet wired through extractCellset. To prevent silent option-drop, those parameters
+     *   are deliberately omitted from this signature so misuse is a compile-time error rather
+     *   than a runtime no-op. Add them back when the underlying extractor supports them.
      * - Tuple-key element order follows axis order, not cube dimension order.
      */
     public async executeMdxAsync(
         mdx: string,
-        options: {
-            cell_properties?: string[];
-            top?: number;
-            skip_contexts?: boolean;
-            skip?: number;
-            skip_zeros?: boolean;
-            skip_consolidated_cells?: boolean;
-            skip_rule_derived_cells?: boolean;
-            sandbox_name?: string;
-            element_unique_names?: boolean;
-            skip_cell_properties?: boolean;
-            use_compact_json?: boolean;
-            skip_sandbox_dimension?: boolean;
-            max_workers?: number;
-            async_axis?: number;
-        } = {}
+        options: { sandbox_name?: string } = {}
     ): Promise<Map<string, any>> {
         const cellsetId = await this.createCellset(mdx, options.sandbox_name);
         try {

--- a/src/services/TM1Service.ts
+++ b/src/services/TM1Service.ts
@@ -79,15 +79,17 @@ export class TM1Service {
         // Attach to RestService for access by other services
         (this._tm1Rest as any).asyncOperationService = this.asyncOperations;
 
-        // Initialize all services
+        // Initialize all services. ProcessService and ViewService are constructed before
+        // CellService so the latter can use them for unbound-process and view operations
+        // (writeThroughBlob requires ProcessService; clearWithMdx uses ViewService).
         this.dimensions = new DimensionService(this._tm1Rest);
         this.hierarchies = new HierarchyService(this._tm1Rest);
         this.subsets = new SubsetService(this._tm1Rest);
         this.cubes = new CubeService(this._tm1Rest);
         this.elements = new ElementService(this._tm1Rest);
-        this.cells = new CellService(this._tm1Rest);
         this.processes = new ProcessService(this._tm1Rest);
         this.views = new ViewService(this._tm1Rest);
+        this.cells = new CellService(this._tm1Rest, this.processes, this.views);
         this.security = new SecurityService(this._tm1Rest);
         this.files = new FileService(this._tm1Rest);
         this.sessions = new SessionService(this._tm1Rest);

--- a/src/tests/100PercentParityCheck.test.ts
+++ b/src/tests/100PercentParityCheck.test.ts
@@ -102,6 +102,15 @@ describe('100% TM1py Parity Function Existence', () => {
         });
     });
 
+    describe('CellService - tm1py parity additions (issue #69)', () => {
+        test('parity helpers and string-set methods exist', () => {
+            expect(typeof cellService.sandboxExists).toBe('function');
+            expect(typeof cellService.generateEnableSandboxTi).toBe('function');
+            expect(typeof cellService.executeMdxRowsAndValuesStringSet).toBe('function');
+            expect(typeof cellService.executeViewRowsAndValuesStringSet).toBe('function');
+        });
+    });
+
     describe('HierarchyService - Balance Check (1 function)', () => {
         test('New HierarchyService function should exist', () => {
             expect(typeof hierarchyService.isBalanced).toBe('function');

--- a/src/tests/cellService.test.ts
+++ b/src/tests/cellService.test.ts
@@ -88,20 +88,23 @@ describe('CellService Tests', () => {
 
         test('should write multiple cell values', async () => {
             mockRestService.post.mockResolvedValue(createMockResponse({}));
-            mockRestService.patch.mockResolvedValue(createMockResponse({}));
+            jest.spyOn(cellService, 'getDimensionNamesForWriting')
+                .mockResolvedValue(['Time', 'Measure', 'Version']);
 
             const cellData = {
-                'Jan:Revenue:Actual': 1000,
-                'Feb:Revenue:Actual': 1200,
-                'Mar:Revenue:Actual': 1100
+                'Jan,Revenue,Actual': 1000,
+                'Feb,Revenue,Actual': 1200,
+                'Mar,Revenue,Actual': 1100,
             };
 
             await cellService.writeValues('SalesCube', cellData);
 
-            // writeValues still uses the old pattern (patch) — it's a separate method from write()
-            expect(mockRestService.patch).toHaveBeenCalled();
-
-            console.log('✅ Multiple cell values written successfully');
+            expect(mockRestService.post).toHaveBeenCalledWith(
+                "/Cubes('SalesCube')/tm1.Update",
+                expect.any(String),
+            );
+            const body = JSON.parse(mockRestService.post.mock.calls[0][1]);
+            expect(body).toHaveLength(3);
         });
     });
 
@@ -167,66 +170,53 @@ describe('CellService Tests', () => {
     });
 
     describe('Cube Operations', () => {
-        test('should clear cube data', async () => {
-            mockRestService.post.mockResolvedValue(createMockResponse({}));
+        test('clearCube delegates to clear with empty expressions', async () => {
+            const clearSpy = jest.spyOn(cellService, 'clear').mockResolvedValue(undefined);
 
             await cellService.clearCube('TestCube');
 
-            expect(mockRestService.post).toHaveBeenCalledWith("/Cubes('TestCube')/tm1.Clear");
-
-            console.log('✅ Cube cleared successfully');
+            expect(clearSpy).toHaveBeenCalledWith('TestCube', {}, undefined);
         });
 
-        test('clearWithMdx should create view, call ClearCellValues, then delete view', async () => {
-            mockRestService.post.mockResolvedValue(createMockResponse({}));
-            mockRestService.delete.mockResolvedValue(createMockResponse({}));
+        test('clearWithMdx creates }TM1py<uuid> view, runs ViewZeroOut TI, deletes view', async () => {
+            // ViewService is lazily resolved to a fresh instance when not injected.
+            // Mock the rest layer to capture all writes.
+            mockRestService.post
+                .mockResolvedValueOnce(createMockResponse({}))                                  // view create
+                .mockResolvedValueOnce(createMockResponse({ ProcessExecuteStatusCode: 'CompletedSuccessfully' })) // exec process
+                ;
+            mockRestService.get.mockResolvedValue(createMockResponse({}));                      // view exists check
+            mockRestService.delete.mockResolvedValue(createMockResponse({}));                   // view delete
 
             await cellService.clearWithMdx('SalesCube', 'SELECT {[Measure].[Revenue]} ON 0 FROM [SalesCube]');
 
             const postCalls = mockRestService.post.mock.calls;
-
-            // 1st POST: create MDX view
+            // 1st POST: create MDXView
             expect(postCalls[0][0]).toBe("/Cubes('SalesCube')/Views");
             const viewBody = JSON.parse(postCalls[0][1]);
-            expect(viewBody['@odata.type']).toBe('ibm.tm1.api.v1.MDXView');
             expect(viewBody.Name).toMatch(/^\}TM1py/);
             expect(viewBody.MDX).toBe('SELECT {[Measure].[Revenue]} ON 0 FROM [SalesCube]');
 
-            // 2nd POST: ClearCellValues on the view
-            expect(postCalls[1][0]).toMatch(/\/Cubes\('SalesCube'\)\/Views\('(%7D|\})TM1py.*'\)\/tm1\.ClearCellValues/);
+            // 2nd POST: unbound TI process running ViewZeroOut
+            expect(postCalls[1][0]).toBe('/ExecuteProcessWithReturn?$expand=*');
+            const processBody = JSON.parse(postCalls[1][1]);
+            expect(processBody.Process.EpilogProcedure).toContain("ViewZeroOut('SalesCube',");
+            expect(processBody.Process.PrologProcedure).toContain('ServerActiveSandboxSet');
 
-            // Should delete temp view in finally
-            expect(mockRestService.delete).toHaveBeenCalledWith(
-                expect.stringMatching(/\/Cubes\('SalesCube'\)\/Views\('(%7D|\})TM1py/)
-            );
+            // Cleanup: view deleted
+            expect(mockRestService.delete).toHaveBeenCalled();
         });
 
-        test('clearWithMdx should pass sandbox_name to view creation and clear URLs', async () => {
-            mockRestService.post.mockResolvedValue(createMockResponse({}));
-            mockRestService.delete.mockResolvedValue(createMockResponse({}));
-
-            await cellService.clearWithMdx('SalesCube', 'SELECT {} ON 0 FROM [SalesCube]', 'MySandbox');
-
-            const postCalls = mockRestService.post.mock.calls;
-
-            // View creation includes sandbox
-            expect(postCalls[0][0]).toContain('?$sandbox=MySandbox');
-
-            // ClearCellValues includes sandbox
-            expect(postCalls[1][0]).toContain('?$sandbox=MySandbox');
-        });
-
-        test('clearWithMdx should delete view even if ClearCellValues fails', async () => {
+        test('clearWithMdx throws TM1Exception with parity message on non-CompletedSuccessfully', async () => {
             mockRestService.post
-                .mockResolvedValueOnce(createMockResponse({}))  // view creation
-                .mockRejectedValueOnce(new Error('ClearCellValues failed'));  // clear fails
+                .mockResolvedValueOnce(createMockResponse({}))                                  // view create
+                .mockResolvedValueOnce(createMockResponse({ ProcessExecuteStatusCode: 'CompletedWithMessages' }));
+            mockRestService.get.mockResolvedValue(createMockResponse({}));
             mockRestService.delete.mockResolvedValue(createMockResponse({}));
 
-            await expect(cellService.clearWithMdx('SalesCube', 'SELECT {} ON 0 FROM [SalesCube]'))
-                .rejects.toThrow('ClearCellValues failed');
-
-            // View should still be deleted in finally
-            expect(mockRestService.delete).toHaveBeenCalledTimes(1);
+            await expect(
+                cellService.clearWithMdx('SalesCube', 'SELECT {} ON 0 FROM [SalesCube]')
+            ).rejects.toThrow(/Failed to clear cube: 'SalesCube' with mdx:/);
         });
 
         test('writeThroughCellset should escape single quotes in bind paths', async () => {
@@ -240,6 +230,59 @@ describe('CellService Tests', () => {
             const bindPath = body.Cells[0]['Tuple@odata.bind'][0];
             expect(bindPath).toContain("Dimensions('O''Brien Dim')");
             expect(bindPath).toContain("Elements('It''s')");
+        });
+
+        test('writeValues posts JSON array of comma-separated tuple writes to /tm1.Update', async () => {
+            mockRestService.post.mockResolvedValue(createMockResponse({}));
+            jest.spyOn(cellService, 'getDimensionNamesForWriting')
+                .mockResolvedValue(['Year', 'Region', 'Product']);
+
+            await cellService.writeValues('SalesCube', { '2024,USA,Books': 100 });
+
+            expect(mockRestService.post).toHaveBeenCalledWith(
+                "/Cubes('SalesCube')/tm1.Update",
+                expect.any(String),
+            );
+            const body = JSON.parse(mockRestService.post.mock.calls[0][1]);
+            expect(Array.isArray(body)).toBe(true);
+            expect(body).toHaveLength(1);
+            expect(body[0].Cells[0]['Tuple@odata.bind']).toEqual([
+                "Dimensions('Year')/Hierarchies('Year')/Elements('2024')",
+                "Dimensions('Region')/Hierarchies('Region')/Elements('USA')",
+                "Dimensions('Product')/Hierarchies('Product')/Elements('Books')",
+            ]);
+            expect(body[0].Value).toBe(100);
+        });
+
+        test('writeValues with sandbox/changeset adds query params and returns changeset', async () => {
+            mockRestService.post.mockResolvedValue(createMockResponse({}));
+
+            const result = await cellService.writeValues(
+                'SalesCube',
+                { 'a,b,c': 1 },
+                ['D1', 'D2', 'D3'],
+                'SB1',
+                'CHG1',
+            );
+
+            const url = mockRestService.post.mock.calls[0][0];
+            expect(url).toContain('!sandbox=SB1');
+            expect(url).toContain('!ChangeSet=CHG1');
+            expect(result).toBe('CHG1');
+        });
+
+        test('writeValues coerces falsy values to empty string', async () => {
+            mockRestService.post.mockResolvedValue(createMockResponse({}));
+
+            await cellService.writeValues(
+                'SalesCube',
+                { 'a,b,c': 0, 'd,e,f': null, 'g,h,i': '', 'j,k,l': false, 'm,n,o': undefined as any },
+                ['D1', 'D2', 'D3'],
+            );
+
+            const body = JSON.parse(mockRestService.post.mock.calls[0][1]);
+            expect(body).toHaveLength(5);
+            for (const entry of body) expect(entry.Value).toBe('');
         });
     });
 
@@ -319,32 +362,27 @@ describe('CellService Tests', () => {
         });
 
         test('should handle large cell data batches', async () => {
-            mockRestService.patch.mockResolvedValue(createMockResponse({}));
+            mockRestService.post.mockResolvedValue(createMockResponse({}));
+            jest.spyOn(cellService, 'getDimensionNamesForWriting')
+                .mockResolvedValue(['Element', 'Measure', 'Version']);
 
             const largeCellSet: { [key: string]: number } = {};
             for (let i = 0; i < 1000; i++) {
-                largeCellSet[`Element${i}:Revenue:Actual`] = Math.random() * 10000;
+                largeCellSet[`Element${i},Revenue,Actual`] = Math.random() * 10000;
             }
 
             const startTime = Date.now();
             await cellService.writeValues('TestCube', largeCellSet);
             const endTime = Date.now();
-            
-            expect(mockRestService.patch).toHaveBeenCalledWith(
+
+            expect(mockRestService.post).toHaveBeenCalledWith(
                 "/Cubes('TestCube')/tm1.Update",
-                expect.objectContaining({
-                    Cells: expect.arrayContaining([
-                        expect.objectContaining({
-                            Coordinates: expect.any(Array),
-                            Value: expect.any(Number)
-                        })
-                    ])
-                })
+                expect.any(String),
             );
-            
-            expect(endTime - startTime).toBeLessThan(1000); // Should be fast with mocking
-            
-            console.log('✅ Large cell batches handled efficiently');
+            const body = JSON.parse(mockRestService.post.mock.calls[0][1]);
+            expect(body).toHaveLength(1000);
+            expect(body[0].Cells[0]['Tuple@odata.bind']).toHaveLength(3);
+            expect(endTime - startTime).toBeLessThan(2000);
         });
 
         test('should handle concurrent cell operations', async () => {
@@ -392,33 +430,30 @@ describe('CellService Tests', () => {
         });
 
         test('should handle complex business scenarios', async () => {
-            mockRestService.patch.mockResolvedValue(createMockResponse({}));
+            mockRestService.post.mockResolvedValue(createMockResponse({}));
+            jest.spyOn(cellService, 'getDimensionNamesForWriting')
+                .mockResolvedValue(['Time', 'Account', 'Version']);
 
-            // Simulate monthly budget allocation
+            // Simulate monthly budget allocation (comma-separated tuple keys per tm1py).
             const budgetAllocations = {
-                'Jan:Salaries:Budget': 50000,
-                'Jan:Marketing:Budget': 20000,
-                'Jan:Operations:Budget': 30000,
-                'Feb:Salaries:Budget': 52000,
-                'Feb:Marketing:Budget': 18000,
-                'Feb:Operations:Budget': 28000
+                'Jan,Salaries,Budget': 50000,
+                'Jan,Marketing,Budget': 20000,
+                'Jan,Operations,Budget': 30000,
+                'Feb,Salaries,Budget': 52000,
+                'Feb,Marketing,Budget': 18000,
+                'Feb,Operations,Budget': 28000,
             };
 
             await cellService.writeValues('BudgetCube', budgetAllocations);
-            
-            expect(mockRestService.patch).toHaveBeenCalledWith(
-                "/Cubes('BudgetCube')/tm1.Update",
-                expect.objectContaining({
-                    Cells: expect.arrayContaining([
-                        expect.objectContaining({
-                            Coordinates: [{ Name: 'Jan' }, { Name: 'Salaries' }, { Name: 'Budget' }],
-                            Value: 50000
-                        })
-                    ])
-                })
-            );
-            
-            console.log('✅ Complex business scenarios handled successfully');
+
+            const body = JSON.parse(mockRestService.post.mock.calls[0][1]);
+            expect(body).toHaveLength(6);
+            expect(body[0].Value).toBe(50000);
+            expect(body[0].Cells[0]['Tuple@odata.bind']).toEqual([
+                "Dimensions('Time')/Hierarchies('Time')/Elements('Jan')",
+                "Dimensions('Account')/Hierarchies('Account')/Elements('Salaries')",
+                "Dimensions('Version')/Hierarchies('Version')/Elements('Budget')",
+            ]);
         });
 
         test('should handle statistical calculations via MDX', async () => {

--- a/src/tests/cellServiceClearMdx.test.ts
+++ b/src/tests/cellServiceClearMdx.test.ts
@@ -1,0 +1,145 @@
+/**
+ * Tests for CellService.clear / clearWithMdx / clearCube (parity with tm1py).
+ *
+ * These tests cover the issue #69 reimplementation: temporary MDXView + ViewZeroOut
+ * unbound TI process. They also include an audit ensuring no fabricated REST endpoint
+ * literal remains in the source.
+ */
+
+import * as fs from 'fs';
+import * as path from 'path';
+import { CellService } from '../services/CellService';
+import { TM1Exception } from '../exceptions/TM1Exception';
+
+describe('CellService.clear / clearWithMdx (issue #69 parity)', () => {
+    function makeCellService(overrides: Record<string, any> = {}) {
+        const post = jest.fn().mockResolvedValue({ data: {}, status: 200, statusText: 'OK', headers: {}, config: {} });
+        const get = jest.fn().mockResolvedValue({ data: {}, status: 200, statusText: 'OK', headers: {}, config: {} });
+        const del = jest.fn().mockResolvedValue({ data: {}, status: 200, statusText: 'OK', headers: {}, config: {} });
+        const rest: any = { post, get, delete: del, ...overrides };
+        return { rest, cellService: new CellService(rest) };
+    }
+
+    test('clearWithMdx posts to /Cubes/Views (create), /ExecuteProcessWithReturn (TI), and deletes view', async () => {
+        const { rest, cellService } = makeCellService();
+        rest.post = jest.fn()
+            .mockResolvedValueOnce({ data: {}, status: 200, statusText: 'OK', headers: {}, config: {} }) // view create
+            .mockResolvedValueOnce({                                                                       // process exec
+                data: { ProcessExecuteStatusCode: 'CompletedSuccessfully' },
+                status: 200, statusText: 'OK', headers: {}, config: {},
+            });
+        // SandboxService.exists path for missing sandbox is irrelevant when no sandboxName.
+
+        await cellService.clearWithMdx('SalesCube', 'SELECT {[Measure].[Revenue]} ON 0 FROM [SalesCube]');
+
+        expect(rest.post).toHaveBeenCalledTimes(2);
+        expect(rest.post.mock.calls[0][0]).toBe("/Cubes('SalesCube')/Views");
+        const viewBody = JSON.parse(rest.post.mock.calls[0][1]);
+        expect(viewBody.Name).toMatch(/^\}TM1py/);
+        expect(viewBody.MDX).toBe('SELECT {[Measure].[Revenue]} ON 0 FROM [SalesCube]');
+
+        expect(rest.post.mock.calls[1][0]).toBe('/ExecuteProcessWithReturn?$expand=*');
+        const procBody = JSON.parse(rest.post.mock.calls[1][1]);
+        expect(procBody.Process.PrologProcedure).toContain('ServerActiveSandboxSet');
+        expect(procBody.Process.EpilogProcedure).toContain("ViewZeroOut('SalesCube',");
+
+        // Cleanup: GET (exists) then DELETE
+        expect(rest.delete).toHaveBeenCalled();
+    });
+
+    test('clearWithMdx throws TM1Exception with parity message on non-CompletedSuccessfully', async () => {
+        const { rest, cellService } = makeCellService();
+        rest.post = jest.fn()
+            .mockResolvedValueOnce({ data: {}, status: 200, statusText: 'OK', headers: {}, config: {} })
+            .mockResolvedValueOnce({
+                data: { ProcessExecuteStatusCode: 'CompletedWithMessages' },
+                status: 200, statusText: 'OK', headers: {}, config: {},
+            });
+
+        const longMdx = 'SELECT {' + 'a'.repeat(150) + '} ON 0 FROM [SalesCube]';
+        try {
+            await cellService.clearWithMdx('SalesCube', longMdx);
+            fail('expected TM1Exception');
+        } catch (err) {
+            expect(err).toBeInstanceOf(TM1Exception);
+            expect((err as Error).message).toMatch(/^Failed to clear cube: 'SalesCube' with mdx: '.*\.\.\.'$/);
+        }
+    });
+
+    test('clear delegates to clearWithMdx with NON EMPTY column-axis MDX containing all dimensions', async () => {
+        const { cellService } = makeCellService();
+        jest.spyOn(cellService, 'getDimensionNamesForWriting').mockResolvedValue(['Year', 'Region', 'Product']);
+        const clearWithMdxSpy = jest.spyOn(cellService, 'clearWithMdx').mockResolvedValue(undefined);
+
+        await cellService.clear('SalesCube', { region: '{[Region].[Australia]}' });
+
+        expect(clearWithMdxSpy).toHaveBeenCalledTimes(1);
+        const [, mdx] = clearWithMdxSpy.mock.calls[0];
+        expect(mdx).toContain('SELECT NON EMPTY');
+        expect(mdx).toContain('FROM [SalesCube]');
+        expect(mdx).toContain('{[Region].[Australia]}');
+        expect(mdx).toContain('{TM1FILTERBYLEVEL({TM1SUBSETALL([Year])},0)}');
+        expect(mdx).toContain('{TM1FILTERBYLEVEL({TM1SUBSETALL([Product])},0)}');
+    });
+
+    test('clear is case-and-space-insensitive when matching expression keys to dimension names', async () => {
+        const { cellService } = makeCellService();
+        jest.spyOn(cellService, 'getDimensionNamesForWriting').mockResolvedValue(['Sales Region']);
+        const clearWithMdxSpy = jest.spyOn(cellService, 'clearWithMdx').mockResolvedValue(undefined);
+
+        await cellService.clear('SalesCube', { salesregion: '{[Sales Region].[USA]}' });
+
+        const [, mdx] = clearWithMdxSpy.mock.calls[0];
+        expect(mdx).toContain('{[Sales Region].[USA]}');
+    });
+
+    test('clearCube delegates to clear with empty expressions', async () => {
+        const { cellService } = makeCellService();
+        const clearSpy = jest.spyOn(cellService, 'clear').mockResolvedValue(undefined);
+
+        await cellService.clearCube('SalesCube', 'SB1');
+
+        expect(clearSpy).toHaveBeenCalledWith('SalesCube', {}, 'SB1');
+    });
+
+    test('generateEnableSandboxTi returns disable-string when no sandbox provided', async () => {
+        const { cellService } = makeCellService();
+        const ti = await cellService.generateEnableSandboxTi();
+        expect(ti).toBe(`ServerActiveSandboxSet('');SetUseActiveSandboxProperty(0);`);
+    });
+
+    test('generateEnableSandboxTi returns enable-string when sandbox exists (no escaping)', async () => {
+        const { cellService } = makeCellService();
+        jest.spyOn(cellService, 'sandboxExists').mockResolvedValue(true);
+
+        const ti = await cellService.generateEnableSandboxTi('My Sandbox');
+
+        expect(ti).toBe(`ServerActiveSandboxSet('My Sandbox');SetUseActiveSandboxProperty(1);`);
+    });
+
+    test('generateEnableSandboxTi throws with exact tm1py message when sandbox missing', async () => {
+        const { cellService } = makeCellService();
+        jest.spyOn(cellService, 'sandboxExists').mockResolvedValue(false);
+
+        await expect(cellService.generateEnableSandboxTi('NoSuch'))
+            .rejects.toThrow(`Sandbox 'NoSuch' does not exist`);
+    });
+
+    test('Audit: CellService.ts must not contain any fabricated endpoint literal', () => {
+        const src = fs.readFileSync(path.join(__dirname, '..', 'services', 'CellService.ts'), 'utf-8');
+        const fabricated = [
+            '/tm1.Clear',
+            '/ExecuteMDXAsync',
+            '/ExecuteMDXCellCount',
+            '/ExecuteMDXElementsValue',
+            '/tm1.ExecuteAsync',
+            '/tm1.UpdateAsync',
+        ];
+        for (const ep of fabricated) {
+            // Match the exact literal in code (allow word boundary so /tm1.Clear* prefixes pass)
+            const escaped = ep.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+            const regex = new RegExp(`['"\`]${escaped}(?:['"\`]|\\b)`);
+            expect(src).not.toMatch(regex);
+        }
+    });
+});

--- a/src/tests/cellServiceClearMdx.test.ts
+++ b/src/tests/cellServiceClearMdx.test.ts
@@ -80,6 +80,8 @@ describe('CellService.clear / clearWithMdx (issue #69 parity)', () => {
         expect(mdx).toContain('{[Region].[Australia]}');
         expect(mdx).toContain('{TM1FILTERBYLEVEL({TM1SUBSETALL([Year])},0)}');
         expect(mdx).toContain('{TM1FILTERBYLEVEL({TM1SUBSETALL([Product])},0)}');
+        // Guard against accidental double-wrapping such as {{[Region].[Australia]}}
+        expect(mdx).not.toMatch(/\{\{[^}]*\}\}/);
     });
 
     test('clear is case-and-space-insensitive when matching expression keys to dimension names', async () => {

--- a/src/tests/enhancedCellService.test.ts
+++ b/src/tests/enhancedCellService.test.ts
@@ -467,6 +467,30 @@ describe('Enhanced CellService Tests', () => {
             expect(createSpy).toHaveBeenCalledWith('SalesCube', 'TestView', true, 'TestSandbox');
         });
 
+        test('cellset cleanup suppresses 404 only (parity with tm1py @tidy_cellset)', async () => {
+            jest.spyOn(cellService, 'createCellsetFromView').mockResolvedValue('CSID-V');
+            jest.spyOn(cellService as any, '_extractCellsetForTupleDict').mockResolvedValue({ Axes: [], Cells: [] });
+            jest.spyOn(cellService, 'getDimensionNamesForWriting').mockResolvedValue([]);
+            const notFound: any = new Error('not found');
+            notFound.statusCode = 404;
+            jest.spyOn(cellService, 'deleteCellset').mockRejectedValueOnce(notFound);
+
+            // 404 during cleanup must not propagate
+            await expect(cellService.execute_view_async('SalesCube', 'V')).resolves.toBeInstanceOf(Map);
+        });
+
+        test('cellset cleanup re-raises non-404 errors (parity with tm1py @tidy_cellset)', async () => {
+            jest.spyOn(cellService, 'createCellsetFromView').mockResolvedValue('CSID-V');
+            jest.spyOn(cellService as any, '_extractCellsetForTupleDict').mockResolvedValue({ Axes: [], Cells: [] });
+            jest.spyOn(cellService, 'getDimensionNamesForWriting').mockResolvedValue([]);
+            const serverError: any = new Error('server error');
+            serverError.statusCode = 500;
+            jest.spyOn(cellService, 'deleteCellset').mockRejectedValueOnce(serverError);
+
+            await expect(cellService.execute_view_async('SalesCube', 'V'))
+                .rejects.toThrow('server error');
+        });
+
         test('execute_view_async prefers Element.UniqueName when Member only carries Element shape', async () => {
             jest.spyOn(cellService, 'createCellsetFromView').mockResolvedValue('CSID-V');
             // Real TM1 cellset shape with $expand=Members($expand=Element($select=UniqueName)):

--- a/src/tests/enhancedCellService.test.ts
+++ b/src/tests/enhancedCellService.test.ts
@@ -164,8 +164,8 @@ describe('Enhanced CellService Tests', () => {
     });
 
     describe('Enhanced Data Reading Functions', () => {
-        test('executeMdxElementsValueDict parses CSV from executeMdxCsv into a dict', async () => {
-            const csv = 'Region|Value\nLondon|100\nParis|200\nBerlin|150\n';
+        test('executeMdxElementsValueDict parses comma-CSV into a dict joined by user separator', async () => {
+            const csv = 'Region,Value\nLondon,100\nParis,200\nBerlin,150\n';
             jest.spyOn(cellService, 'executeMdxCsv').mockResolvedValue(csv);
 
             const result = await cellService.executeMdxElementsValueDict(
@@ -175,13 +175,25 @@ describe('Enhanced CellService Tests', () => {
             expect(result).toEqual({ London: '100', Paris: '200', Berlin: '150' });
         });
 
-        test('executeMdxElementsValueDict honors quoted CSV fields with embedded separators', async () => {
-            const csv = 'Region|Value\n"Lon|don"|100\nParis|"5|0"\n';
+        test('executeMdxElementsValueDict joins multi-dim keys with the user-supplied separator', async () => {
+            const csv = 'Region,Year,Value\nLondon,2024,100\nParis,2024,200\n';
+            jest.spyOn(cellService, 'executeMdxCsv').mockResolvedValue(csv);
+
+            const result = await cellService.executeMdxElementsValueDict(
+                'SELECT 1 ON 0 FROM [c]',
+                '|',
+            );
+
+            expect(result).toEqual({ 'London|2024': '100', 'Paris|2024': '200' });
+        });
+
+        test('executeMdxElementsValueDict honors quoted CSV fields with embedded commas', async () => {
+            const csv = 'Region,Value\n"Lon,don",100\nParis,"5,0"\n';
             jest.spyOn(cellService, 'executeMdxCsv').mockResolvedValue(csv);
 
             const result = await cellService.executeMdxElementsValueDict('SELECT 1 ON 0 FROM [c]');
 
-            expect(result).toEqual({ 'Lon|don': '100', Paris: '5|0' });
+            expect(result).toEqual({ 'Lon,don': '100', Paris: '5,0' });
         });
     });
 

--- a/src/tests/enhancedCellService.test.ts
+++ b/src/tests/enhancedCellService.test.ts
@@ -220,7 +220,7 @@ describe('Enhanced CellService Tests', () => {
                 'sb1'
             );
 
-            expect(mockRestService.post.mock.calls[0][0]).toBe("/Cellsets('CSID1')/tm1.Update?$sandbox=sb1");
+            expect(mockRestService.post.mock.calls[0][0]).toBe("/Cellsets('CSID1')/tm1.Update?!sandbox=sb1");
             const body = JSON.parse(mockRestService.post.mock.calls[0][1]);
             expect(body.Value).toBe('RP100');
             expect(body['ReferenceCube@odata.bind']).toBe("Cubes('SalesCube')");
@@ -394,12 +394,12 @@ describe('Enhanced CellService Tests', () => {
             console.log('✅ extractCellsetCsv special characters test passed');
         });
 
-        test('execute_view_async creates cellset from view, extracts, and returns Map', async () => {
+        test('execute_view_async creates cellset from view, extracts, and returns Map keyed by UniqueName', async () => {
             jest.spyOn(cellService, 'createCellsetFromView').mockResolvedValue('CSID-V');
             jest.spyOn(cellService, 'extractCellset').mockResolvedValue({
                 Axes: [{
                     Cardinality: 1,
-                    Tuples: [{ Members: [{ Name: 'London' }] }],
+                    Tuples: [{ Members: [{ Name: 'London', UniqueName: '[Region].[Region].[London]' }] }],
                 }],
                 Cells: [{ Value: 100 }],
             });
@@ -408,7 +408,8 @@ describe('Enhanced CellService Tests', () => {
             const result = await cellService.execute_view_async('SalesCube', 'TestView');
 
             expect(result instanceof Map).toBe(true);
-            expect(result.get('London')).toBe(100);
+            // Matches tm1py default element_unique_names=True
+            expect(result.get('[Region].[Region].[London]')).toBe(100);
             expect(deleteSpy).toHaveBeenCalledWith('CSID-V', undefined);
         });
 

--- a/src/tests/enhancedCellService.test.ts
+++ b/src/tests/enhancedCellService.test.ts
@@ -411,10 +411,12 @@ describe('Enhanced CellService Tests', () => {
             jest.spyOn(cellService, 'extractCellset').mockResolvedValue({
                 Axes: [{
                     Cardinality: 1,
+                    Hierarchies: [{ Dimension: { Name: 'Region' }, Name: 'Region' }],
                     Tuples: [{ Members: [{ Name: 'London', UniqueName: '[Region].[Region].[London]' }] }],
                 }],
                 Cells: [{ Value: 100 }],
             });
+            jest.spyOn(cellService, 'getDimensionNamesForWriting').mockResolvedValue(['Region']);
             const deleteSpy = jest.spyOn(cellService, 'deleteCellset').mockResolvedValue(undefined);
 
             const result = await cellService.execute_view_async('SalesCube', 'TestView');
@@ -425,9 +427,36 @@ describe('Enhanced CellService Tests', () => {
             expect(deleteSpy).toHaveBeenCalledWith('CSID-V', undefined);
         });
 
+        test('execute_view_async reorders tuple parts by cube dimension order (parity with tm1py.sort_coordinates)', async () => {
+            jest.spyOn(cellService, 'createCellsetFromView').mockResolvedValue('CSID-V');
+            // Axis 0 = Region; Axis 1 = Time. Cube dimensions = [Time, Region] — keys must come out as Time,Region.
+            jest.spyOn(cellService, 'extractCellset').mockResolvedValue({
+                Axes: [
+                    {
+                        Cardinality: 1,
+                        Hierarchies: [{ Dimension: { Name: 'Region' } }],
+                        Tuples: [{ Members: [{ UniqueName: '[Region].[Region].[USA]' }] }],
+                    },
+                    {
+                        Cardinality: 1,
+                        Hierarchies: [{ Dimension: { Name: 'Time' } }],
+                        Tuples: [{ Members: [{ UniqueName: '[Time].[Time].[2024]' }] }],
+                    },
+                ],
+                Cells: [{ Value: 42 }],
+            });
+            jest.spyOn(cellService, 'getDimensionNamesForWriting').mockResolvedValue(['Time', 'Region']);
+            jest.spyOn(cellService, 'deleteCellset').mockResolvedValue(undefined);
+
+            const result = await cellService.execute_view_async('SalesCube', 'TestView');
+
+            expect(result.get('[Time].[Time].[2024],[Region].[Region].[USA]')).toBe(42);
+        });
+
         test('execute_view_async respects private/sandbox options', async () => {
             const createSpy = jest.spyOn(cellService, 'createCellsetFromView').mockResolvedValue('CSID-V');
             jest.spyOn(cellService, 'extractCellset').mockResolvedValue({ Axes: [], Cells: [] });
+            jest.spyOn(cellService, 'getDimensionNamesForWriting').mockResolvedValue([]);
             jest.spyOn(cellService, 'deleteCellset').mockResolvedValue(undefined);
 
             await cellService.execute_view_async('SalesCube', 'TestView', {

--- a/src/tests/enhancedCellService.test.ts
+++ b/src/tests/enhancedCellService.test.ts
@@ -408,7 +408,7 @@ describe('Enhanced CellService Tests', () => {
 
         test('execute_view_async creates cellset from view, extracts, and returns Map keyed by UniqueName', async () => {
             jest.spyOn(cellService, 'createCellsetFromView').mockResolvedValue('CSID-V');
-            jest.spyOn(cellService, 'extractCellset').mockResolvedValue({
+            jest.spyOn(cellService as any, '_extractCellsetForTupleDict').mockResolvedValue({
                 Axes: [{
                     Cardinality: 1,
                     Hierarchies: [{ Dimension: { Name: 'Region' }, Name: 'Region' }],
@@ -430,7 +430,7 @@ describe('Enhanced CellService Tests', () => {
         test('execute_view_async reorders tuple parts by cube dimension order (parity with tm1py.sort_coordinates)', async () => {
             jest.spyOn(cellService, 'createCellsetFromView').mockResolvedValue('CSID-V');
             // Axis 0 = Region; Axis 1 = Time. Cube dimensions = [Time, Region] — keys must come out as Time,Region.
-            jest.spyOn(cellService, 'extractCellset').mockResolvedValue({
+            jest.spyOn(cellService as any, '_extractCellsetForTupleDict').mockResolvedValue({
                 Axes: [
                     {
                         Cardinality: 1,
@@ -455,7 +455,7 @@ describe('Enhanced CellService Tests', () => {
 
         test('execute_view_async respects private/sandbox options', async () => {
             const createSpy = jest.spyOn(cellService, 'createCellsetFromView').mockResolvedValue('CSID-V');
-            jest.spyOn(cellService, 'extractCellset').mockResolvedValue({ Axes: [], Cells: [] });
+            jest.spyOn(cellService as any, '_extractCellsetForTupleDict').mockResolvedValue({ Axes: [], Cells: [] });
             jest.spyOn(cellService, 'getDimensionNamesForWriting').mockResolvedValue([]);
             jest.spyOn(cellService, 'deleteCellset').mockResolvedValue(undefined);
 
@@ -465,6 +465,51 @@ describe('Enhanced CellService Tests', () => {
             });
 
             expect(createSpy).toHaveBeenCalledWith('SalesCube', 'TestView', true, 'TestSandbox');
+        });
+
+        test('execute_view_async prefers Element.UniqueName when Member only carries Element shape', async () => {
+            jest.spyOn(cellService, 'createCellsetFromView').mockResolvedValue('CSID-V');
+            // Real TM1 cellset shape with $expand=Members($expand=Element($select=UniqueName)):
+            // Member has no top-level UniqueName, only Element.UniqueName.
+            jest.spyOn(cellService as any, '_extractCellsetForTupleDict').mockResolvedValue({
+                Axes: [{
+                    Cardinality: 1,
+                    Hierarchies: [{ Dimension: { Name: 'Region' } }],
+                    Tuples: [{ Members: [{ Name: 'London', Element: { UniqueName: '[Region].[Region].[London]' } }] }],
+                }],
+                Cells: [{ Value: 100 }],
+            });
+            jest.spyOn(cellService, 'getDimensionNamesForWriting').mockResolvedValue(['Region']);
+            jest.spyOn(cellService, 'deleteCellset').mockResolvedValue(undefined);
+
+            const result = await cellService.execute_view_async('SalesCube', 'TestView');
+
+            expect(result.get('[Region].[Region].[London]')).toBe(100);
+        });
+    });
+
+    describe('TM1Service-constructed CellService', () => {
+        test('writeAsync does not throw "ProcessService is required" when called via TM1Service constructor (regression for issue #69)', async () => {
+            // Reproduces the path TM1Service uses: pass ProcessService into CellService.
+            // Without this dependency the new writeAsync (which delegates to writeThroughBlob,
+            // which requires ProcessService) would throw at runtime.
+            const tm1RestMock: any = {
+                post: jest.fn().mockResolvedValue(createMockResponse({})),
+                get: jest.fn().mockResolvedValue(createMockResponse({ Dimensions: [] })),
+                delete: jest.fn().mockResolvedValue(createMockResponse({})),
+                patch: jest.fn().mockResolvedValue(createMockResponse({})),
+                put: jest.fn().mockResolvedValue(createMockResponse({})),
+            };
+            const processServiceLike = new (require('../services/ProcessService').ProcessService)(tm1RestMock);
+            const viewServiceLike = new (require('../services/ViewService').ViewService)(tm1RestMock);
+            const cs = new CellService(tm1RestMock, processServiceLike, viewServiceLike);
+
+            // Spy on writeThroughBlob to confirm writeAsync routes there without throwing.
+            const blobSpy = jest.spyOn(cs, 'writeThroughBlob').mockResolvedValue(undefined);
+
+            await cs.writeAsync('SalesCube', { 'a,b,c': 1 }, { slice_size: 1, max_workers: 1 });
+
+            expect(blobSpy).toHaveBeenCalledTimes(1);
         });
     });
 });

--- a/src/tests/enhancedCellService.test.ts
+++ b/src/tests/enhancedCellService.test.ts
@@ -76,24 +76,35 @@ describe('Enhanced CellService Tests', () => {
             console.log('✅ writeDataframe test passed');
         });
 
-        test('writeAsync should return async operation ID', async () => {
-            const cellset = { '2024,Actual,London': 100 };
+        test('writeAsync chunks the cellset and delegates to writeThroughBlob', async () => {
+            const cellset = { '2024,Actual,London': 100, '2024,Actual,Paris': 200 };
 
-            mockRestService.patch.mockResolvedValue(createMockResponse(
-                { ID: 'async-123' }
-            ));
+            const writeThroughBlobSpy = jest
+                .spyOn(cellService, 'writeThroughBlob')
+                .mockResolvedValue(undefined);
 
-            const asyncId = await cellService.writeAsync('SalesCube', cellset);
+            const result = await cellService.writeAsync('SalesCube', cellset, { slice_size: 1, max_workers: 2 });
 
-            expect(asyncId).toBe('async-123');
-            expect(mockRestService.patch).toHaveBeenCalledWith(
-                "/Cubes('SalesCube')/tm1.UpdateAsync",
-                expect.objectContaining({
-                    Cells: expect.any(Array)
-                })
+            expect(result).toBeUndefined();
+            // Two entries with slice_size=1 → two chunks → two writeThroughBlob calls
+            expect(writeThroughBlobSpy).toHaveBeenCalledTimes(2);
+            expect(writeThroughBlobSpy).toHaveBeenCalledWith(
+                'SalesCube',
+                expect.any(Object),
+                expect.objectContaining({ use_blob: true })
             );
-            
-            console.log('✅ writeAsync test passed');
+        });
+
+        test('writeAsync aggregates per-chunk failures into a TM1Exception', async () => {
+            const cellset = { 'a,b,c': 1, 'd,e,f': 2 };
+
+            jest.spyOn(cellService, 'writeThroughBlob')
+                .mockRejectedValueOnce(new Error('chunk1 failed'))
+                .mockResolvedValueOnce(undefined);
+
+            await expect(
+                cellService.writeAsync('SalesCube', cellset, { slice_size: 1, max_workers: 2 })
+            ).rejects.toThrow(/writeAsync partial failure: 1\/2 chunks failed/);
         });
 
         test('writeThroughUnboundProcess should execute TI statements', async () => {
@@ -153,22 +164,24 @@ describe('Enhanced CellService Tests', () => {
     });
 
     describe('Enhanced Data Reading Functions', () => {
-        test('executeMdxElementsValueDict should return element-value dictionary', async () => {
-            const mockData = { 'London': 100, 'Paris': 200, 'Berlin': 150 };
-
-            mockRestService.post.mockResolvedValue(createMockResponse(mockData));
+        test('executeMdxElementsValueDict parses CSV from executeMdxCsv into a dict', async () => {
+            const csv = 'Region|Value\nLondon|100\nParis|200\nBerlin|150\n';
+            jest.spyOn(cellService, 'executeMdxCsv').mockResolvedValue(csv);
 
             const result = await cellService.executeMdxElementsValueDict(
                 'SELECT NON EMPTY {[Region].Members} ON 0 FROM [SalesCube]'
             );
 
-            expect(result).toEqual(mockData);
-            expect(mockRestService.post).toHaveBeenCalledWith(
-                '/ExecuteMDXElementsValue',
-                { MDX: 'SELECT NON EMPTY {[Region].Members} ON 0 FROM [SalesCube]' }
-            );
-            
-            console.log('✅ executeMdxElementsValueDict test passed');
+            expect(result).toEqual({ London: '100', Paris: '200', Berlin: '150' });
+        });
+
+        test('executeMdxElementsValueDict honors quoted CSV fields with embedded separators', async () => {
+            const csv = 'Region|Value\n"Lon|don"|100\nParis|"5|0"\n';
+            jest.spyOn(cellService, 'executeMdxCsv').mockResolvedValue(csv);
+
+            const result = await cellService.executeMdxElementsValueDict('SELECT 1 ON 0 FROM [c]');
+
+            expect(result).toEqual({ 'Lon|don': '100', Paris: '5|0' });
         });
     });
 
@@ -193,18 +206,27 @@ describe('Enhanced CellService Tests', () => {
             console.log('✅ clearWithDataframe test passed');
         });
 
-        test('relativeProportionalSpread should execute proportional spread', async () => {
-            const coordinates = ['2024', 'Actual', 'Total'];
-
+        test('relativeProportionalSpread builds RP cellset payload (parity with tm1py)', async () => {
+            jest.spyOn(cellService, 'createCellset').mockResolvedValue('CSID1');
+            jest.spyOn(cellService, 'deleteCellset').mockResolvedValue(undefined);
             mockRestService.post.mockResolvedValue(createMockResponse({}));
 
-            await cellService.relativeProportionalSpread('SalesCube', coordinates, 1000);
-
-            expect(mockRestService.post).toHaveBeenCalledWith(
-                "/Cubes('SalesCube')/tm1.ProportionalSpread(coordinates=['2024','Actual','Total'],value=1000)"
+            await cellService.relativeProportionalSpread(
+                100,
+                'SalesCube',
+                ['[Region].[All]', '[Time].[2024]'],
+                ['[Region].[USA]'],
+                undefined,
+                'sb1'
             );
-            
-            console.log('✅ relativeProportionalSpread test passed');
+
+            expect(mockRestService.post.mock.calls[0][0]).toBe("/Cellsets('CSID1')/tm1.Update?$sandbox=sb1");
+            const body = JSON.parse(mockRestService.post.mock.calls[0][1]);
+            expect(body.Value).toBe('RP100');
+            expect(body['ReferenceCube@odata.bind']).toBe("Cubes('SalesCube')");
+            expect(body['ReferenceCell@odata.bind']).toEqual([
+                "Dimensions('Region')/Hierarchies('Region')/Elements('USA')",
+            ]);
         });
 
         test('clearSpread should execute clear spread', async () => {
@@ -265,28 +287,30 @@ describe('Enhanced CellService Tests', () => {
     });
 
     describe('New Critical Methods Tests', () => {
-        test('clear should clear cube data with sandbox support', async () => {
-            mockRestService.post.mockResolvedValue(createMockResponse({}));
+        test('clear delegates to clearWithMdx with NON EMPTY column-axis MDX', async () => {
+            jest.spyOn(cellService, 'getDimensionNamesForWriting').mockResolvedValue(['Year', 'Region']);
+            const clearWithMdxSpy = jest.spyOn(cellService, 'clearWithMdx').mockResolvedValue(undefined);
 
-            await cellService.clear('SalesCube', 'TestSandbox');
+            await cellService.clear('SalesCube', { region: '{[Region].[Australia]}' }, 'TestSandbox');
 
-            expect(mockRestService.post).toHaveBeenCalledWith(
-                "/Cubes('SalesCube')/tm1.Clear?$sandbox=TestSandbox"
-            );
-
-            console.log('✅ clear test passed');
+            expect(clearWithMdxSpy).toHaveBeenCalledTimes(1);
+            const [, mdx, sandboxArg] = clearWithMdxSpy.mock.calls[0];
+            expect(sandboxArg).toBe('TestSandbox');
+            expect(mdx).toContain('NON EMPTY');
+            expect(mdx).toContain('FROM [SalesCube]');
+            expect(mdx).toContain('{[Region].[Australia]}');
+            expect(mdx).toContain('{TM1FILTERBYLEVEL({TM1SUBSETALL([Year])},0)}');
         });
 
-        test('clear should clear cube data without sandbox', async () => {
-            mockRestService.post.mockResolvedValue(createMockResponse({}));
+        test('clear without dimensionExpressions defaults all dims', async () => {
+            jest.spyOn(cellService, 'getDimensionNamesForWriting').mockResolvedValue(['Year']);
+            const clearWithMdxSpy = jest.spyOn(cellService, 'clearWithMdx').mockResolvedValue(undefined);
 
             await cellService.clear('SalesCube');
 
-            expect(mockRestService.post).toHaveBeenCalledWith(
-                "/Cubes('SalesCube')/tm1.Clear"
-            );
-
-            console.log('✅ clear without sandbox test passed');
+            const [, mdx, sandboxArg] = clearWithMdxSpy.mock.calls[0];
+            expect(sandboxArg).toBeUndefined();
+            expect(mdx).toContain('{TM1FILTERBYLEVEL({TM1SUBSETALL([Year])},0)}');
         });
 
         test('extractCellsetCsv should extract cellset as CSV with headers', async () => {
@@ -370,56 +394,35 @@ describe('Enhanced CellService Tests', () => {
             console.log('✅ extractCellsetCsv special characters test passed');
         });
 
-        test('execute_view_async should execute view asynchronously', async () => {
-            mockRestService.post.mockResolvedValue(createMockResponse({
-                ID: 'async-view-123'
-            }));
+        test('execute_view_async creates cellset from view, extracts, and returns Map', async () => {
+            jest.spyOn(cellService, 'createCellsetFromView').mockResolvedValue('CSID-V');
+            jest.spyOn(cellService, 'extractCellset').mockResolvedValue({
+                Axes: [{
+                    Cardinality: 1,
+                    Tuples: [{ Members: [{ Name: 'London' }] }],
+                }],
+                Cells: [{ Value: 100 }],
+            });
+            const deleteSpy = jest.spyOn(cellService, 'deleteCellset').mockResolvedValue(undefined);
 
-            const asyncId = await cellService.execute_view_async('SalesCube', 'TestView');
+            const result = await cellService.execute_view_async('SalesCube', 'TestView');
 
-            expect(asyncId).toBe('async-view-123');
-            expect(mockRestService.post).toHaveBeenCalledWith(
-                "/Cubes('SalesCube')/Views('TestView')/tm1.ExecuteAsync"
-            );
-
-            console.log('✅ execute_view_async test passed');
+            expect(result instanceof Map).toBe(true);
+            expect(result.get('London')).toBe(100);
+            expect(deleteSpy).toHaveBeenCalledWith('CSID-V', undefined);
         });
 
-        test('execute_view_async should support all options', async () => {
-            mockRestService.post.mockResolvedValue(createMockResponse({
-                ID: 'async-view-456'
-            }));
+        test('execute_view_async respects private/sandbox options', async () => {
+            const createSpy = jest.spyOn(cellService, 'createCellsetFromView').mockResolvedValue('CSID-V');
+            jest.spyOn(cellService, 'extractCellset').mockResolvedValue({ Axes: [], Cells: [] });
+            jest.spyOn(cellService, 'deleteCellset').mockResolvedValue(undefined);
 
-            const options = {
+            await cellService.execute_view_async('SalesCube', 'TestView', {
                 private: true,
                 sandbox_name: 'TestSandbox',
-                element_unique_names: true,
-                skip_zeros: true,
-                skip_consolidated: true,
-                skip_rule_derived: true
-            };
+            });
 
-            const asyncId = await cellService.execute_view_async('SalesCube', 'TestView', options);
-
-            expect(asyncId).toBe('async-view-456');
-
-            const callUrl = mockRestService.post.mock.calls[0][0];
-            expect(callUrl).toContain('/tm1.ExecuteAsync');
-            expect(callUrl).toContain('private=true');
-            expect(callUrl).toContain('sandbox=TestSandbox');
-            expect(callUrl).toContain('element_unique_names=true');
-
-            console.log('✅ execute_view_async with options test passed');
-        });
-
-        test('execute_view_async should return generated ID if no ID in response', async () => {
-            mockRestService.post.mockResolvedValue(createMockResponse({}));
-
-            const asyncId = await cellService.execute_view_async('SalesCube', 'TestView');
-
-            expect(asyncId).toMatch(/^view_async_/);
-
-            console.log('✅ execute_view_async fallback ID test passed');
+            expect(createSpy).toHaveBeenCalledWith('SalesCube', 'TestView', true, 'TestSandbox');
         });
     });
 });

--- a/src/tests/mdx.advanced.test.ts
+++ b/src/tests/mdx.advanced.test.ts
@@ -184,50 +184,46 @@ describe('Advanced MDX and Calculation Tests', () => {
     describe('Complex Calculation Scenarios', () => {
         test('should handle multi-dimensional aggregations', async () => {
             const cellService = new CellService(mockRestService);
-            
-            // Mock bulk cell operations for aggregation testing
-            mockRestService.patch.mockResolvedValue(createMockResponse({}));
-            
+            jest.spyOn(cellService, 'getDimensionNamesForWriting').mockResolvedValue(['D1', 'D2', 'D3']);
+            mockRestService.post.mockResolvedValue(createMockResponse({}));
+
             const aggregationScenarios = [
                 {
                     name: 'Revenue by Product and Time',
                     cells: {
-                        'Electronics:2023:Q1': 500000,
-                        'Electronics:2023:Q2': 550000,
-                        'Electronics:2023:Q3': 520000,
-                        'Clothing:2023:Q1': 300000,
-                        'Clothing:2023:Q2': 320000,
-                        'Clothing:2023:Q3': 310000
-                    }
+                        'Electronics,2023,Q1': 500000,
+                        'Electronics,2023,Q2': 550000,
+                        'Electronics,2023,Q3': 520000,
+                        'Clothing,2023,Q1': 300000,
+                        'Clothing,2023,Q2': 320000,
+                        'Clothing,2023,Q3': 310000,
+                    },
                 },
                 {
                     name: 'Cost Center Allocations',
                     cells: {
-                        'IT:Salaries:Jan': 120000,
-                        'IT:Equipment:Jan': 25000,
-                        'IT:Training:Jan': 15000,
-                        'HR:Salaries:Jan': 95000,
-                        'HR:Equipment:Jan': 8000,
-                        'HR:Training:Jan': 12000
-                    }
-                }
+                        'IT,Salaries,Jan': 120000,
+                        'IT,Equipment,Jan': 25000,
+                        'IT,Training,Jan': 15000,
+                        'HR,Salaries,Jan': 95000,
+                        'HR,Equipment,Jan': 8000,
+                        'HR,Training,Jan': 12000,
+                    },
+                },
             ];
 
             for (const scenario of aggregationScenarios) {
                 await cellService.writeValues('TestCube', scenario.cells);
-                
-                // Validate the operation completed
-                expect(mockRestService.patch).toHaveBeenCalled();
-                
-                console.log(`✅ Multi-dimensional aggregation processed: ${scenario.name}`);
+                expect(mockRestService.post).toHaveBeenCalled();
             }
         });
 
         test('should handle complex allocation algorithms', async () => {
             const cellService = new CellService(mockRestService);
-            
+            jest.spyOn(cellService, 'getDimensionNamesForWriting').mockResolvedValue(['CostCenter']);
+
             mockRestService.get.mockResolvedValue(createMockResponse({ value: 1000000 })); // Total to allocate
-            mockRestService.patch.mockResolvedValue(createMockResponse({}));
+            mockRestService.post.mockResolvedValue(createMockResponse({}));
             
             // Simulate cost allocation based on multiple drivers
             const allocationDrivers = [
@@ -377,23 +373,22 @@ describe('Advanced MDX and Calculation Tests', () => {
 
         test('should handle batch cell operations efficiently', async () => {
             const cellService = new CellService(mockRestService);
-            
+            jest.spyOn(cellService, 'getDimensionNamesForWriting').mockResolvedValue(['D1', 'D2', 'D3']);
+
             // Create batch update with 1000 cells
             const batchCells: { [key: string]: number } = {};
             for (let i = 0; i < 1000; i++) {
-                batchCells[`Element${i}:Product${i % 10}:Time${i % 12}`] = Math.random() * 10000;
+                batchCells[`Element${i},Product${i % 10},Time${i % 12}`] = Math.random() * 10000;
             }
 
-            mockRestService.patch.mockResolvedValue(createMockResponse({}));
+            mockRestService.post.mockResolvedValue(createMockResponse({}));
 
             const startTime = Date.now();
             await cellService.writeValues('BatchCube', batchCells);
             const endTime = Date.now();
-            
-            expect(mockRestService.patch).toHaveBeenCalledTimes(1); // Should be a single batch call
-            expect(endTime - startTime).toBeLessThan(2000); // Should complete in under 2 seconds
-            
-            console.log(`✅ Batch cell operation (1000 cells) completed in ${endTime - startTime}ms`);
+
+            expect(mockRestService.post).toHaveBeenCalledTimes(1); // Should be a single batch call
+            expect(endTime - startTime).toBeLessThan(2000);
         });
     });
 

--- a/src/tests/simpleCoverage.test.ts
+++ b/src/tests/simpleCoverage.test.ts
@@ -77,7 +77,7 @@ describe('Simple Coverage Tests', () => {
 
             const cellService = new CellService(mockRest);
             jest.spyOn(cellService, 'createCellset').mockResolvedValue('CSID-1');
-            jest.spyOn(cellService, 'extractCellset').mockResolvedValue({ Axes: [], Cells: [] });
+            jest.spyOn(cellService as any, '_extractCellsetForTupleDict').mockResolvedValue({ Axes: [], Cells: [] });
             jest.spyOn(cellService, 'deleteCellset').mockResolvedValue(undefined);
 
             const result = await cellService.executeMdxAsync('SELECT * FROM [TestCube]');
@@ -254,7 +254,7 @@ describe('Simple Coverage Tests', () => {
             jest.spyOn(cellService, 'createCellset')
                 .mockResolvedValueOnce('CSID-1')
                 .mockResolvedValueOnce('CSID-2');
-            jest.spyOn(cellService, 'extractCellset').mockResolvedValue({ Axes: [], Cells: [] });
+            jest.spyOn(cellService as any, '_extractCellsetForTupleDict').mockResolvedValue({ Axes: [], Cells: [] });
             jest.spyOn(cellService, 'deleteCellset').mockResolvedValue(undefined);
 
             const result1 = await cellService.executeMdxAsync('SELECT * FROM [Cube1]');

--- a/src/tests/simpleCoverage.test.ts
+++ b/src/tests/simpleCoverage.test.ts
@@ -72,21 +72,16 @@ describe('Simple Coverage Tests', () => {
             expect(mockRest.post).toHaveBeenCalled();
         });
 
-        test('CellService executeMdxAsync should work', async () => {
-            const mockRest = {
-                post: jest.fn().mockResolvedValue({
-                    data: { ID: 'mdx-test-id' },
-                    status: 200,
-                    statusText: 'OK',
-                    headers: {},
-                    config: {}
-                })
-            } as any;
+        test('CellService executeMdxAsync returns Map<string, any>', async () => {
+            const mockRest = {} as any;
 
             const cellService = new CellService(mockRest);
-            
+            jest.spyOn(cellService, 'createCellset').mockResolvedValue('CSID-1');
+            jest.spyOn(cellService, 'extractCellset').mockResolvedValue({ Axes: [], Cells: [] });
+            jest.spyOn(cellService, 'deleteCellset').mockResolvedValue(undefined);
+
             const result = await cellService.executeMdxAsync('SELECT * FROM [TestCube]');
-            expect(result).toBe('mdx-test-id');
+            expect(result instanceof Map).toBe(true);
         });
     });
 
@@ -253,31 +248,20 @@ describe('Simple Coverage Tests', () => {
 
     describe('Promise and Async Coverage', () => {
         test('should handle promise chains', async () => {
-            const mockRest = {
-                post: jest.fn()
-                    .mockResolvedValueOnce({
-                        data: { ID: 'step1' },
-                        status: 200,
-                        statusText: 'OK',
-                        headers: {},
-                        config: {}
-                    })
-                    .mockResolvedValueOnce({
-                        data: { ID: 'step2' },
-                        status: 200,
-                        statusText: 'OK',
-                        headers: {},
-                        config: {}
-                    })
-            } as any;
+            const mockRest = {} as any;
 
             const cellService = new CellService(mockRest);
-            
+            jest.spyOn(cellService, 'createCellset')
+                .mockResolvedValueOnce('CSID-1')
+                .mockResolvedValueOnce('CSID-2');
+            jest.spyOn(cellService, 'extractCellset').mockResolvedValue({ Axes: [], Cells: [] });
+            jest.spyOn(cellService, 'deleteCellset').mockResolvedValue(undefined);
+
             const result1 = await cellService.executeMdxAsync('SELECT * FROM [Cube1]');
             const result2 = await cellService.executeMdxAsync('SELECT * FROM [Cube2]');
-            
-            expect(result1).toBe('step1');
-            expect(result2).toBe('step2');
+
+            expect(result1 instanceof Map).toBe(true);
+            expect(result2 instanceof Map).toBe(true);
         });
     });
 });


### PR DESCRIPTION
## Summary

Closes #69. Aligns CellService with tm1py by removing six fabricated REST endpoints that don't exist in TM1, fixing wrong method signatures, and adding missing parity helpers. Every change references the corresponding tm1py source line and is verified against `https://github.com/cubewise-code/tm1py/blob/master/TM1py/Services/CellService.py`.

### Removed fabricated endpoints
- `/tm1.Clear` (clear / clearCube)
- `/tm1.ClearCellValues` (clearWithMdx; was already in tm1npm pre-#69)
- `/ExecuteMDXAsync` (executeMdxAsync)
- `/ExecuteMDXCellCount` (executeMdxCellcount)
- `/ExecuteMDXElementsValue` (executeMdxElementsValueDict)
- `/tm1.ExecuteAsync` (execute_view_async)
- `/tm1.UpdateAsync` (writeAsync)

### Reimplemented per tm1py
- **clear / clearWithMdx / clearCube** — temporary `}TM1py<uuid>` MDXView + ViewZeroOut TI process via `/ExecuteProcessWithReturn`. NON EMPTY column-axis MDX with `TM1FILTERBYLEVEL({TM1SUBSETALL([dim])},0)` defaults for unmapped dimensions.
- **relativeProportionalSpread** — exact tm1py signature `(value, cube, uniqueElementNames, referenceUniqueElementNames, referenceCube?, sandboxName?)`; posts to `/Cellsets/{id}/tm1.Update` with RP payload (`Value: 'RP'+value`, `ReferenceCell@odata.bind`, `ReferenceCube@odata.bind`) using write-side `!sandbox=` query param.
- **writeValues** — comma-separated tuple keys, auto-fetched dimensions, proper `Tuple@odata.bind`, `!sandbox=` / `!ChangeSet=` query params, returns changeset, falsy-value coercion (`value || ''`).
- **executeMdxCellcount** — `createCellset + /Cellsets/{id}/Cells/$count`.
- **executeMdxElementsValueDict** — delegates to `executeMdxCsv` with quoted-CSV parser; user separator joins keys.
- **executeMdxAsync / execute_view_async** — `createCellset + extractCellset`, returns `Map<string, any>` keyed by `Element.UniqueName ?? UniqueName ?? Name` (matches tm1py default `element_unique_names=True`).
- **writeAsync** — chunked `Promise.allSettled` over `writeThroughBlob`; aggregates partial failures into `TM1Exception`.

### Added parity helpers
- `sandboxExists(sandboxName)` — delegates to SandboxService.
- `generateEnableSandboxTi(sandboxName?)` — TI prolog string.
- `executeMdxRowsAndValuesStringSet`, `executeViewRowsAndValuesStringSet` — case-and-space-insensitive deduplicated `Set<string>`.
- Private statics: `_parseUniqueElementName` (substring-based, non-throwing, mirrors tm1py exactly including `]]` → `]` unescape), `_safeDeleteCellset`, `_cellsetToTupleDict`, `_extractStringSetFromRowsAndValues`, `_parseCsvLine`, `_abbreviateMdx`.

### Documented parity gaps (intentional, deferred)
- `RestService.sandboxing_disabled` flag not yet exposed; `generateEnableSandboxTi` omits that branch.
- `extract_cellset_async` parallel chunking not ported; async methods serial-extract. To prevent silent option-drop, options that are not yet wired through (`top`, `skip`, `skip_zeros`, `cell_properties`, etc.) are deliberately omitted from the `executeMdxAsync` / `execute_view_async` signatures so misuse is a compile-time error.
- `TM1pyWritePartialFailureException` not ported; `writeAsync` aggregates into `TM1Exception` with descriptive message.
- Tuple-key axis order follows axis ordering, not cube dimension order (tm1py reorders via `sort_coordinates`).
- `writeAsync`'s `dimensions` / `precision` / `measure_dimension_elements` pass-through requires `writeThroughBlob` extension; deferred. Signature narrowed accordingly.

### Breaking changes
- `executeMdxAsync(mdx, options?)` — return type changed: `string` → `Map<string, any>`; `sandbox_name` is the only accepted option.
- `execute_view_async(cubeName, viewName, options?)` — return type: `string` → `Map<string, any>`; only `private` and `sandbox_name` accepted.
- `writeAsync(cubeName, cellsetAsDict, options?)` — return type: `string` → `string | undefined`; option bag narrowed.
- `clear(cubeName, sandbox_name)` → `clear(cubeName, dimensionExpressions?, sandboxName?)`.
- `relativeProportionalSpread` parameter order matches tm1py.
- `writeValues` tuple keys must be comma-separated, not colon-separated.

## Test plan
- [x] TypeScript typecheck clean (`tsc --noEmit`)
- [x] Targeted CellService suites: 85/85 pass
- [x] Full unit suite: 1479/1480 pass (1 pre-existing failure on main: `security.advanced.test.ts` concurrent-modification, unrelated)
- [x] 2 credential-dependent integration suites (`errorHandling`, `security`) require `TM1_PASSWORD` and always fail by design
- [x] New `cellServiceClearMdx.test.ts` covers ViewZeroOut flow, parity error message, sandbox helpers, `clearCube` delegation, and an audit assertion that no fabricated endpoint literal remains in `CellService.ts`
- [x] Updated `cellService`, `enhancedCellService`, `simpleCoverage`, `100PercentParityCheck`, `mdx.advanced` tests for new signatures
- [ ] Manual smoke: run `clear` / `writeValues` / `executeMdxAsync` against a TM1 dev instance to verify the live calls match tm1py's wire format