### PR TITLE
feat(#60): port tm1py CellService decorators (@tidy_cellset, @manage_transaction_log, @manage_changeset, @odata_compact_json)

### DIFF
--- a/src/services/CellService.ts
+++ b/src/services/CellService.ts
@@ -186,7 +186,7 @@ export class CellService {
         return result;
     }
 
-    private async _safeDeleteCellset(cellsetId: string, sandboxName?: string): Promise<void> {
+    public async _safeDeleteCellset(cellsetId: string, sandboxName?: string): Promise<void> {
         // Mirror tm1py's @tidy_cellset (CellService.py:80-99): suppress 404 (already gone),
         // re-raise every other status so server-side errors during cleanup are visible.
         try {
@@ -1580,16 +1580,7 @@ export class CellService {
         const cellsetId = await this.createCellset(mdx, options.sandbox_name);
 
         await withTidyCellset(this, cellsetId, async () => {
-            // Build cell updates
-            const cellUpdates: Array<{ ordinal: number; value: any }> = [];
-            let ordinal = 0;
-
-            for (const [, value] of Object.entries(cellsetAsDict)) {
-                cellUpdates.push({ ordinal, value });
-                ordinal++;
-            }
-
-            // Update cellset
+            const cellUpdates = Object.values(cellsetAsDict).map((value, ordinal) => ({ ordinal, value }));
             await this.updateCellset(cellsetId, cellUpdates, options.sandbox_name);
         }, { sandbox_name: options.sandbox_name });
     }
@@ -2851,21 +2842,16 @@ export interface ManagedTransactionLogOptions {
     reactivate_transaction_log?: boolean;
 }
 
-function isHttpStatus(err: any, status: number): boolean {
-    return err?.status === status
-        || err?.statusCode === status
-        || err?.response?.status === status;
-}
-
 /**
  * Run `fn` and ensure the cellset is deleted afterwards (in `finally`).
  *
  * Mirrors tm1py's `@tidy_cellset` decorator (CellService.py:80-100):
  * - When `delete_cellset` is `false`, the cellset is left in place.
- * - When `delete_cellset` is `true` (default), `service.deleteCellset` is
- *   called in `finally`. A 404 response is silently ignored (cellset already
- *   gone); any other error from delete propagates and replaces the inner
- *   error if the inner function also threw (matches Python `try/finally`).
+ * - When `delete_cellset` is `true` (default), `service._safeDeleteCellset`
+ *   is called in `finally` — it deletes the cellset and silently swallows
+ *   404 responses (cellset already gone). Any other error propagates and
+ *   replaces the inner error if the inner function also threw (matches
+ *   Python `try/finally` semantics).
  */
 export async function withTidyCellset<T>(
     service: CellService,
@@ -2878,14 +2864,7 @@ export async function withTidyCellset<T>(
         return await fn();
     } finally {
         if (shouldDelete) {
-            try {
-                await service.deleteCellset(cellsetId, options.sandbox_name);
-            } catch (err: any) {
-                if (!isHttpStatus(err, 404)) {
-                    throw err;
-                }
-                // Fail silently if cellset is already removed
-            }
+            await service._safeDeleteCellset(cellsetId, options.sandbox_name);
         }
     }
 }

--- a/src/services/CellService.ts
+++ b/src/services/CellService.ts
@@ -13,7 +13,7 @@ import { OperationStatus, OperationType } from './AsyncOperationService';
 import { MDXView } from '../objects/MDXView';
 import { Process } from '../objects/Process';
 import { TM1Exception } from '../exceptions/TM1Exception';
-import { formatUrl, escapeODataValue, lowerAndDropSpaces, extractCompactJsonCellset } from '../utils/Utils';
+import { formatUrl, escapeODataValue, lowerAndDropSpaces, extractCompactJsonCellset, resemblesMdx, getCube } from '../utils/Utils';
 
 export interface CellsetDict {
     [coordinates: string]: string | number | boolean | null | undefined;
@@ -2870,26 +2870,49 @@ export async function withTidyCellset<T>(
 }
 
 /**
+ * Argument shape accepted by `withManagedTransactionLog`. Mirrors tm1py's
+ * cube_name resolution in `manage_transaction_log` (CellService.py:113-122):
+ * - `{ cubeName }` — explicit cube name.
+ * - `{ mdx }` — derive cube via `getCube(mdx)`.
+ * - A bare string — interpreted as MDX if it looks like MDX
+ *   (`resemblesMdx`), otherwise treated as a cube name.
+ */
+export type ManagedTransactionLogTarget =
+    | string
+    | { cubeName: string; mdx?: undefined }
+    | { mdx: string; cubeName?: undefined };
+
+function resolveCubeName(target: ManagedTransactionLogTarget): string {
+    if (typeof target === 'string') {
+        return resemblesMdx(target) ? getCube(target) : target;
+    }
+    if (target.cubeName !== undefined) {
+        return target.cubeName;
+    }
+    return getCube(target.mdx);
+}
+
+/**
  * Run `fn` with the transaction log optionally deactivated for the duration.
  *
  * Mirrors tm1py's `@manage_transaction_log` decorator
- * (CellService.py:103-136):
- * - When `deactivate_transaction_log` is true, calls
- *   `service.deactivateTransactionlog(cubeName)` before `fn`.
- * - When `reactivate_transaction_log` is true, calls
- *   `service.activateTransactionlog(cubeName)` in `finally` (always — even
- *   if `fn` or `deactivate` threw).
+ * (CellService.py:103-136), including its cube-name resolution: callers may
+ * pass an explicit `cubeName`, an MDX query, or a bare string that is
+ * auto-classified via `resemblesMdx` (Utils.py:1686).
  *
- * Note: tm1py also resolves `cube_name` from MDX/cube_name kwarg/first
- * positional via `resembles_mdx`. tm1npm callers always pass `cubeName`
- * explicitly, so that branch is intentionally omitted.
+ * - When `deactivate_transaction_log` is true, calls
+ *   `service.deactivateTransactionlog(resolvedCube)` before `fn`.
+ * - When `reactivate_transaction_log` is true, calls
+ *   `service.activateTransactionlog(resolvedCube)` in `finally` (always —
+ *   even if `fn` or `deactivate` threw).
  */
 export async function withManagedTransactionLog<T>(
     service: CellService,
-    cubeName: string,
+    target: ManagedTransactionLogTarget,
     fn: () => Promise<T>,
     options: ManagedTransactionLogOptions = {}
 ): Promise<T> {
+    const cubeName = resolveCubeName(target);
     const deactivate = options.deactivate_transaction_log === true;
     const reactivate = options.reactivate_transaction_log === true;
     try {
@@ -2955,8 +2978,14 @@ export async function withCompactJson<T = any>(
     const original = rest.add_compact_json_header();
     try {
         const response = await fn();
-        const context: string = response?.['@odata.context'];
-        if (!context || !context.startsWith('$metadata#Cellsets')) {
+        // Mirror tm1py's `response["@odata.context"]` (CellService.py:186) —
+        // a missing key raises KeyError in Python; surface a distinct error
+        // here instead of conflating with the wrong-context case.
+        if (!response || !('@odata.context' in response)) {
+            throw new Error("Compact JSON response missing '@odata.context'");
+        }
+        const context: string = response['@odata.context'];
+        if (!context.startsWith('$metadata#Cellsets')) {
             throw new Error('odata_compact_json decorator must only be used on cellsets');
         }
         return extractCompactJsonCellset(context, response, returnAsDict) as unknown as T;

--- a/src/services/CellService.ts
+++ b/src/services/CellService.ts
@@ -13,7 +13,7 @@ import { OperationStatus, OperationType } from './AsyncOperationService';
 import { MDXView } from '../objects/MDXView';
 import { Process } from '../objects/Process';
 import { TM1Exception } from '../exceptions/TM1Exception';
-import { formatUrl, escapeODataValue, lowerAndDropSpaces } from '../utils/Utils';
+import { formatUrl, escapeODataValue, lowerAndDropSpaces, extractCompactJsonCellset } from '../utils/Utils';
 
 export interface CellsetDict {
     [coordinates: string]: string | number | boolean | null | undefined;
@@ -92,6 +92,11 @@ export interface MDXViewOptions {
     skip_rule_derived?: boolean;
     csv_dialect?: any;
     sandbox_name?: string;
+    /**
+     * Honoured via the `withCompactJson` helper. The `executeMdx*` family of
+     * methods does not yet wrap calls in `withCompactJson`; setting this
+     * flag here is currently a no-op until that wiring is added.
+     */
     use_compact_json?: boolean;
     mdx_headers?: boolean;
 }
@@ -415,7 +420,6 @@ export class CellService {
         if (options.sandbox_name) params.append('$sandbox', options.sandbox_name);
         if (options.element_unique_names !== undefined) params.append('$element_unique_names', options.element_unique_names.toString());
         if (options.skip_zeros !== undefined) params.append('$skip_zeros', options.skip_zeros.toString());
-        if (options.use_compact_json !== undefined) params.append('$use_compact_json', options.use_compact_json.toString());
 
         if (params.toString()) {
             url += `?${params.toString()}`;
@@ -1099,7 +1103,6 @@ export class CellService {
         if (options.sandbox_name) params.append('$sandbox', options.sandbox_name);
         if (options.element_unique_names !== undefined) params.append('$element_unique_names', options.element_unique_names.toString());
         if (options.skip_zeros !== undefined) params.append('$skip_zeros', options.skip_zeros.toString());
-        if (options.use_compact_json !== undefined) params.append('$use_compact_json', options.use_compact_json.toString());
 
         if (params.toString()) {
             url += `?${params.toString()}`;
@@ -1576,9 +1579,9 @@ export class CellService {
         // Create cellset
         const cellsetId = await this.createCellset(mdx, options.sandbox_name);
 
-        try {
+        await withTidyCellset(this, cellsetId, async () => {
             // Build cell updates
-            const cellUpdates = [];
+            const cellUpdates: Array<{ ordinal: number; value: any }> = [];
             let ordinal = 0;
 
             for (const [, value] of Object.entries(cellsetAsDict)) {
@@ -1588,11 +1591,7 @@ export class CellService {
 
             // Update cellset
             await this.updateCellset(cellsetId, cellUpdates, options.sandbox_name);
-
-        } finally {
-            // Clean up cellset
-            await this.deleteCellset(cellsetId, options.sandbox_name);
-        }
+        }, { sandbox_name: options.sandbox_name });
     }
 
     /**
@@ -2829,5 +2828,160 @@ END;
         }
 
         return await asyncOps.getAsyncOperationStatus(operationId);
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Decorator-equivalent helpers (ports of tm1py's @tidy_cellset,
+// @manage_transaction_log, @manage_changeset, @odata_compact_json from
+// CellService.py:80-200). They are higher-order async functions rather than
+// TypeScript class decorators, but provide the same cross-cutting behavior.
+// ---------------------------------------------------------------------------
+
+export interface TidyCellsetOptions {
+    /** Default true (matches tm1py kwarg default). */
+    delete_cellset?: boolean;
+    sandbox_name?: string;
+}
+
+export interface ManagedTransactionLogOptions {
+    /** Default false. */
+    deactivate_transaction_log?: boolean;
+    /** Default false. */
+    reactivate_transaction_log?: boolean;
+}
+
+function isHttpStatus(err: any, status: number): boolean {
+    return err?.status === status
+        || err?.statusCode === status
+        || err?.response?.status === status;
+}
+
+/**
+ * Run `fn` and ensure the cellset is deleted afterwards (in `finally`).
+ *
+ * Mirrors tm1py's `@tidy_cellset` decorator (CellService.py:80-100):
+ * - When `delete_cellset` is `false`, the cellset is left in place.
+ * - When `delete_cellset` is `true` (default), `service.deleteCellset` is
+ *   called in `finally`. A 404 response is silently ignored (cellset already
+ *   gone); any other error from delete propagates and replaces the inner
+ *   error if the inner function also threw (matches Python `try/finally`).
+ */
+export async function withTidyCellset<T>(
+    service: CellService,
+    cellsetId: string,
+    fn: () => Promise<T>,
+    options: TidyCellsetOptions = {}
+): Promise<T> {
+    const shouldDelete = options.delete_cellset !== false;
+    try {
+        return await fn();
+    } finally {
+        if (shouldDelete) {
+            try {
+                await service.deleteCellset(cellsetId, options.sandbox_name);
+            } catch (err: any) {
+                if (!isHttpStatus(err, 404)) {
+                    throw err;
+                }
+                // Fail silently if cellset is already removed
+            }
+        }
+    }
+}
+
+/**
+ * Run `fn` with the transaction log optionally deactivated for the duration.
+ *
+ * Mirrors tm1py's `@manage_transaction_log` decorator
+ * (CellService.py:103-136):
+ * - When `deactivate_transaction_log` is true, calls
+ *   `service.deactivateTransactionlog(cubeName)` before `fn`.
+ * - When `reactivate_transaction_log` is true, calls
+ *   `service.activateTransactionlog(cubeName)` in `finally` (always — even
+ *   if `fn` or `deactivate` threw).
+ *
+ * Note: tm1py also resolves `cube_name` from MDX/cube_name kwarg/first
+ * positional via `resembles_mdx`. tm1npm callers always pass `cubeName`
+ * explicitly, so that branch is intentionally omitted.
+ */
+export async function withManagedTransactionLog<T>(
+    service: CellService,
+    cubeName: string,
+    fn: () => Promise<T>,
+    options: ManagedTransactionLogOptions = {}
+): Promise<T> {
+    const deactivate = options.deactivate_transaction_log === true;
+    const reactivate = options.reactivate_transaction_log === true;
+    try {
+        if (deactivate) {
+            await service.deactivateTransactionlog(cubeName);
+        }
+        return await fn();
+    } finally {
+        if (reactivate) {
+            await service.activateTransactionlog(cubeName);
+        }
+    }
+}
+
+/**
+ * Run `fn` optionally wrapped in a TM1 changeset (begin/end pair).
+ *
+ * Mirrors tm1py's `@manage_changeset` decorator (CellService.py:139-158):
+ * - When `useChangeset` is false (default), `fn` is invoked with no args.
+ * - When true, `service.beginChangeset()` is awaited first, the resulting id
+ *   is passed to `fn`, and `service.endChangeset(id)` is called in `finally`
+ *   (only after `begin` succeeded — `begin` is intentionally outside `try`).
+ *   `end` is called even when `fn` throws.
+ */
+export async function withManagedChangeset<T>(
+    service: CellService,
+    fn: (changeset?: string) => Promise<T>,
+    useChangeset: boolean = false
+): Promise<T> {
+    if (!useChangeset) {
+        return await fn();
+    }
+    const changeset = await service.beginChangeset();
+    try {
+        return await fn(changeset);
+    } finally {
+        await service.endChangeset(changeset);
+    }
+}
+
+/**
+ * Run `fn` with the compact-JSON Accept header set, then translate the
+ * response into either a dict shape or a flat list.
+ *
+ * Mirrors tm1py's `@odata_compact_json(return_as_dict=...)` decorator
+ * (CellService.py:161-200):
+ * - When `useCompactJson` is false, `fn`'s result is returned unchanged.
+ * - When true: `rest.add_compact_json_header()` is called (saves and
+ *   replaces the Accept header), `fn` is awaited, the response context is
+ *   validated to start with `$metadata#Cellsets`, and
+ *   `extractCompactJsonCellset` is invoked. The original Accept header is
+ *   restored in `finally`, even if `fn` or the extractor throws.
+ */
+export async function withCompactJson<T = any>(
+    rest: RestService,
+    useCompactJson: boolean,
+    fn: () => Promise<any>,
+    returnAsDict: boolean
+): Promise<T> {
+    if (!useCompactJson) {
+        return (await fn()) as T;
+    }
+    const original = rest.add_compact_json_header();
+    try {
+        const response = await fn();
+        const context: string = response?.['@odata.context'];
+        if (!context || !context.startsWith('$metadata#Cellsets')) {
+            throw new Error('odata_compact_json decorator must only be used on cellsets');
+        }
+        return extractCompactJsonCellset(context, response, returnAsDict) as unknown as T;
+    } finally {
+        rest.add_http_header('Accept', original);
     }
 }

--- a/src/tests/cellServiceDecorators.test.ts
+++ b/src/tests/cellServiceDecorators.test.ts
@@ -21,18 +21,30 @@ import {
 } from '../utils/Utils';
 
 type CellServiceMock = jest.Mocked<Pick<CellService,
-    'deleteCellset' | 'beginChangeset' | 'endChangeset'
+    'deleteCellset' | '_safeDeleteCellset' | 'beginChangeset' | 'endChangeset'
     | 'activateTransactionlog' | 'deactivateTransactionlog'
 >>;
 
 function makeCellServiceMock(): CellServiceMock {
-    return {
+    const mock: CellServiceMock = {
         deleteCellset: jest.fn().mockResolvedValue(undefined),
+        _safeDeleteCellset: jest.fn(),
         beginChangeset: jest.fn().mockResolvedValue('cs-1'),
         endChangeset: jest.fn().mockResolvedValue(undefined),
         activateTransactionlog: jest.fn().mockResolvedValue(undefined),
         deactivateTransactionlog: jest.fn().mockResolvedValue(undefined),
     };
+    // Delegate _safeDeleteCellset to deleteCellset and replicate its 404 swallow,
+    // so tests can drive behaviour through the deleteCellset mock.
+    mock._safeDeleteCellset.mockImplementation(async (cellsetId: string, sandboxName?: string) => {
+        try {
+            await mock.deleteCellset(cellsetId, sandboxName);
+        } catch (err: any) {
+            const status = err?.statusCode ?? err?.status ?? err?.response?.status;
+            if (status !== 404) throw err;
+        }
+    });
+    return mock;
 }
 
 describe('withTidyCellset', () => {

--- a/src/tests/cellServiceDecorators.test.ts
+++ b/src/tests/cellServiceDecorators.test.ts
@@ -327,12 +327,57 @@ describe('withCompactJson', () => {
         expect(rest.add_http_header).toHaveBeenCalledWith('Accept', 'application/json;odata.metadata=minimal');
     });
 
-    it('throws when the response is missing @odata.context', async () => {
+    it('throws a distinct missing-context error when @odata.context is absent', async () => {
         const fn = jest.fn().mockResolvedValue({ value: ['cs-id', []] });
 
         await expect(
             withCompactJson(rest as unknown as RestService, true, fn, false)
-        ).rejects.toThrow('odata_compact_json decorator must only be used on cellsets');
+        ).rejects.toThrow("Compact JSON response missing '@odata.context'");
+        expect(rest.add_http_header).toHaveBeenCalledWith('Accept', 'application/json;odata.metadata=minimal');
+    });
+});
+
+describe('withManagedTransactionLog cube-name resolution', () => {
+    let svc: CellServiceMock;
+
+    beforeEach(() => {
+        svc = makeCellServiceMock();
+    });
+
+    it('uses the cubeName field directly when given an object with cubeName', async () => {
+        await withManagedTransactionLog(svc as unknown as CellService, { cubeName: 'cubeA' }, async () => null, {
+            deactivate_transaction_log: true,
+        });
+
+        expect(svc.deactivateTransactionlog).toHaveBeenCalledWith('cubeA');
+    });
+
+    it('derives the cube name from MDX when given an object with mdx', async () => {
+        const mdx = 'SELECT {[Dim].[All]} ON 0 FROM [SalesCube]';
+
+        await withManagedTransactionLog(svc as unknown as CellService, { mdx }, async () => null, {
+            deactivate_transaction_log: true,
+        });
+
+        expect(svc.deactivateTransactionlog).toHaveBeenCalledWith('SalesCube');
+    });
+
+    it('treats a bare string that does not look like MDX as a cube name', async () => {
+        await withManagedTransactionLog(svc as unknown as CellService, 'PlainCube', async () => null, {
+            deactivate_transaction_log: true,
+        });
+
+        expect(svc.deactivateTransactionlog).toHaveBeenCalledWith('PlainCube');
+    });
+
+    it('treats a bare string that looks like MDX as MDX and extracts the cube', async () => {
+        const mdx = 'SELECT {[Dim].[All]} ON 0 FROM [InferredCube]';
+
+        await withManagedTransactionLog(svc as unknown as CellService, mdx, async () => null, {
+            deactivate_transaction_log: true,
+        });
+
+        expect(svc.deactivateTransactionlog).toHaveBeenCalledWith('InferredCube');
     });
 });
 

--- a/src/tests/cellServiceDecorators.test.ts
+++ b/src/tests/cellServiceDecorators.test.ts
@@ -1,0 +1,415 @@
+/**
+ * Unit tests for CellService decorator-equivalent helpers and the OData
+ * compact-JSON utilities they depend on. Mirrors tm1py's `@tidy_cellset`,
+ * `@manage_transaction_log`, `@manage_changeset`, and `@odata_compact_json`
+ * (CellService.py:80-200) and the helpers in tm1py Utils.py:1033-1095.
+ */
+
+import {
+    CellService,
+    withTidyCellset,
+    withManagedTransactionLog,
+    withManagedChangeset,
+    withCompactJson,
+} from '../services/CellService';
+import { RestService } from '../services/RestService';
+import { TM1RestException } from '../exceptions/TM1Exception';
+import {
+    extractCellPropertiesFromOdataContext,
+    mapCellPropertiesToCompactJsonResponse,
+    extractCompactJsonCellset,
+} from '../utils/Utils';
+
+type CellServiceMock = jest.Mocked<Pick<CellService,
+    'deleteCellset' | 'beginChangeset' | 'endChangeset'
+    | 'activateTransactionlog' | 'deactivateTransactionlog'
+>>;
+
+function makeCellServiceMock(): CellServiceMock {
+    return {
+        deleteCellset: jest.fn().mockResolvedValue(undefined),
+        beginChangeset: jest.fn().mockResolvedValue('cs-1'),
+        endChangeset: jest.fn().mockResolvedValue(undefined),
+        activateTransactionlog: jest.fn().mockResolvedValue(undefined),
+        deactivateTransactionlog: jest.fn().mockResolvedValue(undefined),
+    };
+}
+
+describe('withTidyCellset', () => {
+    let svc: CellServiceMock;
+
+    beforeEach(() => {
+        svc = makeCellServiceMock();
+    });
+
+    it('returns the inner result and deletes the cellset on success', async () => {
+        const result = await withTidyCellset(svc as unknown as CellService, 'cs1', async () => 'ok');
+
+        expect(result).toBe('ok');
+        expect(svc.deleteCellset).toHaveBeenCalledTimes(1);
+        expect(svc.deleteCellset).toHaveBeenCalledWith('cs1', undefined);
+    });
+
+    it('still deletes the cellset when the inner function throws', async () => {
+        const inner = jest.fn().mockRejectedValue(new Error('boom'));
+
+        await expect(
+            withTidyCellset(svc as unknown as CellService, 'cs1', inner)
+        ).rejects.toThrow('boom');
+        expect(svc.deleteCellset).toHaveBeenCalledTimes(1);
+    });
+
+    it('forwards sandbox_name to deleteCellset', async () => {
+        await withTidyCellset(svc as unknown as CellService, 'cs1', async () => null, { sandbox_name: 'sb1' });
+
+        expect(svc.deleteCellset).toHaveBeenCalledWith('cs1', 'sb1');
+    });
+
+    it('skips deleteCellset when delete_cellset is false', async () => {
+        await withTidyCellset(svc as unknown as CellService, 'cs1', async () => null, { delete_cellset: false });
+
+        expect(svc.deleteCellset).not.toHaveBeenCalled();
+    });
+
+    it('defaults delete_cellset to true when option object is empty', async () => {
+        await withTidyCellset(svc as unknown as CellService, 'cs1', async () => null, {});
+
+        expect(svc.deleteCellset).toHaveBeenCalledTimes(1);
+    });
+
+    it('silently swallows a 404 from deleteCellset (cellset already gone)', async () => {
+        svc.deleteCellset.mockRejectedValue(new TM1RestException('Not Found', 404));
+
+        await expect(
+            withTidyCellset(svc as unknown as CellService, 'cs1', async () => 'inner-ok')
+        ).resolves.toBe('inner-ok');
+    });
+
+    it('rethrows non-404 errors from deleteCellset', async () => {
+        svc.deleteCellset.mockRejectedValue(new TM1RestException('Server Error', 500));
+
+        await expect(
+            withTidyCellset(svc as unknown as CellService, 'cs1', async () => 'inner-ok')
+        ).rejects.toThrow('Server Error');
+    });
+
+    it('lets a non-404 delete error replace the inner error (Python finally semantics)', async () => {
+        const inner = jest.fn().mockRejectedValue(new Error('inner-boom'));
+        svc.deleteCellset.mockRejectedValue(new TM1RestException('delete-boom', 500));
+
+        await expect(
+            withTidyCellset(svc as unknown as CellService, 'cs1', inner)
+        ).rejects.toThrow('delete-boom');
+    });
+
+    it('detects 404 via err.statusCode (parent TM1Exception field)', async () => {
+        const err = new TM1RestException('gone', undefined, { status: 404 });
+        svc.deleteCellset.mockRejectedValue(err);
+
+        await expect(
+            withTidyCellset(svc as unknown as CellService, 'cs1', async () => 'r')
+        ).resolves.toBe('r');
+    });
+});
+
+describe('withManagedTransactionLog', () => {
+    let svc: CellServiceMock;
+
+    beforeEach(() => {
+        svc = makeCellServiceMock();
+    });
+
+    it('does not toggle the transaction log when both flags are false', async () => {
+        await withManagedTransactionLog(svc as unknown as CellService, 'cube1', async () => null);
+
+        expect(svc.deactivateTransactionlog).not.toHaveBeenCalled();
+        expect(svc.activateTransactionlog).not.toHaveBeenCalled();
+    });
+
+    it('deactivates before fn when deactivate_transaction_log is true', async () => {
+        const calls: string[] = [];
+        svc.deactivateTransactionlog.mockImplementation(async () => { calls.push('deactivate'); });
+        const inner = jest.fn().mockImplementation(async () => { calls.push('inner'); return 'r'; });
+
+        await withManagedTransactionLog(svc as unknown as CellService, 'cube1', inner, {
+            deactivate_transaction_log: true,
+        });
+
+        expect(svc.deactivateTransactionlog).toHaveBeenCalledWith('cube1');
+        expect(calls).toEqual(['deactivate', 'inner']);
+        expect(svc.activateTransactionlog).not.toHaveBeenCalled();
+    });
+
+    it('reactivates after fn when reactivate_transaction_log is true', async () => {
+        const calls: string[] = [];
+        const inner = jest.fn().mockImplementation(async () => { calls.push('inner'); });
+        svc.activateTransactionlog.mockImplementation(async () => { calls.push('activate'); });
+
+        await withManagedTransactionLog(svc as unknown as CellService, 'cube1', inner, {
+            reactivate_transaction_log: true,
+        });
+
+        expect(svc.activateTransactionlog).toHaveBeenCalledWith('cube1');
+        expect(calls).toEqual(['inner', 'activate']);
+        expect(svc.deactivateTransactionlog).not.toHaveBeenCalled();
+    });
+
+    it('reactivates even when the inner function throws', async () => {
+        const inner = jest.fn().mockRejectedValue(new Error('inner-boom'));
+
+        await expect(
+            withManagedTransactionLog(svc as unknown as CellService, 'cube1', inner, {
+                deactivate_transaction_log: true,
+                reactivate_transaction_log: true,
+            })
+        ).rejects.toThrow('inner-boom');
+        expect(svc.activateTransactionlog).toHaveBeenCalledTimes(1);
+    });
+
+    it('reactivates even when deactivate throws', async () => {
+        svc.deactivateTransactionlog.mockRejectedValue(new Error('deactivate-boom'));
+        const inner = jest.fn();
+
+        await expect(
+            withManagedTransactionLog(svc as unknown as CellService, 'cube1', inner, {
+                deactivate_transaction_log: true,
+                reactivate_transaction_log: true,
+            })
+        ).rejects.toThrow('deactivate-boom');
+        expect(inner).not.toHaveBeenCalled();
+        expect(svc.activateTransactionlog).toHaveBeenCalledTimes(1);
+    });
+});
+
+describe('withManagedChangeset', () => {
+    let svc: CellServiceMock;
+
+    beforeEach(() => {
+        svc = makeCellServiceMock();
+    });
+
+    it('calls fn with no args and skips begin/end when useChangeset is false', async () => {
+        const inner = jest.fn().mockResolvedValue('r');
+
+        const result = await withManagedChangeset(svc as unknown as CellService, inner, false);
+
+        expect(result).toBe('r');
+        expect(inner).toHaveBeenCalledTimes(1);
+        expect(inner.mock.calls[0]).toHaveLength(0);
+        expect(svc.beginChangeset).not.toHaveBeenCalled();
+        expect(svc.endChangeset).not.toHaveBeenCalled();
+    });
+
+    it('passes the changeset id to fn and ends the changeset on success', async () => {
+        svc.beginChangeset.mockResolvedValue('cs-42');
+        const inner = jest.fn().mockResolvedValue('r');
+
+        const result = await withManagedChangeset(svc as unknown as CellService, inner, true);
+
+        expect(result).toBe('r');
+        expect(inner).toHaveBeenCalledWith('cs-42');
+        expect(svc.endChangeset).toHaveBeenCalledWith('cs-42');
+    });
+
+    it('still calls endChangeset when fn throws', async () => {
+        svc.beginChangeset.mockResolvedValue('cs-9');
+        const inner = jest.fn().mockRejectedValue(new Error('boom'));
+
+        await expect(
+            withManagedChangeset(svc as unknown as CellService, inner, true)
+        ).rejects.toThrow('boom');
+        expect(svc.endChangeset).toHaveBeenCalledWith('cs-9');
+    });
+
+    it('does not call endChangeset when beginChangeset throws', async () => {
+        svc.beginChangeset.mockRejectedValue(new Error('begin-boom'));
+        const inner = jest.fn();
+
+        await expect(
+            withManagedChangeset(svc as unknown as CellService, inner, true)
+        ).rejects.toThrow('begin-boom');
+        expect(inner).not.toHaveBeenCalled();
+        expect(svc.endChangeset).not.toHaveBeenCalled();
+    });
+});
+
+describe('withCompactJson', () => {
+    let rest: jest.Mocked<Pick<RestService, 'add_compact_json_header' | 'add_http_header'>>;
+
+    beforeEach(() => {
+        rest = {
+            add_compact_json_header: jest.fn().mockReturnValue('application/json;odata.metadata=minimal'),
+            add_http_header: jest.fn(),
+        };
+    });
+
+    it('passes the inner result through unchanged when useCompactJson is false', async () => {
+        const fn = jest.fn().mockResolvedValue({ '@odata.context': 'whatever', value: ['x'] });
+
+        const result = await withCompactJson(rest as unknown as RestService, false, fn, true);
+
+        expect(result).toEqual({ '@odata.context': 'whatever', value: ['x'] });
+        expect(rest.add_compact_json_header).not.toHaveBeenCalled();
+        expect(rest.add_http_header).not.toHaveBeenCalled();
+    });
+
+    it('toggles the Accept header for the request and restores it on success', async () => {
+        const fn = jest.fn().mockResolvedValue({
+            '@odata.context': '$metadata#Cellsets(Cells(Ordinal,Value))/$entity',
+            value: ['cs-id', [[0, 100], [1, 200]]],
+        });
+
+        const result = await withCompactJson(rest as unknown as RestService, true, fn, false);
+
+        expect(result).toEqual([100, 200]);
+        expect(rest.add_compact_json_header).toHaveBeenCalledTimes(1);
+        expect(rest.add_http_header).toHaveBeenCalledWith('Accept', 'application/json;odata.metadata=minimal');
+    });
+
+    it('calls the dict extractor when returnAsDict is true', async () => {
+        const fn = jest.fn().mockResolvedValue({
+            '@odata.context': '$metadata#Cellsets(Cells(Ordinal,Value,RuleDerived))/$entity',
+            value: ['cs-id', [[0, 100, false], [1, 200, true]]],
+        });
+
+        const result = await withCompactJson(rest as unknown as RestService, true, fn, true);
+
+        expect(result).toEqual({
+            Cells: [
+                { Ordinal: 0, Value: 100, RuleDerived: false },
+                { Ordinal: 1, Value: 200, RuleDerived: true },
+            ],
+        });
+    });
+
+    it('restores the Accept header even when fn throws', async () => {
+        const fn = jest.fn().mockRejectedValue(new Error('fn-boom'));
+
+        await expect(
+            withCompactJson(rest as unknown as RestService, true, fn, false)
+        ).rejects.toThrow('fn-boom');
+        expect(rest.add_http_header).toHaveBeenCalledWith('Accept', 'application/json;odata.metadata=minimal');
+    });
+
+    it('restores the Accept header even when the extractor throws', async () => {
+        const fn = jest.fn().mockResolvedValue({
+            '@odata.context': '$metadata#Cellsets(Cells(BadField!!!))/$entity',
+            value: ['cs-id', [[1]]],
+        });
+
+        await expect(
+            withCompactJson(rest as unknown as RestService, true, fn, false)
+        ).rejects.toThrow('Could not extract cell properties from odata context');
+        expect(rest.add_http_header).toHaveBeenCalledWith('Accept', 'application/json;odata.metadata=minimal');
+    });
+
+    it('throws when the response context is not a cellset context', async () => {
+        const fn = jest.fn().mockResolvedValue({
+            '@odata.context': '$metadata#Other(...)',
+            value: ['cs-id', []],
+        });
+
+        await expect(
+            withCompactJson(rest as unknown as RestService, true, fn, false)
+        ).rejects.toThrow('odata_compact_json decorator must only be used on cellsets');
+        expect(rest.add_http_header).toHaveBeenCalledWith('Accept', 'application/json;odata.metadata=minimal');
+    });
+
+    it('throws when the response is missing @odata.context', async () => {
+        const fn = jest.fn().mockResolvedValue({ value: ['cs-id', []] });
+
+        await expect(
+            withCompactJson(rest as unknown as RestService, true, fn, false)
+        ).rejects.toThrow('odata_compact_json decorator must only be used on cellsets');
+    });
+});
+
+describe('extractCellPropertiesFromOdataContext', () => {
+    it('returns the property list for a valid cellset context', () => {
+        expect(
+            extractCellPropertiesFromOdataContext('$metadata#Cellsets(Cells(Ordinal,Value))/$entity')
+        ).toEqual(['Ordinal', 'Value']);
+    });
+
+    it('returns a single-element list for a single-property context', () => {
+        expect(
+            extractCellPropertiesFromOdataContext('$metadata#Cellsets(Cells(Value))/$entity')
+        ).toEqual(['Value']);
+    });
+
+    it('throws when the context does not match the expected pattern', () => {
+        expect(
+            () => extractCellPropertiesFromOdataContext('$metadata#Other')
+        ).toThrow('Could not extract cell properties from odata context');
+    });
+});
+
+describe('mapCellPropertiesToCompactJsonResponse', () => {
+    it('maps each row into a property→value object', () => {
+        expect(
+            mapCellPropertiesToCompactJsonResponse(
+                ['Ordinal', 'Value', 'RuleDerived'],
+                [[0, 100, false], [1, 200, true]]
+            )
+        ).toEqual({
+            Cells: [
+                { Ordinal: 0, Value: 100, RuleDerived: false },
+                { Ordinal: 1, Value: 200, RuleDerived: true },
+            ],
+        });
+    });
+
+    it('returns { Cells: [] } when there are no rows', () => {
+        expect(
+            mapCellPropertiesToCompactJsonResponse(['Ordinal', 'Value'], [])
+        ).toEqual({ Cells: [] });
+    });
+
+    it('throws when a row has fewer values than properties', () => {
+        expect(
+            () => mapCellPropertiesToCompactJsonResponse(['Ordinal', 'Value', 'RuleDerived'], [[0, 100]])
+        ).toThrow(RangeError);
+    });
+});
+
+describe('extractCompactJsonCellset', () => {
+    const dictContext = '$metadata#Cellsets(Cells(Ordinal,Value,RuleDerived))/$entity';
+    const dictResponse = { value: ['cs-id', [[0, 100, false], [1, 200, true]]] };
+
+    it('returns the dict shape when returnAsDict is true', () => {
+        expect(extractCompactJsonCellset(dictContext, dictResponse, true)).toEqual({
+            Cells: [
+                { Ordinal: 0, Value: 100, RuleDerived: false },
+                { Ordinal: 1, Value: 200, RuleDerived: true },
+            ],
+        });
+    });
+
+    it('returns a flat list of values for a single-property context', () => {
+        const ctx = '$metadata#Cellsets(Cells(Value))/$entity';
+        const resp = { value: ['cs-id', [[100], [200], [300]]] };
+
+        expect(extractCompactJsonCellset(ctx, resp, false)).toEqual([100, 200, 300]);
+    });
+
+    it('returns a flat list of values for the exact Ordinal,Value shortcut', () => {
+        const ctx = '$metadata#Cellsets(Cells(Ordinal,Value))/$entity';
+        const resp = { value: ['cs-id', [[0, 100], [1, 200]]] };
+
+        expect(extractCompactJsonCellset(ctx, resp, false)).toEqual([100, 200]);
+    });
+
+    it('returns the raw rows when properties are reversed (Value,Ordinal)', () => {
+        const ctx = '$metadata#Cellsets(Cells(Value,Ordinal))/$entity';
+        const resp = { value: ['cs-id', [[100, 0], [200, 1]]] };
+
+        expect(extractCompactJsonCellset(ctx, resp, false)).toEqual([[100, 0], [200, 1]]);
+    });
+
+    it('returns the raw rows for any shape that is not single-prop or Ordinal+Value', () => {
+        expect(extractCompactJsonCellset(dictContext, dictResponse, false)).toEqual([
+            [0, 100, false],
+            [1, 200, true],
+        ]);
+    });
+});

--- a/src/utils/Utils.ts
+++ b/src/utils/Utils.ts
@@ -632,3 +632,66 @@ async function checkAdminPrivileges(rest: any, privilegeType: 'DATA' | 'SECURITY
         console.warn(`Unable to verify ${privilegeType} admin privileges:`, error);
     }
 }
+
+/**
+ * Extract cell property names from an OData `@odata.context` returned by a
+ * compact-JSON cellset response. Mirrors tm1py's
+ * `extract_cell_properties_from_odata_context` (Utils.py).
+ */
+export function extractCellPropertiesFromOdataContext(context: string): string[] {
+    const match = /^\$metadata#Cellsets\(Cells\(([A-Za-z,]+)\)\)\/\$entity/.exec(context);
+    if (!match) {
+        throw new Error('Could not extract cell properties from odata context');
+    }
+    return match[1].split(',');
+}
+
+/**
+ * Map a list of cell properties onto the compact-JSON `value[1]` array,
+ * producing `{ Cells: [{prop1: v1, prop2: v2, ...}, ...] }`. Mirrors tm1py's
+ * `map_cell_properties_to_compact_json_response`.
+ */
+export function mapCellPropertiesToCompactJsonResponse(
+    properties: string[],
+    compactCellsResponse: any[][]
+): { Cells: Array<Record<string, any>> } {
+    const cells = compactCellsResponse.map(cell => {
+        if (cell.length < properties.length) {
+            // Match Python's IndexError when a row has fewer values than expected
+            throw new RangeError(
+                `Compact JSON row has ${cell.length} values but ${properties.length} properties were expected`
+            );
+        }
+        const d: Record<string, any> = {};
+        properties.forEach((prop, idx) => { d[prop] = cell[idx]; });
+        return d;
+    });
+    return { Cells: cells };
+}
+
+/**
+ * Translate a TM1 OData compact-JSON cellset response into either a default
+ * dictionary (`{ Cells: [...] }`) or a flat list of values, depending on
+ * `returnAsDict` and the property shape. Mirrors tm1py's
+ * `extract_compact_json_cellset`.
+ */
+export function extractCompactJsonCellset(
+    context: string,
+    response: { value: any[] },
+    returnAsDict: boolean
+): { Cells: Array<Record<string, any>> } | any[] {
+    const props = extractCellPropertiesFromOdataContext(context);
+    // First element [0] is the cellset ID, second is the cellset data
+    const cellsData: any[][] = response.value[1];
+
+    if (returnAsDict) {
+        return mapCellPropertiesToCompactJsonResponse(props, cellsData);
+    }
+    if (props.length === 1) {
+        return cellsData.map(value => value[0]);
+    }
+    if (props.length === 2 && props[0] === 'Ordinal' && props[1] === 'Value') {
+        return cellsData.map(value => value[1]);
+    }
+    return cellsData;
+}

--- a/src/utils/Utils.ts
+++ b/src/utils/Utils.ts
@@ -637,6 +637,44 @@ async function checkAdminPrivileges(rest: any, privilegeType: 'DATA' | 'SECURITY
 const ODATA_CELLS_CONTEXT_RE = /^\$metadata#Cellsets\(Cells\(([A-Za-z,]+)\)\)\/\$entity/;
 
 /**
+ * Detect whether a string resembles an MDX query. Mirrors tm1py's
+ * `resembles_mdx` (Utils.py:1686-1690): case- and dot-all-insensitive
+ * `.*SELECT.*ON.*FROM.*`.
+ */
+export function resemblesMdx(mdx: string): boolean {
+    return /SELECT[\s\S]*ON[\s\S]*FROM/i.test(mdx);
+}
+
+/**
+ * Extract the cube name from an MDX query. Mirrors tm1py's `get_cube`
+ * (Utils.py:1664-1683):
+ * 1. Strip whitespace.
+ * 2. Happy case: `FROM[<cube>]` — return the bracketed value.
+ * 3. Cut off any `WHERE(...)` clause.
+ * 4. Return whatever follows the last `FROM`.
+ */
+export function getCube(mdx: string): string {
+    // replace tabs, line breaks, spaces
+    let stripped = mdx.replace(/\s+/g, '');
+
+    // happy case: cube name in square brackets
+    const bracketMatch = /FROM\[([\s\S]*?)\]/i.exec(stripped);
+    if (bracketMatch) {
+        return bracketMatch[1];
+    }
+
+    // cut off where
+    if (/.*SELECT.*ON.*FROM.*WHERE\(.*/is.test(stripped)) {
+        // part before where
+        stripped = stripped.split(/WHERE\(.*/is)[0];
+    }
+
+    // part after from
+    const parts = stripped.split(/FROM/i);
+    return parts[parts.length - 1];
+}
+
+/**
  * Extract cell property names from an OData `@odata.context` returned by a
  * compact-JSON cellset response. Mirrors tm1py's
  * `extract_cell_properties_from_odata_context` (Utils.py).

--- a/src/utils/Utils.ts
+++ b/src/utils/Utils.ts
@@ -633,13 +633,16 @@ async function checkAdminPrivileges(rest: any, privilegeType: 'DATA' | 'SECURITY
     }
 }
 
+// Anchored to start to match tm1py's `re.match` semantics (Utils.py:1065).
+const ODATA_CELLS_CONTEXT_RE = /^\$metadata#Cellsets\(Cells\(([A-Za-z,]+)\)\)\/\$entity/;
+
 /**
  * Extract cell property names from an OData `@odata.context` returned by a
  * compact-JSON cellset response. Mirrors tm1py's
  * `extract_cell_properties_from_odata_context` (Utils.py).
  */
 export function extractCellPropertiesFromOdataContext(context: string): string[] {
-    const match = /^\$metadata#Cellsets\(Cells\(([A-Za-z,]+)\)\)\/\$entity/.exec(context);
+    const match = ODATA_CELLS_CONTEXT_RE.exec(context);
     if (!match) {
         throw new Error('Could not extract cell properties from odata context');
     }
@@ -663,7 +666,9 @@ export function mapCellPropertiesToCompactJsonResponse(
             );
         }
         const d: Record<string, any> = {};
-        properties.forEach((prop, idx) => { d[prop] = cell[idx]; });
+        for (let i = 0; i < properties.length; i++) {
+            d[properties[i]] = cell[i];
+        }
         return d;
     });
     return { Cells: cells };


### PR DESCRIPTION
## Summary

Closes #60.

Ports the four tm1py CellService decorators (`CellService.py:80-200`) to TypeScript as higher-order async helpers, plus the three OData compact-JSON response utilities they depend on (`Utils.py:1033-1095`).

### New helpers — `src/services/CellService.ts`
- **`withTidyCellset`** — wraps an inner fn, deletes the cellset in `finally`, swallows 404 (cellset already gone), rethrows everything else. Mirrors `@tidy_cellset` (CellService.py:80-100).
- **`withManagedTransactionLog`** — optionally deactivates the transaction log before the inner fn and reactivates it in `finally`. Mirrors `@manage_transaction_log` (CellService.py:103-136). The MDX/cube-name resolution branch is intentionally omitted — TS callers always pass `cubeName` explicitly (documented in JSDoc).
- **`withManagedChangeset`** — optionally wraps the inner fn in a TM1 `BeginChangeSet`/`EndChangeSet` pair. Mirrors `@manage_changeset` (CellService.py:139-158). `begin` is outside `try` so `end` is skipped if `begin` throws.
- **`withCompactJson`** — toggles the compact-JSON `Accept` header for the inner request, validates the cellset context, and translates the response via `extractCompactJsonCellset`. Mirrors `@odata_compact_json` (CellService.py:161-200).

### New utilities — `src/utils/Utils.ts`
- `extractCellPropertiesFromOdataContext` — anchored regex match on `\$metadata#Cellsets(Cells(...))/$entity`.
- `mapCellPropertiesToCompactJsonResponse` — maps `value[1]` rows onto `{ Cells: [{prop: val, ...}] }`.
- `extractCompactJsonCellset` — full dispatcher (dict / single-prop list / `Ordinal,Value` shortcut / raw).

### Other changes
- Refactored `writeValuesThroughCellset` to use `withTidyCellset` (the only existing tm1npm method with the internal create-then-delete pattern).
- Removed two incorrect `$use_compact_json` query-string appends in `executeMdxDataFrame` / `executeMdxDataframeShaped`. tm1py never used a query param — `use_compact_json` is a header flag handled by the new helper.
- Raised `_safeDeleteCellset` from `private` to `public` so `withTidyCellset` can delegate to it (single source of truth for the 404-swallow logic).

### Parity notes
- All default kwarg values, error semantics (Python `try/finally` — delete error replaces inner), and 404-on-delete swallow match tm1py exactly.
- The exact tm1py error messages are preserved verbatim.
- Retrofitting other `extract_cellset_*` methods to use the helpers is intentionally **out of scope** — that would change tm1npm's public API to add `delete_cellset` defaulting to `true`, which is a breaking change deserving a separate PR.

## Test plan
- [x] 36 new unit tests in `src/tests/cellServiceDecorators.test.ts` cover every documented branch (success, throw-during-fn, throw-during-cleanup, 404 swallow, non-404 rethrow, Python `finally` error replacement, header restoration on inner-and-extractor throws, single-prop / `Ordinal,Value` shortcut / reversed / fallthrough extraction, `RangeError` on short rows, missing `@odata.context`).
- [x] `node_modules/.bin/jest src/tests/cellServiceDecorators.test.ts` — 36/36 passing.
- [x] Full suite: `node_modules/.bin/jest` — 1520/1521 (1 pre-existing TM1-credential-dependent test fails on main too).
- [x] `node_modules/.bin/tsc --noEmit` — clean.