### PR TITLE
fix(#67): align CellService extract methods with tm1py

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -61,6 +61,7 @@ All notable changes to this project are documented here.
 ### Dependencies
 
 - Added `stream-json ^2.1.0` as a runtime dependency (used by `extractCellsetCsvIterJson`).
+- Added `stream-chain ^3.0.0` as a runtime dependency (composed with `stream-json` to chain the read/parse pipeline). Listed explicitly so installs under pnpm strict mode and Yarn PnP resolve correctly — previously only present as a transitive dep.
 - Added `@types/stream-json ^1.7.8` as a dev dependency.
 
 ## 2.0.0 — 2026-04-16

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,67 @@
 
 All notable changes to this project are documented here.
 
+## 2.2.0 — 2026-05-02
+
+### BREAKING CHANGES
+
+**Four `CellService` methods changed from positional arguments to an options object**
+(see [#67](https://github.com/KimKaoPoo/tm1npm/issues/67)).
+
+- **`extractCellset`** — was `(cellsetId, deleteCellset?, sandboxName?)`,
+  now accepts `ExtractCellsetOptions` and returns `CaseAndSpaceInsensitiveTuplesDict`
+  instead of a plain object.
+  - Migration: `extractCellset(id, true, 'sb')` → `extractCellset(id, { deleteCellset: true, sandboxName: 'sb' })`.
+
+- **`extractCellsetCsv`** — was `(cellsetId, sandboxName?, includeHeaders?)`,
+  now accepts `ExtractCellsetCsvOptions`.
+  - Migration: `extractCellsetCsv(id, 'sb', false)` → `extractCellsetCsv(id, { sandboxName: 'sb', includeHeaders: false })`.
+
+- **`extractCellsetRawResponse`** — was `(cellsetId, ...positional)`,
+  now accepts `ExtractCellsetRawOptions`.
+
+- **`extractCellsetComposition`** — return shape changed from
+  `{ cube, rows, columns }` to `{ cube, titles, rows, columns }` (adds `titles`
+  for title/page-filter axes, matching tm1py's return value).
+
+### Added
+
+- **`Utils.ts`** — new cellset-shaping helpers (all match tm1py parity):
+  - `dimensionNameFromElementUniqueName` / `hierarchyNameFromElementUniqueName` /
+    `elementNameFromElementUniqueName` — parse element unique-name strings.
+  - `dimensionNamesFromElementUniqueNames` — extract dimension names from an iterable.
+  - `extractAxesFromCellset` — split raw cellset axes into rows/columns/titles.
+  - `extractUniqueNamesFromMembers` — collect member unique-names from axis tuples.
+  - `sortCoordinates` — sort member addresses by cube-dimension order.
+  - `buildContentFromCellsetDict` — convert a `RawCellsetDict` to a nested content dict.
+  - `buildCsvFromCellsetDict` — convert a `RawCellsetDict` to a CSV string.
+  - New interfaces: `CellsetAxis`, `RawCellsetDict`, `CsvDialect`.
+  - `CaseAndSpaceInsensitiveTuplesDict` — `Map` subclass with normalized tuple keys.
+
+- **`CellService`** — new and rewritten methods (all match tm1py parity):
+  - `extractCellsetRaw` — full cellset dict with tidy and compact-JSON support.
+  - `extractCellsetCellsRaw` — cells-only slice; wrapped with `withCompactJson`.
+  - `extractCellsetAxesRawAsync` — parallel per-axis fetch using `Promise.all`.
+  - `extractCellsetCellsRawAsync` — parallel chunk fetch using `Promise.all`.
+  - `extractCellsetCsvIterJson` — streaming CSV via `stream-json` (no full parse).
+  - New exported interfaces: `ExtractCellsetRawOptions`, `ExtractCellsetCsvOptions`,
+    `ExtractCellsetMetadataRawOptions`, `ExtractCellsetCompositionResult`.
+
+### Changed
+
+- `extractCellset` now returns `CaseAndSpaceInsensitiveTuplesDict` (normalized-key
+  `Map` subclass) instead of a plain object.
+- `extractCellsetCsv` now performs client-side CSV conversion via
+  `buildCsvFromCellsetDict` (no server-side `/Content` endpoint call).
+- Internal callers (`extractCellsetRowsAndValues`, `extractCellsetDataframe`,
+  `extractCellsetDataframePivot`, `extractCellsetAsync`) updated to use
+  `extractCellsetRaw` for consistency.
+
+### Dependencies
+
+- Added `stream-json ^2.1.0` as a runtime dependency (used by `extractCellsetCsvIterJson`).
+- Added `@types/stream-json ^1.7.8` as a dev dependency.
+
 ## 2.0.0 — 2026-04-16
 
 ### BREAKING CHANGES

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "tm1npm",
-  "version": "2.1.0",
+  "version": "2.2.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "tm1npm",
-      "version": "2.1.0",
+      "version": "2.2.0",
       "license": "MIT",
       "dependencies": {
         "@types/stream-json": "^1.7.8",

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,15 +9,16 @@
       "version": "2.2.0",
       "license": "MIT",
       "dependencies": {
-        "@types/stream-json": "^1.7.8",
         "axios": "^1.6.0",
         "luxon": "^3.4.0",
+        "stream-chain": "^3.0.0",
         "stream-json": "^2.1.0",
         "uuid": "^9.0.0"
       },
       "devDependencies": {
         "@types/jest": "^29.0.0",
         "@types/node": "^20.0.0",
+        "@types/stream-json": "^1.7.8",
         "@types/uuid": "^9.0.0",
         "@typescript-eslint/eslint-plugin": "^6.0.0",
         "@typescript-eslint/parser": "^6.0.0",
@@ -1377,6 +1378,7 @@
       "version": "20.19.13",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-20.19.13.tgz",
       "integrity": "sha512-yCAeZl7a0DxgNVteXFHt9+uyFbqXGy/ShC4BlcHkoE0AfGXYv/BUiplV72DjMYXHDBXFjhvr6DD1NiRVfB4j8g==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "undici-types": "~6.21.0"
@@ -1400,6 +1402,7 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/@types/stream-chain/-/stream-chain-2.1.0.tgz",
       "integrity": "sha512-guDyAl6s/CAzXUOWpGK2bHvdiopLIwpGu8v10+lb9hnQOyo4oj/ZUQFOvqFjKGsE3wJP1fpIesCcMvbXuWsqOg==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/node": "*"
@@ -1409,6 +1412,7 @@
       "version": "1.7.8",
       "resolved": "https://registry.npmjs.org/@types/stream-json/-/stream-json-1.7.8.tgz",
       "integrity": "sha512-MU1OB1eFLcYWd1LjwKXrxdoPtXSRzRmAnnxs4Js/ayB5O/NvHraWwuOaqMWIebpYwM6khFlsJOHEhI9xK/ab4Q==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/node": "*",
@@ -5423,6 +5427,7 @@
       "version": "6.21.0",
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
       "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/update-browserslist-db": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,8 +9,10 @@
       "version": "2.1.0",
       "license": "MIT",
       "dependencies": {
+        "@types/stream-json": "^1.7.8",
         "axios": "^1.6.0",
         "luxon": "^3.4.0",
+        "stream-json": "^2.1.0",
         "uuid": "^9.0.0"
       },
       "devDependencies": {
@@ -1375,7 +1377,6 @@
       "version": "20.19.13",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-20.19.13.tgz",
       "integrity": "sha512-yCAeZl7a0DxgNVteXFHt9+uyFbqXGy/ShC4BlcHkoE0AfGXYv/BUiplV72DjMYXHDBXFjhvr6DD1NiRVfB4j8g==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "undici-types": "~6.21.0"
@@ -1394,6 +1395,25 @@
       "integrity": "sha512-9aEbYZ3TbYMznPdcdr3SmIrLXwC/AKZXQeCf9Pgao5CKb8CyHuEX5jzWPTkvregvhRJHcpRO6BFoGW9ycaOkYw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@types/stream-chain": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@types/stream-chain/-/stream-chain-2.1.0.tgz",
+      "integrity": "sha512-guDyAl6s/CAzXUOWpGK2bHvdiopLIwpGu8v10+lb9hnQOyo4oj/ZUQFOvqFjKGsE3wJP1fpIesCcMvbXuWsqOg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
+    "node_modules/@types/stream-json": {
+      "version": "1.7.8",
+      "resolved": "https://registry.npmjs.org/@types/stream-json/-/stream-json-1.7.8.tgz",
+      "integrity": "sha512-MU1OB1eFLcYWd1LjwKXrxdoPtXSRzRmAnnxs4Js/ayB5O/NvHraWwuOaqMWIebpYwM6khFlsJOHEhI9xK/ab4Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*",
+        "@types/stream-chain": "*"
+      }
     },
     "node_modules/@types/uuid": {
       "version": "9.0.8",
@@ -5024,6 +5044,27 @@
         "node": ">=8"
       }
     },
+    "node_modules/stream-chain": {
+      "version": "3.6.2",
+      "resolved": "https://registry.npmjs.org/stream-chain/-/stream-chain-3.6.2.tgz",
+      "integrity": "sha512-MRUXdH/Fcv2I95WSkPthvpxGsuKeBpr50UXcP5Z3ncWafYxrWelMTVI3G7vJFABCs1ipoTPCN3J13ZcLpymrtA==",
+      "license": "BSD-3-Clause",
+      "funding": {
+        "url": "https://github.com/sponsors/uhop"
+      }
+    },
+    "node_modules/stream-json": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/stream-json/-/stream-json-2.1.0.tgz",
+      "integrity": "sha512-9gV/ywtebMn3DdKnNKYCb9iESvgR1dHbucNV+bRGvdvy+jV4c9FFgYKmENhpKv58jSwvs90Wk80RhfKk1KxHPg==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "stream-chain": "^3.6.1"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/uhop"
+      }
+    },
     "node_modules/string-length": {
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/string-length/-/string-length-4.0.2.tgz",
@@ -5382,7 +5423,6 @@
       "version": "6.21.0",
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
       "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/update-browserslist-db": {

--- a/package.json
+++ b/package.json
@@ -56,6 +56,7 @@
   "dependencies": {
     "axios": "^1.6.0",
     "luxon": "^3.4.0",
+    "stream-chain": "^3.0.0",
     "stream-json": "^2.1.0",
     "uuid": "^9.0.0"
   },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tm1npm",
-  "version": "2.1.0",
+  "version": "2.2.0",
   "description": "A Node.js module for TM1",
   "main": "lib/index.js",
   "types": "lib/index.d.ts",

--- a/package.json
+++ b/package.json
@@ -56,11 +56,13 @@
   "dependencies": {
     "axios": "^1.6.0",
     "luxon": "^3.4.0",
+    "stream-json": "^2.1.0",
     "uuid": "^9.0.0"
   },
   "devDependencies": {
     "@types/jest": "^29.0.0",
     "@types/node": "^20.0.0",
+    "@types/stream-json": "^1.7.8",
     "@types/uuid": "^9.0.0",
     "@typescript-eslint/eslint-plugin": "^6.0.0",
     "@typescript-eslint/parser": "^6.0.0",

--- a/src/services/CellService.ts
+++ b/src/services/CellService.ts
@@ -1384,7 +1384,10 @@ export class CellService {
      * Mirrors tm1py's `extract_cellset_raw_response` URL builder (CellService.py:3636-3704).
      */
     private _buildCellsetRawUrl(cellsetId: string, opts: ExtractCellsetRawOptions): string {
-        const cellProperties = [...(opts.cellProperties ?? ['Value'])];
+        // tm1py: `if not cell_properties:` treats [] as falsy. JS `??` would
+        // accept [] verbatim and emit a malformed `Cells($select=)` URL.
+        const cellProperties = [...((opts.cellProperties && opts.cellProperties.length > 0)
+            ? opts.cellProperties : ['Value'])];
         if (opts.skipRuleDerivedCells) {
             cellProperties.push('RuleDerived');
             cellProperties.push('Updateable');
@@ -1457,7 +1460,9 @@ export class CellService {
             useCompactJson?: boolean;
         } = {}
     ): Promise<{ Cells: any[]; '@odata.context'?: string; ID?: string }> {
-        const cellProperties = [...(options.cellProperties ?? ['Value'])];
+        // tm1py: `if not cell_properties:` treats [] as falsy.
+        const cellProperties = [...((options.cellProperties && options.cellProperties.length > 0)
+            ? options.cellProperties : ['Value'])];
         if (options.skipRuleDerivedCells) {
             cellProperties.push('RuleDerived');
             // necessary due to bug in TM1 11.8: If only RuleDerived is retrieved
@@ -1698,7 +1703,9 @@ export class CellService {
     ): Promise<{ '@odata.context': string; ID: string; Cells: any[] }> {
         const maxWorkers = options.maxWorkers ?? 8;
 
-        const cellProperties = [...(options.cellProperties ?? ['Value'])];
+        // tm1py: `if not cell_properties:` treats [] as falsy.
+        const cellProperties = [...((options.cellProperties && options.cellProperties.length > 0)
+            ? options.cellProperties : ['Value'])];
         if (options.skipRuleDerivedCells) {
             cellProperties.push('RuleDerived');
             cellProperties.push('Updateable');

--- a/src/services/CellService.ts
+++ b/src/services/CellService.ts
@@ -1726,10 +1726,9 @@ export class CellService {
 
         const cellcount = await this.getCellsetCellsCount(cellsetId, options.sandboxName);
 
-        if (cellcount === 0) {
-            return { '@odata.context': '', ID: '', Cells: [] };
-        }
-
+        // Match tm1py: when cellcount is 0, partitionSize=ceil(0/maxWorkers)=0 and
+        // each chunk fetch issues a request without `;$top=` — equivalent to fetching
+        // all (zero) cells. Don't short-circuit; keep wire behavior identical to tm1py.
         const partitionSize = Math.ceil(cellcount / maxWorkers);
         const results = await Promise.all(
             Array.from({ length: maxWorkers }, (_, p) => fetchChunk(p, partitionSize))
@@ -1963,8 +1962,12 @@ export class CellService {
 
         await this._streamJsonWalk(rawResponse.data, prefixesOfInterest, (prefix, event, value) => {
             if (prefix === 'Cells.item.Value') {
-                // tm1py CellService.py:4482-4499
-                const total = axes0List.length || 1;
+                // tm1py CellService.py:4482-4499 — divmod raises ZeroDivisionError
+                // when axes0List is empty; match that strict behavior.
+                if (axes0List.length === 0) {
+                    throw new Error('division by zero: axes0List is empty');
+                }
+                const total = axes0List.length;
                 const r = currentCellOrdinal % total;
                 const q = Math.floor(currentCellOrdinal / total);
                 let row: string[];

--- a/src/services/CellService.ts
+++ b/src/services/CellService.ts
@@ -1685,6 +1685,65 @@ export class CellService {
     }
 
     /**
+     * Extract cellset cells asynchronously using parallel chunked requests.
+     * Mirrors tm1py's `extract_cellset_cells_raw_async` (CellService.py:4078-4157).
+     * Uses Promise.all instead of Python's ThreadPoolExecutor.
+     */
+    public async extractCellsetCellsRawAsync(
+        cellsetId: string,
+        options: ExtractCellsetCellsRawAsyncOptions = {}
+    ): Promise<{ '@odata.context': string; ID: string; Cells: any[] }> {
+        const maxWorkers = options.maxWorkers ?? 8;
+
+        const cellProperties = [...(options.cellProperties ?? ['Value'])];
+        if (options.skipRuleDerivedCells) {
+            cellProperties.push('RuleDerived');
+            cellProperties.push('Updateable');
+        }
+        if (options.skipConsolidatedCells) cellProperties.push('Consolidated');
+        if ((options.skipZeros || options.skipRuleDerivedCells || options.skipConsolidatedCells)
+                && !cellProperties.includes('Ordinal')) {
+            cellProperties.push('Ordinal');
+        }
+
+        const filters: string[] = [];
+        if (options.skipZeros) filters.push("Value ne 0 and Value ne null and Value ne ''");
+        if (options.skipConsolidatedCells) filters.push('Consolidated eq false');
+        if (options.skipRuleDerivedCells) filters.push('RuleDerived eq false');
+        const filterCells = filters.join(' and ');
+
+        const fetchChunk = async (partition: number, partitionSize: number): Promise<any> => {
+            const top = partitionSize;
+            const skip = partition * partitionSize;
+            const topClause = top ? ';$top=' + top : '';
+            const skipClause = skip ? ';$skip=' + skip : '';
+            const filterClause = filterCells ? ';$filter=' + filterCells : '';
+            let url = `/Cellsets('${cellsetId}')?$expand=Cells($select=${cellProperties.join(',')}${topClause}${skipClause}${filterClause})`;
+            if (options.sandboxName) url += `&!sandbox=${encodeURIComponent(options.sandboxName)}`;
+            return (await this.rest.get(url)).data;
+        };
+
+        const cellcount = await this.getCellsetCellsCount(cellsetId, options.sandboxName);
+
+        if (cellcount === 0) {
+            return { '@odata.context': '', ID: '', Cells: [] };
+        }
+
+        const partitionSize = Math.ceil(cellcount / maxWorkers);
+        const results = await Promise.all(
+            Array.from({ length: maxWorkers }, (_, p) => fetchChunk(p, partitionSize))
+        );
+
+        const allCells = results.flatMap((r: any) => r.Cells || []);
+        const last = results[results.length - 1];
+        return {
+            '@odata.context': last['@odata.context'] ?? '',
+            ID: last.ID ?? '',
+            Cells: allCells,
+        };
+    }
+
+    /**
      * Extract cellset values only
      */
     public async extractCellsetValues(

--- a/src/services/CellService.ts
+++ b/src/services/CellService.ts
@@ -2041,44 +2041,60 @@ export class CellService {
     ): Promise<void> {
         // eslint-disable-next-line @typescript-eslint/no-var-requires
         const { chain } = require('stream-chain');
+        // stream-json v2: default export is the make() function that returns a Duplex stream
+        // (parser() returns a Flushable fn for stream-chain; make() returns a proper Duplex)
         // eslint-disable-next-line @typescript-eslint/no-var-requires
-        const { parser } = require('stream-json');
+        const make = require('stream-json');
 
         return new Promise<void>((resolve, reject) => {
             const pipeline = chain([
                 stream,
-                parser({ packKeys: true, packStrings: true, packNumbers: true }),
+                make({ packKeys: true, packStrings: true, packNumbers: true }),
             ]);
 
-            // Path tracking state
+            // Path tracking state — mirrors ijson prefix semantics
+            // Each entry in pushStack records how many path segments were pushed when
+            // entering the corresponding container, so we know how many to pop on exit.
             const pathStack: string[] = [];
             let lastKey: string | null = null;
-            const pathTypes: Array<'obj' | 'arr'> = [];
+            // pushStack[i]: number of segments pushed when opening the i-th container
+            const pushStack: number[] = [];
+            // currentContainerIsArray[i]: whether the i-th container is an array
+            const containerIsArray: boolean[] = [];
 
             pipeline.on('data', (token: { name: string; value?: any }) => {
                 switch (token.name) {
-                    case 'startObject':
-                        if (lastKey !== null) { pathStack.push(lastKey); lastKey = null; }
-                        else if (pathTypes[pathTypes.length - 1] === 'arr') { pathStack.push('item'); }
-                        pathTypes.push('obj');
+                    case 'startObject': {
+                        let pushed = 0;
+                        const parentIsArray = containerIsArray.length > 0
+                            && containerIsArray[containerIsArray.length - 1];
+                        if (lastKey !== null) {
+                            pathStack.push(lastKey); lastKey = null; pushed = 1;
+                        } else if (parentIsArray) {
+                            pathStack.push('item'); pushed = 1;
+                        }
+                        containerIsArray.push(false);
+                        pushStack.push(pushed);
                         break;
+                    }
 
-                    case 'startArray':
-                        if (lastKey !== null) { pathStack.push(lastKey); lastKey = null; }
-                        pathTypes.push('arr');
+                    case 'startArray': {
+                        let pushed = 0;
+                        if (lastKey !== null) {
+                            pathStack.push(lastKey); lastKey = null; pushed = 1;
+                        }
+                        containerIsArray.push(true);
+                        pushStack.push(pushed);
                         break;
+                    }
 
                     case 'endObject':
-                        pathTypes.pop();
-                        if (pathStack.length > 0 && pathStack[pathStack.length - 1] === 'item') {
-                            pathStack.pop();
-                        }
+                    case 'endArray': {
+                        containerIsArray.pop();
+                        const n = pushStack.pop() ?? 0;
+                        for (let i = 0; i < n; i++) pathStack.pop();
                         break;
-
-                    case 'endArray':
-                        pathTypes.pop();
-                        if (pathStack.length > 0) pathStack.pop();
-                        break;
+                    }
 
                     case 'keyValue':
                         lastKey = token.value;
@@ -2095,7 +2111,12 @@ export class CellService {
                         if (prefixesOfInterest.has(prefix)) {
                             const event = token.name === 'stringValue' ? 'string'
                                 : token.name === 'numberValue' ? 'number' : 'other';
-                            visit(prefix, event, token.value);
+                            // stream-json v2 emits numberValue.value as a string (accumulated chunks)
+                            // — parse to JS number so callers can do numeric comparisons
+                            const value = token.name === 'numberValue'
+                                ? parseFloat(token.value as string)
+                                : token.value;
+                            visit(prefix, event, value);
                         }
                         lastKey = null;
                         break;

--- a/src/services/CellService.ts
+++ b/src/services/CellService.ts
@@ -1376,14 +1376,21 @@ export class CellService {
      */
     public async getCellsetCellsCount(cellsetId: string, sandbox_name?: string): Promise<number> {
         // tm1py extract_cellset_cellcount uses add_url_parameters(url, **{"!sandbox": ...})
-        // (CellService.py:4308) which produces &!sandbox= (URL-encoded), not $sandbox.
+        // (CellService.py:4308) which produces &!sandbox= , and `value.replace("'", "''")`
+        // is the only escaping applied.
         let url = `/Cellsets('${cellsetId}')/Cells/$count`;
         if (sandbox_name) {
             // First query param on this URL — must use `?`, not `&`.
-            url += `?!sandbox=${encodeURIComponent(sandbox_name)}`;
+            url += `?!sandbox=${sandbox_name.replace(/'/g, "''")}`;
         }
         const response = await this.rest.get(url);
-        return response.data.value || response.data || 0;
+        // tm1py: return int(response.content) (CellService.py:4310). The OData
+        // /$count endpoint returns text/plain, which axios delivers as a string
+        // (or sometimes a parsed number). Coerce explicitly so downstream
+        // arithmetic doesn't silently produce NaN.
+        const raw = response.data?.value ?? response.data;
+        const n = Number(raw);
+        return Number.isFinite(n) ? n : 0;
     }
 
     /**
@@ -1432,7 +1439,12 @@ export class CellService {
             `Cube($select=Name;$expand=Dimensions($select=Name)),` +
             `Axes(${filterAxis}$expand=${expandHierarchies}Tuples($expand=Members(${selectMember}${expandElem})${topTuples})),` +
             `Cells($select=${cellProperties.join(',')}${topCells}${skipCells}${filterClause})`;
-        if (opts.sandboxName) url += `&!sandbox=${encodeURIComponent(opts.sandboxName)}`;
+        // tm1py add_url_parameters (Utils.py:1011-1030) only doubles single
+        // quotes; the HTTP layer handles any further encoding. encodeURIComponent
+        // would over-encode (%, &, +, ?) and produce a wire string that diverges
+        // from tm1py — TM1 rejects/misinterprets some payloads. Apply tm1py's
+        // exact escaping at all !sandbox sites in this PR.
+        if (opts.sandboxName) url += `&!sandbox=${opts.sandboxName.replace(/'/g, "''")}`;
         return url;
     }
 
@@ -1501,7 +1513,7 @@ export class CellService {
         const filterClause = filterCells ? ';$filter=' + filterCells : '';
 
         let url = `/Cellsets('${cellsetId}')?$expand=Cells($select=${cellProperties.join(',')}${topClause}${skipClause}${filterClause})`;
-        if (options.sandboxName) url += `&!sandbox=${encodeURIComponent(options.sandboxName)}`;
+        if (options.sandboxName) url += `&!sandbox=${options.sandboxName.replace(/'/g, "''")}`;
 
         return withCompactJson(this.rest, options.useCompactJson === true,
             async () => (await this.rest.get(url)).data, /* returnAsDict */ true);
@@ -1578,7 +1590,7 @@ export class CellService {
             `Cube($select=Name;$expand=Dimensions($select=Name)),` +
             `Axes(${filterAxis}$expand=${expandHierarchies}Tuples($expand=Members(${selectMember}${expandElem})${topTuples}))`;
 
-        if (options.sandboxName) url += `&!sandbox=${encodeURIComponent(options.sandboxName)}`;
+        if (options.sandboxName) url += `&!sandbox=${options.sandboxName.replace(/'/g, "''")}`;
 
         // tm1py extract_cellset_metadata_raw is @tidy_cellset (CellService.py:3789).
         // The function-level `delete_cellset=False` default lives in the inner
@@ -1675,7 +1687,7 @@ export class CellService {
             let url =
                 `/Cellsets('${cellsetId}')?$expand=` +
                 `Axes(${filterAxis}$expand=${expandHierarchies}Tuples($expand=Members(${selectMember}${expandElem})${partClause}))`;
-            if (options.sandboxName) url += `&!sandbox=${encodeURIComponent(options.sandboxName)}`;
+            if (options.sandboxName) url += `&!sandbox=${options.sandboxName.replace(/'/g, "''")}`;
             return (await this.rest.get(url)).data;
         };
 
@@ -1744,7 +1756,7 @@ export class CellService {
             const skipClause = skip ? ';$skip=' + skip : '';
             const filterClause = filterCells ? ';$filter=' + filterCells : '';
             let url = `/Cellsets('${cellsetId}')?$expand=Cells($select=${cellProperties.join(',')}${topClause}${skipClause}${filterClause})`;
-            if (options.sandboxName) url += `&!sandbox=${encodeURIComponent(options.sandboxName)}`;
+            if (options.sandboxName) url += `&!sandbox=${options.sandboxName.replace(/'/g, "''")}`;
             return (await this.rest.get(url)).data;
         };
 
@@ -1832,7 +1844,7 @@ export class CellService {
             let url =
                 `/Cellsets('${cellsetId}')?$expand=` +
                 `Cube($select=Name),Axes($expand=Hierarchies($select=UniqueName))`;
-            if (options.sandboxName) url += `&!sandbox=${encodeURIComponent(options.sandboxName)}`;
+            if (options.sandboxName) url += `&!sandbox=${options.sandboxName.replace(/'/g, "''")}`;
 
             const data = (await this.rest.get(url)).data;
             const cube: string = data.Cube.Name;

--- a/src/services/CellService.ts
+++ b/src/services/CellService.ts
@@ -1556,17 +1556,12 @@ export class CellService {
 
         if (options.sandboxName) url += `&!sandbox=${encodeURIComponent(options.sandboxName)}`;
 
-        const deleteCellset = options.deleteCellset === true;
-        const response = await (async () => {
-            try {
-                return (await this.rest.get(url)).data;
-            } finally {
-                if (deleteCellset) {
-                    await this._safeDeleteCellset(cellsetId, options.sandboxName);
-                }
-            }
-        })();
-        return response;
+        // tm1py decorates extract_cellset_metadata_raw with @tidy_cellset
+        // (CellService.py:3789-3790) — default delete_cellset=true.
+        const deleteCellset = options.deleteCellset !== false;
+        return withTidyCellset(this, cellsetId, async () => {
+            return (await this.rest.get(url)).data;
+        }, { delete_cellset: deleteCellset, sandbox_name: options.sandboxName });
     }
 
     /**
@@ -1598,7 +1593,8 @@ export class CellService {
         cellsetId: string,
         sandbox_name?: string
     ): Promise<number[]> {
-        const metadata = await this.extractCellsetMetadataRaw(cellsetId, { sandboxName: sandbox_name });
+        // tm1py extract_cellset_axes_cardinality has no @tidy_cellset (CellService.py:3969-3972).
+        const metadata = await this.extractCellsetMetadataRaw(cellsetId, { sandboxName: sandbox_name, deleteCellset: false });
 
         if (metadata.Axes) {
             return metadata.Axes.map((axis: any) => axis.Cardinality || 0);
@@ -1800,37 +1796,41 @@ export class CellService {
      */
     public async extractCellsetComposition(
         cellsetId: string,
-        options: { sandboxName?: string } = {}
+        options: { sandboxName?: string; deleteCellset?: boolean } = {}
     ): Promise<ExtractCellsetCompositionResult> {
-        let url =
-            `/Cellsets('${cellsetId}')?$expand=` +
-            `Cube($select=Name),Axes($expand=Hierarchies($select=UniqueName))`;
-        if (options.sandboxName) url += `&!sandbox=${encodeURIComponent(options.sandboxName)}`;
+        // tm1py decorates this with @tidy_cellset (CellService.py:4263) — default cleanup on.
+        const deleteCellset = options.deleteCellset !== false;
+        return withTidyCellset(this, cellsetId, async () => {
+            let url =
+                `/Cellsets('${cellsetId}')?$expand=` +
+                `Cube($select=Name),Axes($expand=Hierarchies($select=UniqueName))`;
+            if (options.sandboxName) url += `&!sandbox=${encodeURIComponent(options.sandboxName)}`;
 
-        const data = (await this.rest.get(url)).data;
-        const cube: string = data.Cube.Name;
+            const data = (await this.rest.get(url)).data;
+            const cube: string = data.Cube.Name;
 
-        const rows: string[] = [];
-        const titles: string[] = [];
-        const columns: string[] = [];
+            const rows: string[] = [];
+            const titles: string[] = [];
+            const columns: string[] = [];
 
-        if (data.Axes.length === 1) {
-            if (data.Axes[0].Hierarchies) {
-                columns.push(...data.Axes[0].Hierarchies.map((h: any) => h.UniqueName));
+            if (data.Axes.length === 1) {
+                if (data.Axes[0].Hierarchies) {
+                    columns.push(...data.Axes[0].Hierarchies.map((h: any) => h.UniqueName));
+                }
+            } else {
+                if (data.Axes[0].Hierarchies) {
+                    columns.push(...data.Axes[0].Hierarchies.map((h: any) => h.UniqueName));
+                }
+                if (data.Axes[1].Hierarchies) {
+                    rows.push(...data.Axes[1].Hierarchies.map((h: any) => h.UniqueName));
+                }
             }
-        } else {
-            if (data.Axes[0].Hierarchies) {
-                columns.push(...data.Axes[0].Hierarchies.map((h: any) => h.UniqueName));
+            if (data.Axes.length > 2) {
+                titles.push(...data.Axes[2].Hierarchies.map((h: any) => h.UniqueName));
             }
-            if (data.Axes[1].Hierarchies) {
-                rows.push(...data.Axes[1].Hierarchies.map((h: any) => h.UniqueName));
-            }
-        }
-        if (data.Axes.length > 2) {
-            titles.push(...data.Axes[2].Hierarchies.map((h: any) => h.UniqueName));
-        }
 
-        return { cube, titles, rows, columns };
+            return { cube, titles, rows, columns };
+        }, { delete_cellset: deleteCellset, sandbox_name: options.sandboxName });
     }
 
     /**
@@ -1863,7 +1863,7 @@ export class CellService {
         const deleteCellset = options.deleteCellset !== false;
 
         const { rows, columns } = await this.extractCellsetComposition(
-            cellsetId, { sandboxName: options.sandboxName }
+            cellsetId, { sandboxName: options.sandboxName, deleteCellset: false }
         );
 
         const rawCellset = await this.extractCellsetRaw(cellsetId, {
@@ -1911,7 +1911,7 @@ export class CellService {
         const lineterminator = options.csvDialect?.lineterminator ?? lineSeparator;
 
         const { cube, rows, columns } = await this.extractCellsetComposition(
-            cellsetId, { sandboxName: options.sandboxName }
+            cellsetId, { sandboxName: options.sandboxName, deleteCellset: false }
         );
 
         const rawResponse = await this.extractCellsetRawResponse(cellsetId, {

--- a/src/services/CellService.ts
+++ b/src/services/CellService.ts
@@ -1418,6 +1418,86 @@ export class CellService {
     }
 
     /**
+     * Extract cellset cells without axes metadata.
+     * Mirrors tm1py's `extract_cellset_cells_raw` (CellService.py:3914-3967).
+     * @see extractCellsetCellsRaw — full implementation added in Step 5.
+     */
+    public async extractCellsetCellsRaw(
+        cellsetId: string,
+        options: {
+            cellProperties?: string[];
+            top?: number; skip?: number;
+            skipZeros?: boolean;
+            skipConsolidatedCells?: boolean;
+            skipRuleDerivedCells?: boolean;
+            sandboxName?: string;
+            useCompactJson?: boolean;
+        } = {}
+    ): Promise<{ Cells: any[]; '@odata.context'?: string; ID?: string }> {
+        // Full implementation in Step 5 — this stub satisfies the forward reference.
+        const cellProperties = [...(options.cellProperties ?? ['Value'])];
+        if (options.skipRuleDerivedCells) { cellProperties.push('RuleDerived'); cellProperties.push('Updateable'); }
+        if (options.skipConsolidatedCells) cellProperties.push('Consolidated');
+        if ((options.skip || options.skipZeros || options.skipRuleDerivedCells || options.skipConsolidatedCells)
+                && !cellProperties.includes('Ordinal')) cellProperties.push('Ordinal');
+        const filters: string[] = [];
+        if (options.skipZeros) filters.push("Value ne 0 and Value ne null and Value ne ''");
+        if (options.skipConsolidatedCells) filters.push('Consolidated eq false');
+        if (options.skipRuleDerivedCells) filters.push('RuleDerived eq false');
+        const filterCells = filters.join(' and ');
+        const topClause = options.top ? ';$top=' + options.top : '';
+        const skipClause = options.skip ? ';$skip=' + options.skip : '';
+        const filterClause = filterCells ? ';$filter=' + filterCells : '';
+        let url = `/Cellsets('${cellsetId}')?$expand=Cells($select=${cellProperties.join(',')}${topClause}${skipClause}${filterClause})`;
+        if (options.sandboxName) url += `&!sandbox=${encodeURIComponent(options.sandboxName)}`;
+        return withCompactJson(this.rest, options.useCompactJson === true,
+            async () => (await this.rest.get(url)).data, true);
+    }
+
+    /**
+     * Extract full cellset data and return raw dict.
+     * Mirrors tm1py's `extract_cellset_raw` (CellService.py:3708-3787).
+     * Cleans up cellset by default (deleteCellset=true).
+     */
+    public async extractCellsetRaw(
+        cellsetId: string,
+        options: ExtractCellsetRawOptions = {}
+    ): Promise<RawCellsetDict> {
+        const useCompactJson = options.useCompactJson === true;
+        const deleteCellset = options.deleteCellset !== false;
+
+        return withTidyCellset(this, cellsetId, async () => {
+            if (!useCompactJson) {
+                const url = this._buildCellsetRawUrl(cellsetId, options);
+                return (await this.rest.get(url)).data as RawCellsetDict;
+            }
+
+            // Compact-JSON path: tm1py CellService.py:3762-3787
+            const metadata = await this.extractCellsetMetadataRaw(cellsetId, {
+                elemProperties: options.elemProperties,
+                memberProperties: options.memberProperties,
+                top: options.top,
+                skip: options.skip,
+                skipContexts: options.skipContexts,
+                includeHierarchies: options.includeHierarchies,
+                sandboxName: options.sandboxName,
+                deleteCellset: false,
+            });
+            const cells = await this.extractCellsetCellsRaw(cellsetId, {
+                cellProperties: options.cellProperties,
+                top: options.top,
+                skip: options.skip,
+                skipZeros: options.skipZeros,
+                skipConsolidatedCells: options.skipConsolidatedCells,
+                skipRuleDerivedCells: options.skipRuleDerivedCells,
+                sandboxName: options.sandboxName,
+                useCompactJson: true,
+            });
+            return { ...metadata, ...cells } as RawCellsetDict;
+        }, { delete_cellset: deleteCellset, sandbox_name: options.sandboxName });
+    }
+
+    /**
      * Extract cellset metadata (Cube + Axes) without cells.
      * Mirrors tm1py's `extract_cellset_metadata_raw` (CellService.py:3789-3843).
      */

--- a/src/services/CellService.ts
+++ b/src/services/CellService.ts
@@ -19,6 +19,7 @@ import {
     RawCellsetDict,
     buildContentFromCellsetDict,
     buildCsvFromCellsetDict,
+    csvRowToString,
     dimensionNamesFromElementUniqueNames,
     CsvDialect,
 } from '../utils/Utils';
@@ -1433,7 +1434,7 @@ export class CellService {
         options: ExtractCellsetRawOptions = {}
     ): Promise<any> {
         const url = this._buildCellsetRawUrl(cellsetId, options);
-        return this.rest.get(url, { responseType: 'stream' as any });
+        return this.rest.get(url, { responseType: 'stream' });
     }
 
     /**
@@ -1976,7 +1977,7 @@ export class CellService {
                 }
                 if (row.length > maxEntriesPerRow) maxEntriesPerRow = row.length;
                 if (row.length < leastEntriesPerRow) leastEntriesPerRow = row.length;
-                csvBodyLines.push(this._csvRow(row, delimiter, lineterminator));
+                csvBodyLines.push(csvRowToString(row, delimiter, lineterminator));
 
             } else if (prefix === 'Axes.item.Tuples.item.Members.item.Name' && event === 'string') {
                 // tm1py CellService.py:4501-4505
@@ -2025,7 +2026,7 @@ export class CellService {
         }
 
         // tm1py CellService.py:4551-4556 — header + body
-        const headerLine = this._csvRow([...rowHeaders, ...columnHeaders, 'Value'], delimiter, lineterminator);
+        const headerLine = csvRowToString([...rowHeaders, ...columnHeaders, 'Value'], delimiter, lineterminator);
         return headerLine + csvBodyLines.join('').replace(/\s+$/, '');
     }
 
@@ -2125,23 +2126,17 @@ export class CellService {
             });
 
             pipeline.on('end', () => resolve());
-            pipeline.on('error', (err: Error) => reject(err));
+            pipeline.on('error', (err: Error) => {
+                // Ensure the upstream HTTP response stream is released so the socket
+                // doesn't stay buffered when parsing fails mid-document.
+                if (typeof (stream as any).destroy === 'function') {
+                    try { (stream as any).destroy(); } catch { /* already torn down */ }
+                }
+                reject(err);
+            });
         });
     }
 
-    /**
-     * Format a CSV row from string values using Excel-dialect escaping rules.
-     * Wraps values in quotes when they contain the delimiter, line terminator, or `"`.
-     */
-    private _csvRow(values: string[], delimiter: string, lineterminator: string): string {
-        const escape = (v: string): string => {
-            if (v.includes(delimiter) || v.includes(lineterminator) || v.includes('"')) {
-                return '"' + v.replace(/"/g, '""') + '"';
-            }
-            return v;
-        };
-        return values.map(escape).join(delimiter) + lineterminator;
-    }
 
     /**
      * Get element attributes by dimension for a cube.

--- a/src/services/CellService.ts
+++ b/src/services/CellService.ts
@@ -56,6 +56,13 @@ export interface ExtractCellsetRawOptions {
     includeHierarchies?: boolean;
     useCompactJson?: boolean;
     deleteCellset?: boolean;          // default true (tidy)
+    /**
+     * Only meaningful for `extractCellsetRawResponse`. When true, the underlying
+     * Axios GET uses `responseType: 'stream'` so callers can iterate the raw
+     * bytes (used by `extractCellsetCsvIterJson`). Default false — matches
+     * tm1py's `extract_cellset_raw_response` which returns a buffered Response.
+     */
+    asStream?: boolean;
 }
 
 export interface ExtractCellsetCsvOptions {
@@ -1430,15 +1437,23 @@ export class CellService {
     }
 
     /**
-     * Extract cellset raw response as an Axios response with stream body.
-     * Mirrors tm1py's `extract_cellset_raw_response` (CellService.py:3610-3706).
+     * Extract cellset raw response as an Axios response.
+     * Mirrors tm1py's `extract_cellset_raw_response` (CellService.py:3610-3706),
+     * which returns a buffered Response by default — callers like
+     * `extract_cellset_raw` then call `.json()`. Streaming is opt-in.
+     *
+     * Pass `asStream: true` to receive a `responseType: 'stream'` body for
+     * incremental iteration (used by `extractCellsetCsvIterJson`).
      */
     public async extractCellsetRawResponse(
         cellsetId: string,
         options: ExtractCellsetRawOptions = {}
     ): Promise<any> {
         const url = this._buildCellsetRawUrl(cellsetId, options);
-        return this.rest.get(url, { responseType: 'stream' });
+        if (options.asStream === true) {
+            return this.rest.get(url, { responseType: 'stream' });
+        }
+        return this.rest.get(url);
     }
 
     /**
@@ -1938,6 +1953,7 @@ export class CellService {
             sandboxName: options.sandboxName,
             memberProperties: includeAttributes ? ['Name', 'Attributes'] : ['Name'],
             deleteCellset: false,
+            asStream: true,
         });
 
         const rowHeaders = options.mdxHeaders ? [...rows] : [...dimensionNamesFromElementUniqueNames(rows)];

--- a/src/services/CellService.ts
+++ b/src/services/CellService.ts
@@ -1845,37 +1845,51 @@ export class CellService {
     }
 
     /**
-     * Extract cellset as CSV format — REPLACED in Step 9.
-     * This interim version uses extractCellsetRaw.
+     * Execute cellset and return only the content, in CSV format.
+     * Mirrors tm1py's `extract_cellset_csv` (CellService.py:4312-4383).
+     * Uses CLIENT-SIDE conversion via buildCsvFromCellsetDict — no use_blob.
+     *
+     * BREAKING CHANGE from v2.1: was `(cellsetId, sandbox_name?, includeHeaders?)`.
+     * Now takes an options object with full tm1py parameter set.
+     * Migration: `extractCellsetCsv(id, 'sb', false)` →
+     *   `extractCellsetCsv(id, { sandboxName: 'sb', includeHeaders: false })`.
      */
     public async extractCellsetCsv(
         cellsetId: string,
-        sandbox_name?: string,
-        includeHeaders: boolean = true
+        options: ExtractCellsetCsvOptions = {}
     ): Promise<string> {
-        const cellset = await this.extractCellsetRaw(cellsetId, { sandboxName: sandbox_name });
-        const dataframe = this.buildDataFrameFromCellset(cellset);
+        const skipZeros = options.skipZeros !== false;  // default true (tm1py parity)
+        const includeHeaders = options.includeHeaders !== false;
+        const deleteCellset = options.deleteCellset !== false;
 
-        const rows: string[] = [];
+        const { rows, columns } = await this.extractCellsetComposition(
+            cellsetId, { sandboxName: options.sandboxName }
+        );
 
-        // Add headers if requested
-        if (includeHeaders) {
-            rows.push(dataframe.columns.map(col => `"${col}"`).join(','));
-        }
+        const rawCellset = await this.extractCellsetRaw(cellsetId, {
+            cellProperties: ['Value'],
+            elemProperties: ['Name'],
+            memberProperties: options.includeAttributes ? ['Name', 'Attributes'] : undefined,
+            top: options.top,
+            skip: options.skip,
+            skipContexts: true,
+            skipZeros,
+            skipConsolidatedCells: options.skipConsolidatedCells,
+            skipRuleDerivedCells: options.skipRuleDerivedCells,
+            sandboxName: options.sandboxName,
+            useCompactJson: options.useCompactJson,
+            deleteCellset,
+        });
 
-        // Add data rows
-        for (const row of dataframe.data) {
-            const csvRow = row.map(cell => {
-                if (cell === null || cell === undefined) return '';
-                if (typeof cell === 'string' && (cell.includes(',') || cell.includes('"'))) {
-                    return `"${cell.replace(/"/g, '""')}"`;
-                }
-                return String(cell);
-            }).join(',');
-            rows.push(csvRow);
-        }
-
-        return rows.join('\n');
+        return buildCsvFromCellsetDict(rows, columns, rawCellset, {
+            top: options.top,
+            csvDialect: options.csvDialect,
+            lineSeparator: options.lineSeparator,
+            valueSeparator: options.valueSeparator,
+            includeAttributes: options.includeAttributes,
+            includeHeaders,
+            mdxHeaders: options.mdxHeaders,
+        });
     }
 
     /**

--- a/src/services/CellService.ts
+++ b/src/services/CellService.ts
@@ -2171,7 +2171,8 @@ export class CellService {
     private async _getAttributesByDimension(cubeName: string): Promise<Record<string, string[]>> {
         // tm1py _get_attributes_by_dimension (CellService.py:5123-5134) calls
         // get_dimension_names_for_writing(cube) — which excludes the sandbox
-        // dim and other control dims — and element_service.get_element_attribute_names.
+        // dim and other control dims — and element_service.get_element_attribute_names
+        // (the lighter `?$select=Name` form, not the full attribute objects).
         // Exceptions propagate; do NOT swallow them here.
         // eslint-disable-next-line @typescript-eslint/no-var-requires
         const { ElementService } = require('./ElementService');
@@ -2179,11 +2180,10 @@ export class CellService {
         const dimensions = await this.getDimensionNamesForWriting(cubeName);
         const result: Record<string, string[]> = {};
         for (const dim of dimensions) {
-            // Skip TM1 control dimensions (names starting with `}`) — tm1py's
-            // get_dimension_names_for_writing already excludes them.
+            // Defensive: getDimensionNamesForWriting should already exclude
+            // `}`-prefixed control dims, but skip if any leak through.
             if (dim.startsWith('}')) continue;
-            const attrs = await elementService.getElementAttributes(dim, dim);
-            result[dim] = (attrs || []).map((a: any) => a.Name ?? a.name ?? String(a));
+            result[dim] = await elementService.getElementAttributeNames(dim, dim);
         }
         return result;
     }

--- a/src/services/CellService.ts
+++ b/src/services/CellService.ts
@@ -13,7 +13,103 @@ import { OperationStatus, OperationType } from './AsyncOperationService';
 import { MDXView } from '../objects/MDXView';
 import { Process } from '../objects/Process';
 import { TM1Exception } from '../exceptions/TM1Exception';
-import { formatUrl, escapeODataValue, lowerAndDropSpaces, extractCompactJsonCellset, resemblesMdx, getCube } from '../utils/Utils';
+import {
+    formatUrl, escapeODataValue, lowerAndDropSpaces, extractCompactJsonCellset, resemblesMdx, getCube,
+    CaseAndSpaceInsensitiveTuplesDict,
+    RawCellsetDict,
+    buildContentFromCellsetDict,
+    buildCsvFromCellsetDict,
+    dimensionNamesFromElementUniqueNames,
+    CsvDialect,
+} from '../utils/Utils';
+
+// ─── Public interface types for CellService extract methods ───────────────
+
+export interface ExtractCellsetOptions {
+    cellProperties?: string[];
+    top?: number;
+    skip?: number;
+    deleteCellset?: boolean;          // default true
+    skipContexts?: boolean;
+    skipZeros?: boolean;
+    skipConsolidatedCells?: boolean;
+    skipRuleDerivedCells?: boolean;
+    sandboxName?: string;
+    elementUniqueNames?: boolean;     // default true
+    skipCellProperties?: boolean;
+    useCompactJson?: boolean;
+    skipSandboxDimension?: boolean;
+}
+
+export interface ExtractCellsetRawOptions {
+    cellProperties?: string[];
+    elemProperties?: string[];
+    memberProperties?: string[];
+    top?: number;
+    skip?: number;
+    skipContexts?: boolean;
+    skipZeros?: boolean;
+    skipConsolidatedCells?: boolean;
+    skipRuleDerivedCells?: boolean;
+    sandboxName?: string;
+    includeHierarchies?: boolean;
+    useCompactJson?: boolean;
+    deleteCellset?: boolean;          // default true (tidy)
+}
+
+export interface ExtractCellsetCsvOptions {
+    top?: number;
+    skip?: number;
+    skipZeros?: boolean;              // default true (matches tm1py)
+    skipConsolidatedCells?: boolean;
+    skipRuleDerivedCells?: boolean;
+    csvDialect?: CsvDialect;
+    lineSeparator?: string;           // default '\r\n'
+    valueSeparator?: string;          // default ','
+    sandboxName?: string;
+    includeAttributes?: boolean;
+    useCompactJson?: boolean;
+    includeHeaders?: boolean;         // default true
+    mdxHeaders?: boolean;
+    deleteCellset?: boolean;          // default true
+}
+
+export interface ExtractCellsetAxesRawAsyncOptions {
+    asyncAxis?: number;               // default 1
+    maxWorkers?: number;              // default 8
+    elemProperties?: string[];
+    memberProperties?: string[];
+    skipContexts?: boolean;
+    includeHierarchies?: boolean;
+    sandboxName?: string;
+}
+
+export interface ExtractCellsetCellsRawAsyncOptions {
+    maxWorkers?: number;              // default 8
+    cellProperties?: string[];
+    skipZeros?: boolean;
+    skipConsolidatedCells?: boolean;
+    skipRuleDerivedCells?: boolean;
+    sandboxName?: string;
+}
+
+export interface ExtractCellsetCompositionResult {
+    cube: string;
+    titles: string[];
+    rows: string[];
+    columns: string[];
+}
+
+export interface ExtractCellsetMetadataRawOptions {
+    elemProperties?: string[];
+    memberProperties?: string[];
+    top?: number;
+    skip?: number;
+    skipContexts?: boolean;
+    includeHierarchies?: boolean;
+    sandboxName?: string;
+    deleteCellset?: boolean;
+}
 
 export interface CellsetDict {
     [coordinates: string]: string | number | boolean | null | undefined;
@@ -1263,37 +1359,102 @@ export class CellService {
     }
 
     /**
-     * Extract cellset raw response
+     * Build the full OData URL for a cellset GET.
+     * Mirrors tm1py's `extract_cellset_raw_response` URL builder (CellService.py:3636-3704).
      */
-    public async extractCellsetRawResponse(
-        cellsetId: string,
-        sandbox_name?: string
-    ): Promise<Response> {
-        let url = `/Cellsets('${cellsetId}')/?$expand=Axes,Cells`;
-
-        if (sandbox_name) {
-            url += `&$sandbox=${sandbox_name}`;
+    private _buildCellsetRawUrl(cellsetId: string, opts: ExtractCellsetRawOptions): string {
+        const cellProperties = [...(opts.cellProperties ?? ['Value'])];
+        if (opts.skipRuleDerivedCells) {
+            cellProperties.push('RuleDerived');
+            cellProperties.push('Updateable');
+        }
+        if (opts.skipConsolidatedCells) cellProperties.push('Consolidated');
+        if ((opts.skip || opts.skipZeros || opts.skipRuleDerivedCells || opts.skipConsolidatedCells)
+                && !cellProperties.includes('Ordinal')) {
+            cellProperties.push('Ordinal');
         }
 
-        const response = await this.rest.get(url, { responseType: 'stream' });
-        return response.data;
+        const memberProps = (opts.memberProperties && opts.memberProperties.length > 0)
+            ? opts.memberProperties : ['Name'];
+        const selectMember = '$select=' + memberProps.join(',');
+        const expandElem = (opts.elemProperties && opts.elemProperties.length > 0)
+            ? ';$expand=Element($select=' + opts.elemProperties.join(',') + ')' : '';
+
+        const filterAxis = opts.skipContexts ? '$filter=Ordinal ne 2;' : '';
+
+        const filters: string[] = [];
+        if (opts.skipZeros) filters.push("Value ne 0 and Value ne null and Value ne ''");
+        if (opts.skipConsolidatedCells) filters.push('Consolidated eq false');
+        if (opts.skipRuleDerivedCells) filters.push('RuleDerived eq false');
+        const filterCells = filters.join(' and ');
+
+        const expandHierarchies = opts.includeHierarchies
+            ? 'Hierarchies($select=Name;$expand=Dimension($select=Name)),' : '';
+
+        const topTuples = (opts.top && !opts.skip) ? ';$top=' + opts.top : '';
+        const topCells = opts.top ? ';$top=' + opts.top : '';
+        const skipCells = opts.skip ? ';$skip=' + opts.skip : '';
+        const filterClause = filterCells ? ';$filter=' + filterCells : '';
+
+        let url =
+            `/Cellsets('${cellsetId}')?$expand=` +
+            `Cube($select=Name;$expand=Dimensions($select=Name)),` +
+            `Axes(${filterAxis}$expand=${expandHierarchies}Tuples($expand=Members(${selectMember}${expandElem})${topTuples})),` +
+            `Cells($select=${cellProperties.join(',')}${topCells}${skipCells}${filterClause})`;
+        if (opts.sandboxName) url += `&!sandbox=${encodeURIComponent(opts.sandboxName)}`;
+        return url;
     }
 
     /**
-     * Extract cellset metadata raw
+     * Extract cellset raw response as an Axios response with stream body.
+     * Mirrors tm1py's `extract_cellset_raw_response` (CellService.py:3610-3706).
+     */
+    public async extractCellsetRawResponse(
+        cellsetId: string,
+        options: ExtractCellsetRawOptions = {}
+    ): Promise<any> {
+        const url = this._buildCellsetRawUrl(cellsetId, options);
+        return this.rest.get(url, { responseType: 'stream' as any });
+    }
+
+    /**
+     * Extract cellset metadata (Cube + Axes) without cells.
+     * Mirrors tm1py's `extract_cellset_metadata_raw` (CellService.py:3789-3843).
      */
     public async extractCellsetMetadataRaw(
         cellsetId: string,
-        sandbox_name?: string
+        options: ExtractCellsetMetadataRawOptions = {}
     ): Promise<any> {
-        let url = `/Cellsets('${cellsetId}')?$expand=Axes`;
+        const memberProps = (options.memberProperties && options.memberProperties.length > 0)
+            ? options.memberProperties : ['Name'];
+        const selectMember = '$select=' + memberProps.join(',');
+        const expandElem = (options.elemProperties && options.elemProperties.length > 0)
+            ? ';$expand=Element($select=' + options.elemProperties.join(',') + ')' : '';
 
-        if (sandbox_name) {
-            url += `&$sandbox=${sandbox_name}`;
-        }
+        const expandHierarchies = options.includeHierarchies
+            ? 'Hierarchies($select=Name;$expand=Dimension($select=Name)),' : '';
 
-        const response = await this.rest.get(url);
-        return response.data;
+        const filterAxis = options.skipContexts ? '$filter=Ordinal ne 2;' : '';
+        const topTuples = (options.top && !options.skip) ? ';$top=' + options.top : '';
+
+        let url =
+            `/Cellsets('${cellsetId}')?$expand=` +
+            `Cube($select=Name;$expand=Dimensions($select=Name)),` +
+            `Axes(${filterAxis}$expand=${expandHierarchies}Tuples($expand=Members(${selectMember}${expandElem})${topTuples}))`;
+
+        if (options.sandboxName) url += `&!sandbox=${encodeURIComponent(options.sandboxName)}`;
+
+        const deleteCellset = options.deleteCellset === true;
+        const response = await (async () => {
+            try {
+                return (await this.rest.get(url)).data;
+            } finally {
+                if (deleteCellset) {
+                    await this._safeDeleteCellset(cellsetId, options.sandboxName);
+                }
+            }
+        })();
+        return response;
     }
 
     /**
@@ -1325,7 +1486,7 @@ export class CellService {
         cellsetId: string,
         sandbox_name?: string
     ): Promise<number[]> {
-        const metadata = await this.extractCellsetMetadataRaw(cellsetId, sandbox_name);
+        const metadata = await this.extractCellsetMetadataRaw(cellsetId, { sandboxName: sandbox_name });
 
         if (metadata.Axes) {
             return metadata.Axes.map((axis: any) => axis.Cardinality || 0);
@@ -1382,12 +1543,13 @@ export class CellService {
 
     /**
      * Extract cellset composition (cube, dimensions)
+     * @deprecated Replaced by new extractCellsetComposition with options object in Step 8
      */
-    public async extractCellsetComposition(
+    private async _extractCellsetCompositionOld(
         cellsetId: string,
         sandbox_name?: string
     ): Promise<{ cube: string; dimensions: string[] }> {
-        const metadata = await this.extractCellsetMetadataRaw(cellsetId, sandbox_name);
+        const metadata = await this.extractCellsetMetadataRaw(cellsetId, { sandboxName: sandbox_name });
 
         let cube = '';
         const dimensions: string[] = [];

--- a/src/services/CellService.ts
+++ b/src/services/CellService.ts
@@ -606,25 +606,44 @@ export class CellService {
     }
 
     /**
-     * Extract data from cellset
+     * Execute cellset and return cells with their properties as a
+     * CaseAndSpaceInsensitiveTuplesDict. Mirrors tm1py's `extract_cellset`
+     * (CellService.py:4827-4890).
+     *
+     * BREAKING CHANGE from v2.1: was `(cellsetId, expand_axes, sandbox_name)` returning
+     * raw JSON. Now takes options object and returns CaseAndSpaceInsensitiveTuplesDict.
+     * Migration: `extractCellset(id, true, 'sb')` → `extractCellset(id, { sandboxName: 'sb' })`.
      */
     public async extractCellset(
-        cellsetId: string, 
-        expand_axes: boolean = true,
-        sandbox_name?: string
-    ): Promise<any> {
-        let url = `/Cellsets('${cellsetId}')`;
-        
-        const params = new URLSearchParams();
-        if (expand_axes) params.append('$expand', 'Axes,Cells');
-        if (sandbox_name) params.append('$sandbox', sandbox_name);
+        cellsetId: string,
+        options: ExtractCellsetOptions = {}
+    ): Promise<CaseAndSpaceInsensitiveTuplesDict<any>> {
+        const cellProperties = (options.cellProperties && options.cellProperties.length > 0)
+            ? options.cellProperties : ['Value'];
 
-        if (params.toString()) {
-            url += `?${params.toString()}`;
-        }
+        const rawCellset = await this.extractCellsetRaw(cellsetId, {
+            cellProperties,
+            elemProperties: ['UniqueName'],
+            memberProperties: ['UniqueName'],
+            top: options.top,
+            skip: options.skip,
+            skipContexts: options.skipContexts,
+            deleteCellset: options.deleteCellset !== false,
+            skipZeros: options.skipZeros,
+            skipConsolidatedCells: options.skipConsolidatedCells,
+            skipRuleDerivedCells: options.skipRuleDerivedCells,
+            sandboxName: options.sandboxName,
+            includeHierarchies: false,
+            useCompactJson: options.useCompactJson,
+        });
 
-        const response = await this.rest.get(url);
-        return response.data;
+        return buildContentFromCellsetDict(
+            rawCellset,
+            options.top ?? null,
+            options.elementUniqueNames !== false,
+            options.skipCellProperties === true,
+            options.skipSandboxDimension === true
+        );
     }
 
     /**
@@ -1599,7 +1618,7 @@ export class CellService {
         cellsetId: string,
         sandbox_name?: string
     ): Promise<{ rows: any[][], values: any[] }> {
-        const cellset = await this.extractCellset(cellsetId, true, sandbox_name);
+        const cellset = await this.extractCellsetRaw(cellsetId, { sandboxName: sandbox_name });
 
         const rows: any[][] = [];
         const values: any[] = [];
@@ -1664,19 +1683,20 @@ export class CellService {
         cellsetId: string,
         sandbox_name?: string
     ): Promise<DataFrame> {
-        const cellset = await this.extractCellset(cellsetId, true, sandbox_name);
+        const cellset = await this.extractCellsetRaw(cellsetId, { sandboxName: sandbox_name });
         return this.buildDataFrameFromCellset(cellset);
     }
 
     /**
-     * Extract cellset as CSV format
+     * Extract cellset as CSV format — REPLACED in Step 9.
+     * This interim version uses extractCellsetRaw.
      */
     public async extractCellsetCsv(
         cellsetId: string,
         sandbox_name?: string,
         includeHeaders: boolean = true
     ): Promise<string> {
-        const cellset = await this.extractCellset(cellsetId, true, sandbox_name);
+        const cellset = await this.extractCellsetRaw(cellsetId, { sandboxName: sandbox_name });
         const dataframe = this.buildDataFrameFromCellset(cellset);
 
         const rows: string[] = [];
@@ -1725,7 +1745,7 @@ export class CellService {
         cellsetId: string,
         sandbox_name?: string
     ): Promise<DataFrame> {
-        const cellset = await this.extractCellset(cellsetId, true, sandbox_name);
+        const cellset = await this.extractCellsetRaw(cellsetId, { sandboxName: sandbox_name });
         return this.buildPivotDataFrameFromCellset(cellset);
     }
 
@@ -1755,7 +1775,7 @@ export class CellService {
          */
 
         // Get cellset metadata first
-        const cellset = await this.extractCellset(cellsetId, false, sandbox_name);
+        const cellset = await this.extractCellsetRaw(cellsetId, { sandboxName: sandbox_name, deleteCellset: false });
         const cellCount = cellset.Cells?.length || 0;
 
         // For small cellsets, use synchronous method

--- a/src/services/CellService.ts
+++ b/src/services/CellService.ts
@@ -1368,12 +1368,12 @@ export class CellService {
      * Get cellset cells count
      */
     public async getCellsetCellsCount(cellsetId: string, sandbox_name?: string): Promise<number> {
+        // tm1py extract_cellset_cellcount uses add_url_parameters(url, **{"!sandbox": ...})
+        // (CellService.py:4308) which produces &!sandbox= (URL-encoded), not $sandbox.
         let url = `/Cellsets('${cellsetId}')/Cells/$count`;
-
         if (sandbox_name) {
-            url += `?$sandbox=${sandbox_name}`;
+            url += `&!sandbox=${encodeURIComponent(sandbox_name)}`;
         }
-
         const response = await this.rest.get(url);
         return response.data.value || response.data || 0;
     }
@@ -1496,6 +1496,9 @@ export class CellService {
         options: ExtractCellsetRawOptions = {}
     ): Promise<RawCellsetDict> {
         const useCompactJson = options.useCompactJson === true;
+        // tm1py extract_cellset_raw is @tidy_cellset (CellService.py:3708). The
+        // wrapper's `kwargs.get("delete_cellset", True)` defaults to True when
+        // no kwarg is passed — function-signature defaults don't reach **kwargs.
         const deleteCellset = options.deleteCellset !== false;
 
         return withTidyCellset(this, cellsetId, async () => {
@@ -1556,8 +1559,10 @@ export class CellService {
 
         if (options.sandboxName) url += `&!sandbox=${encodeURIComponent(options.sandboxName)}`;
 
-        // tm1py decorates extract_cellset_metadata_raw with @tidy_cellset
-        // (CellService.py:3789-3790) — default delete_cellset=true.
+        // tm1py extract_cellset_metadata_raw is @tidy_cellset (CellService.py:3789).
+        // The function-level `delete_cellset=False` default lives in the inner
+        // function and never reaches the wrapper's **kwargs, so an unforwarded
+        // call still deletes (kwargs.get("delete_cellset", True) → True).
         const deleteCellset = options.deleteCellset !== false;
         return withTidyCellset(this, cellsetId, async () => {
             return (await this.rest.get(url)).data;
@@ -2120,7 +2125,19 @@ export class CellService {
                             const value = token.name === 'numberValue'
                                 ? parseFloat(token.value as string)
                                 : token.value;
-                            visit(prefix, event, value);
+                            // Synchronous visitor exceptions (e.g. ZeroDivisionError-style
+                            // throws inside the cells handler) must reject the outer Promise;
+                            // EventEmitter listener throws don't propagate naturally.
+                            try {
+                                visit(prefix, event, value);
+                            } catch (err) {
+                                if (typeof (stream as any).destroy === 'function') {
+                                    try { (stream as any).destroy(); } catch { /* already torn down */ }
+                                }
+                                pipeline.destroy();
+                                reject(err as Error);
+                                return;
+                            }
                         }
                         lastKey = null;
                         break;
@@ -2147,27 +2164,23 @@ export class CellService {
      * Mirrors tm1py's `_get_attributes_by_dimension` (CellService.py:~4573).
      */
     private async _getAttributesByDimension(cubeName: string): Promise<Record<string, string[]>> {
-        try {
-            // Import ElementService lazily to avoid circular dependency
-            // eslint-disable-next-line @typescript-eslint/no-var-requires
-            const { ElementService } = require('./ElementService');
-            const elementService = new ElementService(this.rest);
-            const url = `/Cubes('${encodeURIComponent(cubeName)}')?$expand=Dimensions($select=Name)`;
-            const resp = await this.rest.get(url);
-            const dimensions: string[] = (resp.data?.Dimensions || []).map((d: any) => d.Name);
-            const result: Record<string, string[]> = {};
-            for (const dim of dimensions) {
-                try {
-                    const attrs = await elementService.getElementAttributes(dim, dim);
-                    result[dim] = (attrs || []).map((a: any) => a.Name ?? a.name ?? String(a));
-                } catch {
-                    result[dim] = [];
-                }
-            }
-            return result;
-        } catch {
-            return {};
+        // tm1py _get_attributes_by_dimension (CellService.py:5123-5134) calls
+        // get_dimension_names_for_writing(cube) — which excludes the sandbox
+        // dim and other control dims — and element_service.get_element_attribute_names.
+        // Exceptions propagate; do NOT swallow them here.
+        // eslint-disable-next-line @typescript-eslint/no-var-requires
+        const { ElementService } = require('./ElementService');
+        const elementService = new ElementService(this.rest);
+        const dimensions = await this.getDimensionNamesForWriting(cubeName);
+        const result: Record<string, string[]> = {};
+        for (const dim of dimensions) {
+            // Skip TM1 control dimensions (names starting with `}`) — tm1py's
+            // get_dimension_names_for_writing already excludes them.
+            if (dim.startsWith('}')) continue;
+            const attrs = await elementService.getElementAttributes(dim, dim);
+            result[dim] = (attrs || []).map((a: any) => a.Name ?? a.name ?? String(a));
         }
+        return result;
     }
 
     /**

--- a/src/services/CellService.ts
+++ b/src/services/CellService.ts
@@ -1607,6 +1607,84 @@ export class CellService {
     }
 
     /**
+     * Fetch only Axes with Cardinality from a cellset.
+     * Mirrors tm1py's `extract_cellset_axes_cardinality` (CellService.py:3969-3972)
+     * but returns the raw dict shape rather than a processed array.
+     */
+    private async _fetchCellsetAxesCardinalityRaw(
+        cellsetId: string
+    ): Promise<{ Axes: Array<{ Cardinality: number }> }> {
+        const url = `/Cellsets('${cellsetId}')?$expand=Axes($select=Cardinality)`;
+        return (await this.rest.get(url)).data;
+    }
+
+    /**
+     * Extract cellset axes asynchronously using parallel chunked requests.
+     * Mirrors tm1py's `extract_cellset_axes_raw_async` (CellService.py:3974-4076).
+     * Uses Promise.all instead of Python's ThreadPoolExecutor.
+     */
+    public async extractCellsetAxesRawAsync(
+        cellsetId: string,
+        options: ExtractCellsetAxesRawAsyncOptions = {}
+    ): Promise<RawCellsetDict> {
+        const asyncAxis = options.asyncAxis ?? 1;
+        const maxWorkers = options.maxWorkers ?? 8;
+
+        const axesCardinality = await this._fetchCellsetAxesCardinalityRaw(cellsetId);
+
+        if (asyncAxis >= axesCardinality.Axes.length) {
+            throw new Error("Argument 'async_axis' must be less than axes cardinality");
+        }
+
+        const memberProps = (options.memberProperties && options.memberProperties.length > 0)
+            ? options.memberProperties : ['Name'];
+        const selectMember = '$select=' + memberProps.join(',');
+        const expandElem = (options.elemProperties && options.elemProperties.length > 0)
+            ? ';$expand=Element($select=' + options.elemProperties.join(',') + ')' : '';
+        const expandHierarchies = options.includeHierarchies
+            ? 'Hierarchies($select=Name;$expand=Dimension($select=Name)),' : '';
+
+        const fetchAxisChunk = async (axis: number, partition: number, partitionSize: number): Promise<any> => {
+            const top = partitionSize;
+            const skip = partition * partitionSize;
+            const filterAxis = `$filter=Ordinal eq ${axis};`;
+            const partClause = partitionSize > 0 ? `;$top=${top};$skip=${skip}` : '';
+            let url =
+                `/Cellsets('${cellsetId}')?$expand=` +
+                `Axes(${filterAxis}$expand=${expandHierarchies}Tuples($expand=Members(${selectMember}${expandElem})${partClause}))`;
+            if (options.sandboxName) url += `&!sandbox=${encodeURIComponent(options.sandboxName)}`;
+            return (await this.rest.get(url)).data;
+        };
+
+        // Extract non-async axis (the opposite axis)
+        const axes = await fetchAxisChunk(1 - asyncAxis, 0, 0);
+
+        // Extract async axis tuples in parallel chunks
+        const partitionSize = Math.ceil(axesCardinality.Axes[asyncAxis].Cardinality / maxWorkers);
+        const chunkResults = await Promise.all(
+            Array.from({ length: maxWorkers }, (_, p) => fetchAxisChunk(asyncAxis, p, partitionSize))
+        );
+        const asyncAxisTuples = chunkResults.flatMap((r: any) => r.Axes[0]?.Tuples ?? []);
+
+        // Combine results
+        axes.Axes.splice(asyncAxis, 0, {
+            Ordinal: asyncAxis,
+            Cardinality: axesCardinality.Axes[asyncAxis].Cardinality,
+            Tuples: asyncAxisTuples,
+        });
+
+        // Optionally include context axis (axis 2)
+        if (!options.skipContexts) {
+            const ctx = await fetchAxisChunk(2, 0, 0);
+            if (ctx.Axes && ctx.Axes.length > 0) {
+                axes.Axes.push(ctx.Axes[0]);
+            }
+        }
+
+        return axes;
+    }
+
+    /**
      * Extract cellset values only
      */
     public async extractCellsetValues(

--- a/src/services/CellService.ts
+++ b/src/services/CellService.ts
@@ -1893,6 +1893,265 @@ export class CellService {
     }
 
     /**
+     * Execute cellset and return only the content, in CSV format — streaming version.
+     * Mirrors tm1py's `extract_cellset_csv_iter_json` (CellService.py:4385-4556).
+     * Uses stream-json for incremental JSON parsing (equivalent of Python's ijson).
+     */
+    public async extractCellsetCsvIterJson(
+        cellsetId: string,
+        options: Omit<ExtractCellsetCsvOptions, 'useCompactJson' | 'deleteCellset'> = {}
+    ): Promise<string> {
+        const skipZeros = options.skipZeros !== false;   // default true
+        const valueSeparator = options.valueSeparator ?? ',';
+        const lineSeparator = options.lineSeparator ?? '\r\n';
+        const includeAttributes = options.includeAttributes === true;
+
+        // Use csvDialect settings if provided (tm1py: CellService.py:4444-4446)
+        const delimiter = options.csvDialect?.delimiter ?? valueSeparator;
+        const lineterminator = options.csvDialect?.lineterminator ?? lineSeparator;
+
+        const { cube, rows, columns } = await this.extractCellsetComposition(
+            cellsetId, { sandboxName: options.sandboxName }
+        );
+
+        const rawResponse = await this.extractCellsetRawResponse(cellsetId, {
+            cellProperties: ['Value', 'Ordinal'],
+            top: options.top,
+            skip: options.skip,
+            skipContexts: true,
+            skipZeros,
+            skipConsolidatedCells: options.skipConsolidatedCells,
+            skipRuleDerivedCells: options.skipRuleDerivedCells,
+            sandboxName: options.sandboxName,
+            memberProperties: includeAttributes ? ['Name', 'Attributes'] : ['Name'],
+            deleteCellset: false,
+        });
+
+        const rowHeaders = options.mdxHeaders ? [...rows] : [...dimensionNamesFromElementUniqueNames(rows)];
+        const columnHeaders = options.mdxHeaders ? [...columns] : [...dimensionNamesFromElementUniqueNames(columns)];
+
+        const attributesPrefixes = new Set<string>();
+        if (includeAttributes) {
+            const attributesByDimension = await this._getAttributesByDimension(cube);
+            for (const [, attrs] of Object.entries(attributesByDimension)) {
+                for (const attr of attrs) {
+                    attributesPrefixes.add(`Axes.item.Tuples.item.Members.item.Attributes.${attr}`);
+                }
+            }
+        }
+
+        const prefixesOfInterest = new Set<string>([
+            'Cells.item.Value',
+            'Axes.item.Tuples.item.Members.item.Name',
+            'Cells.item.Ordinal',
+            'Axes.item.Tuples.item.Ordinal',
+            'Cube.Dimensions.item.Name',
+            'Axes.item.Ordinal',
+            ...attributesPrefixes,
+        ]);
+
+        // Mirrors tm1py CellService.py:4448-4537 state machine
+        const axes0List: string[][] = [];   // columns axis tuples member names
+        const axes1List: string[][] = [];   // rows axis tuples member names
+        let currentAxes = 0;
+        let currentTuple = 0;
+        let currentCellOrdinal = 0;
+        const csvBodyLines: string[] = [];
+        let maxEntriesPerRow = 0;
+        let leastEntriesPerRow = 1_000;
+
+        await this._streamJsonWalk(rawResponse.data, prefixesOfInterest, (prefix, event, value) => {
+            if (prefix === 'Cells.item.Value') {
+                // tm1py CellService.py:4482-4499
+                const total = axes0List.length || 1;
+                const r = currentCellOrdinal % total;
+                const q = Math.floor(currentCellOrdinal / total);
+                let row: string[];
+                if (axes0List.length === 1 && axes0List[0].length === 0) {
+                    row = [...axes1List[q], String(value)];
+                } else if (axes1List.length === 0) {
+                    row = [...axes0List[r], String(value)];
+                } else {
+                    row = [...axes1List[q], ...axes0List[r], String(value)];
+                }
+                if (row.length > maxEntriesPerRow) maxEntriesPerRow = row.length;
+                if (row.length < leastEntriesPerRow) leastEntriesPerRow = row.length;
+                csvBodyLines.push(this._csvRow(row, delimiter, lineterminator));
+
+            } else if (prefix === 'Axes.item.Tuples.item.Members.item.Name' && event === 'string') {
+                // tm1py CellService.py:4501-4505
+                (currentAxes === 0 ? axes0List : axes1List)[currentTuple].push(String(value));
+            }
+
+            if (attributesPrefixes.has(prefix)) {
+                // tm1py CellService.py:4507-4524
+                if (event !== 'string' && event !== 'number') return;
+                const attributeName = prefix.split('.').pop() ?? '';
+                const v = String(value);
+                const list = currentAxes === 0 ? axes0List : axes1List;
+                list[currentTuple].push(v);
+                if (currentTuple === 0) {
+                    if (currentAxes === 0) {
+                        columnHeaders.splice(list[currentTuple].length - 1, 0, attributeName);
+                    } else {
+                        rowHeaders.splice(list[currentTuple].length - 1, 0, attributeName);
+                    }
+                }
+            } else if (prefix === 'Cells.item.Ordinal' && event === 'number') {
+                // tm1py CellService.py:4526
+                currentCellOrdinal = value as number;
+            } else if (prefix === 'Axes.item.Tuples.item.Ordinal' && event === 'number') {
+                // tm1py CellService.py:4529-4533
+                currentTuple = value as number;
+                (currentAxes === 0 ? axes0List : axes1List).push([]);
+            } else if (prefix === 'Axes.item.Ordinal' && event === 'number') {
+                // tm1py CellService.py:4536
+                currentAxes = value as number;
+            }
+        });
+
+        // tm1py CellService.py:4539-4541 — empty cellset parity
+        if (csvBodyLines.length === 0) return '';
+
+        // tm1py CellService.py:4543-4549 — include_attributes validation
+        if (includeAttributes) {
+            if (!(leastEntriesPerRow === maxEntriesPerRow &&
+                  maxEntriesPerRow === rowHeaders.length + columnHeaders.length + 1)) {
+                throw new Error(
+                    "Invalid response. With 'includeAttributes' as true," +
+                    " Attributes must be requested explicitly as PROPERTIES in the MDX"
+                );
+            }
+        }
+
+        // tm1py CellService.py:4551-4556 — header + body
+        const headerLine = this._csvRow([...rowHeaders, ...columnHeaders, 'Value'], delimiter, lineterminator);
+        return headerLine + csvBodyLines.join('').replace(/\s+$/, '');
+    }
+
+    /**
+     * Walk a JSON stream and call `visit` for each leaf value whose dotted path
+     * is in `prefixesOfInterest`. Mirrors tm1py's ijson.parse prefix filter.
+     * Uses stream-json v2 with stream-chain for incremental parsing.
+     */
+    private async _streamJsonWalk(
+        stream: NodeJS.ReadableStream,
+        prefixesOfInterest: Set<string>,
+        visit: (prefix: string, event: string, value: any) => void
+    ): Promise<void> {
+        // eslint-disable-next-line @typescript-eslint/no-var-requires
+        const { chain } = require('stream-chain');
+        // eslint-disable-next-line @typescript-eslint/no-var-requires
+        const { parser } = require('stream-json');
+
+        return new Promise<void>((resolve, reject) => {
+            const pipeline = chain([
+                stream,
+                parser({ packKeys: true, packStrings: true, packNumbers: true }),
+            ]);
+
+            // Path tracking state
+            const pathStack: string[] = [];
+            let lastKey: string | null = null;
+            const pathTypes: Array<'obj' | 'arr'> = [];
+
+            pipeline.on('data', (token: { name: string; value?: any }) => {
+                switch (token.name) {
+                    case 'startObject':
+                        if (lastKey !== null) { pathStack.push(lastKey); lastKey = null; }
+                        else if (pathTypes[pathTypes.length - 1] === 'arr') { pathStack.push('item'); }
+                        pathTypes.push('obj');
+                        break;
+
+                    case 'startArray':
+                        if (lastKey !== null) { pathStack.push(lastKey); lastKey = null; }
+                        pathTypes.push('arr');
+                        break;
+
+                    case 'endObject':
+                        pathTypes.pop();
+                        if (pathStack.length > 0 && pathStack[pathStack.length - 1] === 'item') {
+                            pathStack.pop();
+                        }
+                        break;
+
+                    case 'endArray':
+                        pathTypes.pop();
+                        if (pathStack.length > 0) pathStack.pop();
+                        break;
+
+                    case 'keyValue':
+                        lastKey = token.value;
+                        break;
+
+                    case 'stringValue':
+                    case 'numberValue':
+                    case 'nullValue':
+                    case 'trueValue':
+                    case 'falseValue': {
+                        const prefix = lastKey !== null
+                            ? (pathStack.length > 0 ? pathStack.join('.') + '.' + lastKey : lastKey)
+                            : pathStack.join('.');
+                        if (prefixesOfInterest.has(prefix)) {
+                            const event = token.name === 'stringValue' ? 'string'
+                                : token.name === 'numberValue' ? 'number' : 'other';
+                            visit(prefix, event, token.value);
+                        }
+                        lastKey = null;
+                        break;
+                    }
+                }
+            });
+
+            pipeline.on('end', () => resolve());
+            pipeline.on('error', (err: Error) => reject(err));
+        });
+    }
+
+    /**
+     * Format a CSV row from string values using Excel-dialect escaping rules.
+     * Wraps values in quotes when they contain the delimiter, line terminator, or `"`.
+     */
+    private _csvRow(values: string[], delimiter: string, lineterminator: string): string {
+        const escape = (v: string): string => {
+            if (v.includes(delimiter) || v.includes(lineterminator) || v.includes('"')) {
+                return '"' + v.replace(/"/g, '""') + '"';
+            }
+            return v;
+        };
+        return values.map(escape).join(delimiter) + lineterminator;
+    }
+
+    /**
+     * Get element attributes by dimension for a cube.
+     * Used by extractCellsetCsvIterJson to build attribute prefix sets.
+     * Mirrors tm1py's `_get_attributes_by_dimension` (CellService.py:~4573).
+     */
+    private async _getAttributesByDimension(cubeName: string): Promise<Record<string, string[]>> {
+        try {
+            // Import ElementService lazily to avoid circular dependency
+            // eslint-disable-next-line @typescript-eslint/no-var-requires
+            const { ElementService } = require('./ElementService');
+            const elementService = new ElementService(this.rest);
+            const url = `/Cubes('${encodeURIComponent(cubeName)}')?$expand=Dimensions($select=Name)`;
+            const resp = await this.rest.get(url);
+            const dimensions: string[] = (resp.data?.Dimensions || []).map((d: any) => d.Name);
+            const result: Record<string, string[]> = {};
+            for (const dim of dimensions) {
+                try {
+                    const attrs = await elementService.getElementAttributes(dim, dim);
+                    result[dim] = (attrs || []).map((a: any) => a.Name ?? a.name ?? String(a));
+                } catch {
+                    result[dim] = [];
+                }
+            }
+            return result;
+        } catch {
+            return {};
+        }
+    }
+
+    /**
      * Extract cellset as shaped DataFrame
      */
     public async extractCellsetDataframeShaped(

--- a/src/services/CellService.ts
+++ b/src/services/CellService.ts
@@ -1790,39 +1790,47 @@ export class CellService {
     }
 
     /**
-     * Extract cellset composition (cube, dimensions)
-     * @deprecated Replaced by new extractCellsetComposition with options object in Step 8
+     * Retrieve composition of dimensions on the axes in the cellset.
+     * Mirrors tm1py's `@tidy_cellset extract_cellset_composition` (CellService.py:4263-4296).
+     *
+     * BREAKING CHANGE from v2.1: was `(cellsetId, sandbox_name?)` returning
+     * `{cube, dimensions}`. Now returns `{cube, titles, rows, columns}` matching
+     * tm1py's 4-tuple. Migration: use `.columns` / `.rows` / `.titles` instead of
+     * `.dimensions`.
      */
-    private async _extractCellsetCompositionOld(
+    public async extractCellsetComposition(
         cellsetId: string,
-        sandbox_name?: string
-    ): Promise<{ cube: string; dimensions: string[] }> {
-        const metadata = await this.extractCellsetMetadataRaw(cellsetId, { sandboxName: sandbox_name });
+        options: { sandboxName?: string } = {}
+    ): Promise<ExtractCellsetCompositionResult> {
+        let url =
+            `/Cellsets('${cellsetId}')?$expand=` +
+            `Cube($select=Name),Axes($expand=Hierarchies($select=UniqueName))`;
+        if (options.sandboxName) url += `&!sandbox=${encodeURIComponent(options.sandboxName)}`;
 
-        let cube = '';
-        const dimensions: string[] = [];
+        const data = (await this.rest.get(url)).data;
+        const cube: string = data.Cube.Name;
 
-        if (metadata.Axes) {
-            for (const axis of metadata.Axes) {
-                if (axis.Hierarchies) {
-                    for (const hierarchy of axis.Hierarchies) {
-                        if (hierarchy.Dimension && hierarchy.Dimension.Name) {
-                            dimensions.push(hierarchy.Dimension.Name);
-                        }
-                    }
-                }
+        const rows: string[] = [];
+        const titles: string[] = [];
+        const columns: string[] = [];
+
+        if (data.Axes.length === 1) {
+            if (data.Axes[0].Hierarchies) {
+                columns.push(...data.Axes[0].Hierarchies.map((h: any) => h.UniqueName));
+            }
+        } else {
+            if (data.Axes[0].Hierarchies) {
+                columns.push(...data.Axes[0].Hierarchies.map((h: any) => h.UniqueName));
+            }
+            if (data.Axes[1].Hierarchies) {
+                rows.push(...data.Axes[1].Hierarchies.map((h: any) => h.UniqueName));
             }
         }
-
-        // Try to derive cube name from cellset context or metadata
-        if (metadata['@odata.context']) {
-            const contextMatch = metadata['@odata.context'].match(/Cubes\('([^']+)'\)/);
-            if (contextMatch) {
-                cube = contextMatch[1];
-            }
+        if (data.Axes.length > 2) {
+            titles.push(...data.Axes[2].Hierarchies.map((h: any) => h.UniqueName));
         }
 
-        return { cube, dimensions };
+        return { cube, titles, rows, columns };
     }
 
     /**

--- a/src/services/CellService.ts
+++ b/src/services/CellService.ts
@@ -1438,14 +1438,16 @@ export class CellService {
 
     /**
      * Extract cellset cells without axes metadata.
-     * Mirrors tm1py's `extract_cellset_cells_raw` (CellService.py:3914-3967).
-     * @see extractCellsetCellsRaw — full implementation added in Step 5.
+     * Mirrors tm1py's `@odata_compact_json(return_as_dict=True) extract_cellset_cells_raw`
+     * (CellService.py:3913-3967).
+     * Wrapped with withCompactJson(returnAsDict=true) to mirror the decorator.
      */
     public async extractCellsetCellsRaw(
         cellsetId: string,
         options: {
             cellProperties?: string[];
-            top?: number; skip?: number;
+            top?: number;
+            skip?: number;
             skipZeros?: boolean;
             skipConsolidatedCells?: boolean;
             skipRuleDerivedCells?: boolean;
@@ -1453,24 +1455,34 @@ export class CellService {
             useCompactJson?: boolean;
         } = {}
     ): Promise<{ Cells: any[]; '@odata.context'?: string; ID?: string }> {
-        // Full implementation in Step 5 — this stub satisfies the forward reference.
         const cellProperties = [...(options.cellProperties ?? ['Value'])];
-        if (options.skipRuleDerivedCells) { cellProperties.push('RuleDerived'); cellProperties.push('Updateable'); }
+        if (options.skipRuleDerivedCells) {
+            cellProperties.push('RuleDerived');
+            // necessary due to bug in TM1 11.8: If only RuleDerived is retrieved
+            // it occasionally produces wrong results (tm1py parity comment)
+            cellProperties.push('Updateable');
+        }
         if (options.skipConsolidatedCells) cellProperties.push('Consolidated');
         if ((options.skip || options.skipZeros || options.skipRuleDerivedCells || options.skipConsolidatedCells)
-                && !cellProperties.includes('Ordinal')) cellProperties.push('Ordinal');
+                && !cellProperties.includes('Ordinal')) {
+            cellProperties.push('Ordinal');
+        }
+
         const filters: string[] = [];
         if (options.skipZeros) filters.push("Value ne 0 and Value ne null and Value ne ''");
         if (options.skipConsolidatedCells) filters.push('Consolidated eq false');
         if (options.skipRuleDerivedCells) filters.push('RuleDerived eq false');
         const filterCells = filters.join(' and ');
+
         const topClause = options.top ? ';$top=' + options.top : '';
         const skipClause = options.skip ? ';$skip=' + options.skip : '';
         const filterClause = filterCells ? ';$filter=' + filterCells : '';
+
         let url = `/Cellsets('${cellsetId}')?$expand=Cells($select=${cellProperties.join(',')}${topClause}${skipClause}${filterClause})`;
         if (options.sandboxName) url += `&!sandbox=${encodeURIComponent(options.sandboxName)}`;
+
         return withCompactJson(this.rest, options.useCompactJson === true,
-            async () => (await this.rest.get(url)).data, true);
+            async () => (await this.rest.get(url)).data, /* returnAsDict */ true);
     }
 
     /**

--- a/src/services/CellService.ts
+++ b/src/services/CellService.ts
@@ -1372,7 +1372,8 @@ export class CellService {
         // (CellService.py:4308) which produces &!sandbox= (URL-encoded), not $sandbox.
         let url = `/Cellsets('${cellsetId}')/Cells/$count`;
         if (sandbox_name) {
-            url += `&!sandbox=${encodeURIComponent(sandbox_name)}`;
+            // First query param on this URL — must use `?`, not `&`.
+            url += `?!sandbox=${encodeURIComponent(sandbox_name)}`;
         }
         const response = await this.rest.get(url);
         return response.data.value || response.data || 0;
@@ -1975,13 +1976,17 @@ export class CellService {
                 const total = axes0List.length;
                 const r = currentCellOrdinal % total;
                 const q = Math.floor(currentCellOrdinal / total);
+                // tm1py: row = … + [str(value)]. Python's str(None) is 'None',
+                // not 'null' — match so downstream parsers (dataframe NA detection)
+                // see the expected sentinel.
+                const cellStr = value === null ? 'None' : String(value);
                 let row: string[];
                 if (axes0List.length === 1 && axes0List[0].length === 0) {
-                    row = [...axes1List[q], String(value)];
+                    row = [...axes1List[q], cellStr];
                 } else if (axes1List.length === 0) {
-                    row = [...axes0List[r], String(value)];
+                    row = [...axes0List[r], cellStr];
                 } else {
-                    row = [...axes1List[q], ...axes0List[r], String(value)];
+                    row = [...axes1List[q], ...axes0List[r], cellStr];
                 }
                 if (row.length > maxEntriesPerRow) maxEntriesPerRow = row.length;
                 if (row.length < leastEntriesPerRow) leastEntriesPerRow = row.length;

--- a/src/tests/cellServiceExtract.test.ts
+++ b/src/tests/cellServiceExtract.test.ts
@@ -478,6 +478,14 @@ describe('_buildCellsetRawUrl (via extractCellsetRaw URL inspection)', () => {
         expect(url).toContain('$select=Name');  // member properties default
     });
 
+    it('cellProperties=[] is treated as falsy and defaults to ["Value"] (tm1py parity)', async () => {
+        // tm1py: `if not cell_properties:` treats [] as falsy. JS `??` would let
+        // [] through and emit `Cells($select=)` — malformed.
+        const url = await captureUrl({ cellProperties: [] });
+        expect(url).toContain('Cells($select=Value)');
+        expect(url).not.toContain('Cells($select=)');
+    });
+
     it('appends Ordinal when skip is set', async () => {
         const url = await captureUrl({ skip: 5 });
         expect(url).toContain('Value,Ordinal');

--- a/src/tests/cellServiceExtract.test.ts
+++ b/src/tests/cellServiceExtract.test.ts
@@ -756,6 +756,17 @@ describe('extractCellsetCellsRawAsync', () => {
         expect(rest.get).toHaveBeenCalledTimes(9); // 1 count + 8 chunks
     });
 
+    it('passes !sandbox to getCellsetCellsCount via the count GET (?-prefixed)', async () => {
+        rest.get
+            .mockResolvedValueOnce(mockResp(0))
+            .mockResolvedValue(mockResp({ '@odata.context': 'ctx', ID: 'id', Cells: [] }));
+        await svc.extractCellsetCellsRawAsync('CS1', { maxWorkers: 1, sandboxName: 'sb1' });
+        const countUrl = rest.get.mock.calls[0][0] as string;
+        // First (and only) query param on the $count URL must use `?`, not `&`.
+        expect(countUrl).toContain("/Cells/$count?!sandbox=sb1");
+        expect(countUrl).not.toContain("/Cells/$count&");
+    });
+
     it('cellcount=100 maxWorkers=4 → 4 GETs + 1 count', async () => {
         rest.get
             .mockResolvedValueOnce(mockResp(100))   // getCellsetCellsCount
@@ -1076,6 +1087,27 @@ describe('extractCellsetCsvIterJson', () => {
 
         const csv = await svc.extractCellsetCsvIterJson('CS1');
         expect(csv).toContain('42');
+    });
+
+    it('null cell value serializes to "None" (Python str(None) parity)', async () => {
+        // tm1py: row = … + [str(value)]. Python str(None) → "None", not "null".
+        // Downstream dataframe NA detection looks for "None" specifically.
+        const rawData = {
+            Cube: { Name: 'C', Dimensions: [{ Name: 'Year' }, { Name: 'Region' }] },
+            Axes: [
+                { Ordinal: 0, Tuples: [{ Ordinal: 0, Members: [{ Name: 'Jan' }] }] },
+                { Ordinal: 1, Tuples: [{ Ordinal: 0, Members: [{ Name: 'North' }] }] }
+            ],
+            Cells: [{ Value: null, Ordinal: 0 }]
+        };
+
+        rest.get
+            .mockResolvedValueOnce(mockResp(compositionResp))
+            .mockResolvedValueOnce(mockResp(makeReadableStream(rawData)));
+
+        const csv = await svc.extractCellsetCsvIterJson('CS1');
+        expect(csv).toContain('None');
+        expect(csv).not.toContain('null');
     });
 
     it('rejects when visit() throws (Cells.item.Value before any axes tuples)', async () => {

--- a/src/tests/cellServiceExtract.test.ts
+++ b/src/tests/cellServiceExtract.test.ts
@@ -900,6 +900,37 @@ describe('extractCellsetCellsRawAsync', () => {
         expect(countUrl).not.toContain("/Cells/$count&");
     });
 
+    it('coerces /$count text/plain response to a number (tm1py int(response.content) parity)', async () => {
+        // OData $count returns text/plain; axios may deliver it as a string.
+        // tm1py uses int(response.content); tm1npm must coerce too — otherwise
+        // Math.ceil(cellcount / maxWorkers) downstream can produce NaN.
+        rest.get
+            .mockResolvedValueOnce(mockResp("100"))   // string body (axios on text/plain)
+            .mockResolvedValue(mockResp({ '@odata.context': 'ctx', ID: 'id', Cells: [] }));
+        await svc.extractCellsetCellsRawAsync('CS1', { maxWorkers: 4 });
+        // 100 / 4 = 25 → each chunk URL must contain `;$top=25`, not `;$top=NaN`.
+        const chunkUrls = rest.get.mock.calls.slice(1).map(c => c[0] as string);
+        for (const url of chunkUrls) {
+            expect(url).toContain(';$top=25');
+            expect(url).not.toContain('NaN');
+        }
+    });
+
+    it('uses tm1py-style sandbox quoting (single-quote doubling, no %-encoding)', async () => {
+        rest.get
+            .mockResolvedValueOnce(mockResp(0))
+            .mockResolvedValue(mockResp({ '@odata.context': 'ctx', ID: 'id', Cells: [] }));
+        // Sandbox name with characters that encodeURIComponent would mangle
+        // (& and ') — tm1py only doubles the single quote.
+        await svc.extractCellsetCellsRawAsync('CS1', {
+            maxWorkers: 1, sandboxName: "a&b'c",
+        });
+        const chunkUrl = rest.get.mock.calls[1][0] as string;
+        expect(chunkUrl).toContain("!sandbox=a&b''c");
+        expect(chunkUrl).not.toContain('%26');
+        expect(chunkUrl).not.toContain('%27');
+    });
+
     it('cellcount=100 maxWorkers=4 → 4 GETs + 1 count', async () => {
         rest.get
             .mockResolvedValueOnce(mockResp(100))   // getCellsetCellsCount

--- a/src/tests/cellServiceExtract.test.ts
+++ b/src/tests/cellServiceExtract.test.ts
@@ -207,6 +207,21 @@ describe('Utils helpers', () => {
             expect(result.get('[d].[d].[x]')).toBe(42);
         });
 
+        it('top > cells.length clamps (no TypeError) — tm1py slicing parity', () => {
+            // tm1py: cells[: top or len(cells)] never indexes past end.
+            const raw: RawCellsetDict = {
+                Cube: { Name: 'C', Dimensions: [{ Name: 'D' }] },
+                Axes: [
+                    { Cardinality: 1, Tuples: [{ Members: [{ UniqueName: '[D].[D].[a]', Element: null as any }] }] }
+                ],
+                Cells: [{ Value: 1 }],
+            };
+            // top=10, only 1 cell present — should clamp, not throw
+            expect(() => buildContentFromCellsetDict(raw, 10)).not.toThrow();
+            const result = buildContentFromCellsetDict(raw, 10);
+            expect(result.size).toBe(1);
+        });
+
         it('skipSandboxDimension drops Sandboxes first dimension', () => {
             const raw: RawCellsetDict = {
                 Cube: { Name: 'C', Dimensions: [{ Name: 'Sandboxes' }, { Name: 'Year' }] },
@@ -267,6 +282,31 @@ describe('Utils helpers', () => {
             };
             const csv = buildCsvFromCellsetDict([], [], emptyCellset);
             expect(csv).toBe('');
+        });
+
+        it('top > cells.length clamps (no TypeError) — tm1py slicing parity', () => {
+            const csv = buildCsvFromCellsetDict(
+                ['[Region].[Region]'], ['[Year].[Year]'], raw2x2,
+                { top: 100, includeHeaders: false }
+            );
+            // raw2x2 has 2 cells; top=100 must NOT throw and must emit 2 lines.
+            expect(csv.trim().split(/\r\n|\n/).length).toBe(2);
+        });
+
+        it('falsy cell values serialize to "" — tm1py `or` semantics (0/false/"")', () => {
+            // tm1py Utils.py:548: str(cell["Value"] or "") — Python `or` treats 0, False, ""
+            // as falsy. JS `||` matches that; `??` does not (the bug we're fixing).
+            const cellsetWithZero: RawCellsetDict = {
+                Cube: { Name: 'C', Dimensions: [{ Name: 'Year' }] },
+                Axes: [
+                    { Cardinality: 1, Tuples: [{ Members: [{ Name: '2024' }] }] },
+                ],
+                Cells: [{ Value: 0 }],
+            };
+            const csv = buildCsvFromCellsetDict([], ['[Year].[Year]'], cellsetWithZero,
+                { includeHeaders: false });
+            // tm1py strips trailing whitespace; last field is empty (not "0").
+            expect(csv).toBe('2024,');
         });
 
         it('default lineSeparator is CRLF', () => {

--- a/src/tests/cellServiceExtract.test.ts
+++ b/src/tests/cellServiceExtract.test.ts
@@ -600,6 +600,40 @@ describe('_buildCellsetRawUrl (via extractCellsetRaw URL inspection)', () => {
     });
 });
 
+// ─── extractCellsetRawResponse stream-vs-buffered ────────────────────────────
+
+describe('extractCellsetRawResponse', () => {
+    let rest: jest.Mocked<RestService>;
+    let svc: CellService;
+
+    beforeEach(() => {
+        rest = makeMockRest();
+        svc = makeCellService(rest);
+    });
+
+    it('default → buffered Axios response (parseable JSON), no responseType: stream', async () => {
+        // tm1py extract_cellset_raw_response (CellService.py:3705) returns a
+        // buffered Response by default; consumers call .json() on it. Streaming
+        // is opt-in via caller kwargs. Default tm1npm must NOT request 'stream'.
+        rest.get.mockResolvedValueOnce(mockResp({ Cube: {}, Axes: [], Cells: [] }));
+        const resp = await svc.extractCellsetRawResponse('CS1');
+        // No options object passed to rest.get → buffered.
+        expect(rest.get).toHaveBeenCalledWith(expect.any(String));
+        expect(rest.get.mock.calls[0].length).toBe(1);
+        // Response data is the parsed JSON, not a stream.
+        expect(resp.data).toMatchObject({ Cube: {}, Axes: [], Cells: [] });
+    });
+
+    it('asStream: true → responseType: stream is forwarded to Axios', async () => {
+        rest.get.mockResolvedValueOnce(mockResp({}));
+        await svc.extractCellsetRawResponse('CS1', { asStream: true });
+        expect(rest.get).toHaveBeenCalledWith(
+            expect.any(String),
+            { responseType: 'stream' }
+        );
+    });
+});
+
 // ─── Tidy / cleanup tests ─────────────────────────────────────────────────────
 
 describe('extractCellsetRaw tidy / cleanup', () => {

--- a/src/tests/cellServiceExtract.test.ts
+++ b/src/tests/cellServiceExtract.test.ts
@@ -223,6 +223,27 @@ describe('Utils helpers', () => {
             expect(result.size).toBe(1);
         });
 
+        it('top=0 returns ALL cells (Python `or` truthy semantics)', () => {
+            // tm1py: cells[: top or len(cells)] — `0 or N` evaluates to N.
+            // JS `??` would honor 0 and slice empty; `||` matches Python.
+            const raw: RawCellsetDict = {
+                Cube: { Name: 'C', Dimensions: [{ Name: 'D' }] },
+                Axes: [
+                    {
+                        Cardinality: 3,
+                        Tuples: [
+                            { Members: [{ UniqueName: '[D].[D].[a]', Element: null as any }] },
+                            { Members: [{ UniqueName: '[D].[D].[b]', Element: null as any }] },
+                            { Members: [{ UniqueName: '[D].[D].[c]', Element: null as any }] },
+                        ]
+                    }
+                ],
+                Cells: [{ Value: 1 }, { Value: 2 }, { Value: 3 }],
+            };
+            const result = buildContentFromCellsetDict(raw, 0);
+            expect(result.size).toBe(3);
+        });
+
         it('coordinate tuples with element names containing "," do NOT collide', () => {
             // tm1py uses Python tuples as dict keys (Utils.py:412); the TS port joins
             // with TUPLE_KEY_SEPARATOR (\x00), which can't appear in TM1 element names.
@@ -338,6 +359,45 @@ describe('Utils helpers', () => {
                 { includeHeaders: false });
             // tm1py strips trailing whitespace; last field is empty (not "0").
             expect(csv).toBe('2024,');
+        });
+
+        it('top=0 returns ALL cells (Python `or` truthy semantics)', () => {
+            // tm1py: cells[: top or len(cells)] — `0 or N` → N.
+            const csv = buildCsvFromCellsetDict(
+                ['[Region].[Region]'], ['[Year].[Year]'], raw2x2,
+                { top: 0, includeHeaders: false }
+            );
+            // raw2x2 has 2 cells; top=0 must NOT slice empty.
+            const lines = csv.trim().split(/\r\n|\n/).filter(l => l.length > 0);
+            expect(lines.length).toBe(2);
+        });
+
+        it('falsy attribute values serialize to "" — tm1py `if attribute_value else ""` parity', () => {
+            // tm1py Utils.py:654: str(attribute_value) if attribute_value else "" —
+            // 0/false/"" all become "". JS check `v ? String(v) : ''` matches.
+            const cellset: RawCellsetDict = {
+                Cube: { Name: 'C', Dimensions: [{ Name: 'Year' }] },
+                Axes: [
+                    {
+                        Cardinality: 1,
+                        Tuples: [{
+                            Members: [{
+                                Name: '2024',
+                                Attributes: { count: 0, flag: false, label: '' }
+                            }]
+                        }]
+                    },
+                ],
+                Cells: [{ Value: 1 }],
+            };
+            const csv = buildCsvFromCellsetDict(
+                [], ['[Year].[Year]'], cellset,
+                { includeAttributes: true, includeHeaders: false }
+            );
+            // Member name '2024', then 3 empty attribute fields, then '1'.
+            expect(csv).toBe('2024,,,,1');
+            expect(csv).not.toContain(',0,');
+            expect(csv).not.toContain('false');
         });
 
         it('quotes values containing bare \\n (tm1py csv.writer QUOTE_MINIMAL parity)', () => {

--- a/src/tests/cellServiceExtract.test.ts
+++ b/src/tests/cellServiceExtract.test.ts
@@ -16,6 +16,7 @@ import {
     sortCoordinates,
     buildContentFromCellsetDict,
     buildCsvFromCellsetDict,
+    TUPLE_KEY_SEPARATOR,
     RawCellsetDict,
 } from '../utils/Utils';
 
@@ -173,7 +174,7 @@ describe('Utils helpers', () => {
             const result = buildContentFromCellsetDict(raw);
             expect(result.size).toBe(4);
             // year=2024, region=NA → ordinal 0
-            expect(result.get('[year].[year].[2024],[region].[region].[na]')).toBeDefined();
+            expect(result.get(`[year].[year].[2024]${TUPLE_KEY_SEPARATOR}[region].[region].[na]`)).toBeDefined();
         });
 
         it('applies top truncation', () => {
@@ -220,6 +221,36 @@ describe('Utils helpers', () => {
             expect(() => buildContentFromCellsetDict(raw, 10)).not.toThrow();
             const result = buildContentFromCellsetDict(raw, 10);
             expect(result.size).toBe(1);
+        });
+
+        it('coordinate tuples with element names containing "," do NOT collide', () => {
+            // tm1py uses Python tuples as dict keys (Utils.py:412); the TS port joins
+            // with TUPLE_KEY_SEPARATOR (\x00), which can't appear in TM1 element names.
+            // Joining with ',' instead would silently merge ['a,b','c'] and ['a','b,c'].
+            const raw: RawCellsetDict = {
+                Cube: { Name: 'C', Dimensions: [{ Name: 'D1' }, { Name: 'D2' }] },
+                Axes: [
+                    {
+                        Cardinality: 2,
+                        Tuples: [
+                            { Members: [{ UniqueName: '[D1].[D1].[a,b]', Element: null as any }] },
+                            { Members: [{ UniqueName: '[D1].[D1].[a]', Element: null as any }] },
+                        ]
+                    },
+                    {
+                        Cardinality: 2,
+                        Tuples: [
+                            { Members: [{ UniqueName: '[D2].[D2].[c]', Element: null as any }] },
+                            { Members: [{ UniqueName: '[D2].[D2].[b,c]', Element: null as any }] },
+                        ]
+                    },
+                ],
+                Cells: [{ Value: 1 }, { Value: 2 }, { Value: 3 }, { Value: 4 }],
+            };
+            const result = buildContentFromCellsetDict(raw);
+            expect(result.size).toBe(4);
+            expect(result.get(`[d1].[d1].[a,b]${TUPLE_KEY_SEPARATOR}[d2].[d2].[c]`)).toBeDefined();
+            expect(result.get(`[d1].[d1].[a]${TUPLE_KEY_SEPARATOR}[d2].[d2].[b,c]`)).toBeDefined();
         });
 
         it('skipSandboxDimension drops Sandboxes first dimension', () => {

--- a/src/tests/cellServiceExtract.test.ts
+++ b/src/tests/cellServiceExtract.test.ts
@@ -662,11 +662,15 @@ describe('extractCellsetCellsRawAsync', () => {
         svc = makeCellService(rest);
     });
 
-    it('cellcount=0 → returns {Cells: []} without error', async () => {
-        // getCellsetCellsCount returns 0
-        rest.get.mockResolvedValueOnce(mockResp(0));
-        const result = await svc.extractCellsetCellsRawAsync('CS1');
+    it('cellcount=0 → still issues maxWorkers chunk requests (tm1py wire parity)', async () => {
+        // tm1py issues max_workers parallel chunks even when cellcount=0 — partition_size=0
+        // produces no `;$top=` clause so each chunk fetches the full (empty) cellset.
+        rest.get
+            .mockResolvedValueOnce(mockResp(0))
+            .mockResolvedValue(mockResp({ '@odata.context': 'ctx', ID: 'id', Cells: [] }));
+        const result = await svc.extractCellsetCellsRawAsync('CS1', { maxWorkers: 8 });
         expect(result.Cells).toEqual([]);
+        expect(rest.get).toHaveBeenCalledTimes(9); // 1 count + 8 chunks
     });
 
     it('cellcount=100 maxWorkers=4 → 4 GETs + 1 count', async () => {

--- a/src/tests/cellServiceExtract.test.ts
+++ b/src/tests/cellServiceExtract.test.ts
@@ -1,0 +1,993 @@
+/**
+ * Unit tests for CellService extract methods — Issue #67.
+ * All tests mock RestService.get; no live TM1 connection required.
+ */
+
+import { CellService, ExtractCellsetRawOptions, ExtractCellsetCompositionResult } from '../services/CellService';
+import { RestService } from '../services/RestService';
+import {
+    CaseAndSpaceInsensitiveTuplesDict,
+    dimensionNameFromElementUniqueName,
+    hierarchyNameFromElementUniqueName,
+    elementNameFromElementUniqueName,
+    dimensionNamesFromElementUniqueNames,
+    extractAxesFromCellset,
+    extractUniqueNamesFromMembers,
+    sortCoordinates,
+    buildContentFromCellsetDict,
+    buildCsvFromCellsetDict,
+    RawCellsetDict,
+} from '../utils/Utils';
+
+// ─── Helpers ─────────────────────────────────────────────────────────────────
+
+function makeMockRest(): jest.Mocked<RestService> {
+    return {
+        get: jest.fn(),
+        post: jest.fn(),
+        put: jest.fn(),
+        patch: jest.fn(),
+        delete: jest.fn(),
+        add_compact_json_header: jest.fn().mockReturnValue('application/json'),
+        add_http_header: jest.fn(),
+    } as unknown as jest.Mocked<RestService>;
+}
+
+function mockResp(data: any, status: number = 200) {
+    return {
+        data,
+        status,
+        statusText: status === 200 ? 'OK' : status === 204 ? 'No Content' : 'Error',
+        headers: {},
+        config: {} as any,
+    };
+}
+
+function makeCellService(rest: jest.Mocked<RestService>): CellService {
+    return new CellService(rest);
+}
+
+// ─── Utils helpers ────────────────────────────────────────────────────────────
+
+describe('Utils helpers', () => {
+    describe('dimensionNameFromElementUniqueName', () => {
+        it("'[Year].[Year].[2024]' → 'Year'", () => {
+            expect(dimensionNameFromElementUniqueName('[Year].[Year].[2024]')).toBe('Year');
+        });
+        it("'[Sales Region].[Region].[North America]' → 'Sales Region'", () => {
+            expect(dimensionNameFromElementUniqueName('[Sales Region].[Region].[North America]')).toBe('Sales Region');
+        });
+    });
+
+    describe('hierarchyNameFromElementUniqueName', () => {
+        it("'[Year].[Hier1].[2024]' → 'Hier1'", () => {
+            expect(hierarchyNameFromElementUniqueName('[Year].[Hier1].[2024]')).toBe('Hier1');
+        });
+        it("'[Year].[Year].[2024]' → 'Year'", () => {
+            expect(hierarchyNameFromElementUniqueName('[Year].[Year].[2024]')).toBe('Year');
+        });
+    });
+
+    describe('elementNameFromElementUniqueName', () => {
+        it("'[Year].[Year].[2024]' → '2024'", () => {
+            expect(elementNameFromElementUniqueName('[Year].[Year].[2024]')).toBe('2024');
+        });
+        it("double-bracket escape: '[a].[a].[bracket]]name]' → 'bracket]name'", () => {
+            expect(elementNameFromElementUniqueName('[a].[a].[bracket]]name]')).toBe('bracket]name');
+        });
+        it("'[Region].[Region].[North America]' → 'North America'", () => {
+            expect(elementNameFromElementUniqueName('[Region].[Region].[North America]')).toBe('North America');
+        });
+    });
+
+    describe('dimensionNamesFromElementUniqueNames', () => {
+        it('extracts dimension names from iterable', () => {
+            const names = ['[Year].[Year].[2024]', '[Region].[Region].[NA]'];
+            expect(dimensionNamesFromElementUniqueNames(names)).toEqual(['Year', 'Region']);
+        });
+    });
+
+    describe('extractAxesFromCellset', () => {
+        it('drops axes with empty Tuples', () => {
+            const raw: any = {
+                Axes: [
+                    { Cardinality: 2, Tuples: [{ Members: [] }, { Members: [] }] },
+                    { Cardinality: 0, Tuples: [] },
+                ],
+                Cells: [],
+            };
+            const axes = extractAxesFromCellset(raw);
+            expect(axes).toHaveLength(1);
+            expect(axes[0].Cardinality).toBe(2);
+        });
+
+        it('drops null/undefined axes', () => {
+            const raw: any = {
+                Axes: [null, { Cardinality: 1, Tuples: [{ Members: [{ UniqueName: '[Y].[Y].[2024]' }] }] }],
+                Cells: [],
+            };
+            const axes = extractAxesFromCellset(raw);
+            expect(axes).toHaveLength(1);
+        });
+    });
+
+    describe('extractUniqueNamesFromMembers', () => {
+        it('prefers Element.UniqueName', () => {
+            const members = [{ UniqueName: 'bad', Element: { UniqueName: '[Y].[Y].[2024]' } }];
+            expect(extractUniqueNamesFromMembers(members)).toEqual(['[Y].[Y].[2024]']);
+        });
+
+        it('falls back to UniqueName when Element missing', () => {
+            const members = [{ UniqueName: '[Y].[Y].[2024]' }];
+            expect(extractUniqueNamesFromMembers(members)).toEqual(['[Y].[Y].[2024]']);
+        });
+
+        it('falls back to UniqueName when Element null', () => {
+            const members = [{ UniqueName: '[Y].[Y].[2024]', Element: null }];
+            expect(extractUniqueNamesFromMembers(members)).toEqual(['[Y].[Y].[2024]']);
+        });
+    });
+
+    describe('sortCoordinates', () => {
+        it('sorts by cube dimension order', () => {
+            const cubeDims = ['Region', 'Year'];
+            const unsorted = ['[Year].[Year].[2024]', '[Region].[Region].[NA]'];
+            const sorted = sortCoordinates(cubeDims, unsorted, true);
+            expect(sorted[0]).toBe('[Region].[Region].[NA]');
+            expect(sorted[1]).toBe('[Year].[Year].[2024]');
+        });
+
+        it('strips to element name when elementUniqueNames=false', () => {
+            const cubeDims = ['Year'];
+            const unsorted = ['[Year].[Year].[2024]'];
+            const sorted = sortCoordinates(cubeDims, unsorted, false);
+            expect(sorted[0]).toBe('2024');
+        });
+    });
+
+    describe('buildContentFromCellsetDict', () => {
+        it('golden-test: 2x2 cellset → 4-entry dict', () => {
+            const raw: RawCellsetDict = {
+                Cube: { Name: 'C', Dimensions: [{ Name: 'Year' }, { Name: 'Region' }] },
+                Axes: [
+                    {
+                        Cardinality: 2,
+                        Tuples: [
+                            { Members: [{ Element: { UniqueName: '[Year].[Year].[2024]' }, UniqueName: '' }] },
+                            { Members: [{ Element: { UniqueName: '[Year].[Year].[2025]' }, UniqueName: '' }] },
+                        ]
+                    },
+                    {
+                        Cardinality: 2,
+                        Tuples: [
+                            { Members: [{ Element: { UniqueName: '[Region].[Region].[NA]' }, UniqueName: '' }] },
+                            { Members: [{ Element: { UniqueName: '[Region].[Region].[EU]' }, UniqueName: '' }] },
+                        ]
+                    },
+                ],
+                Cells: [
+                    { Value: 10 }, { Value: 20 }, { Value: 30 }, { Value: 40 }
+                ],
+            };
+
+            const result = buildContentFromCellsetDict(raw);
+            expect(result.size).toBe(4);
+            // year=2024, region=NA → ordinal 0
+            expect(result.get('[year].[year].[2024],[region].[region].[na]')).toBeDefined();
+        });
+
+        it('applies top truncation', () => {
+            const raw: RawCellsetDict = {
+                Cube: { Name: 'C', Dimensions: [{ Name: 'D' }] },
+                Axes: [
+                    {
+                        Cardinality: 3,
+                        Tuples: [
+                            { Members: [{ UniqueName: '[D].[D].[a]', Element: null as any }] },
+                            { Members: [{ UniqueName: '[D].[D].[b]', Element: null as any }] },
+                            { Members: [{ UniqueName: '[D].[D].[c]', Element: null as any }] },
+                        ]
+                    }
+                ],
+                Cells: [{ Value: 1 }, { Value: 2 }, { Value: 3 }],
+            };
+            const result = buildContentFromCellsetDict(raw, 2);
+            expect(result.size).toBe(2);
+        });
+
+        it('skipCellProperties=true returns only cell.Value', () => {
+            const raw: RawCellsetDict = {
+                Cube: { Name: 'C', Dimensions: [{ Name: 'D' }] },
+                Axes: [
+                    { Cardinality: 1, Tuples: [{ Members: [{ UniqueName: '[D].[D].[x]', Element: null as any }] }] }
+                ],
+                Cells: [{ Value: 42, Ordinal: 0, RuleDerived: false }],
+            };
+            const result = buildContentFromCellsetDict(raw, null, true, true);
+            expect(result.get('[d].[d].[x]')).toBe(42);
+        });
+
+        it('skipSandboxDimension drops Sandboxes first dimension', () => {
+            const raw: RawCellsetDict = {
+                Cube: { Name: 'C', Dimensions: [{ Name: 'Sandboxes' }, { Name: 'Year' }] },
+                Axes: [
+                    {
+                        Cardinality: 1,
+                        Tuples: [{
+                            Members: [
+                                { UniqueName: '[Year].[Year].[2024]', Element: null as any },
+                            ]
+                        }]
+                    }
+                ],
+                Cells: [{ Value: 5 }],
+            };
+            const result = buildContentFromCellsetDict(raw, null, true, false, true);
+            expect(result.size).toBe(1);
+        });
+    });
+
+    describe('buildCsvFromCellsetDict', () => {
+        const raw2x2: RawCellsetDict = {
+            Cube: { Name: 'C', Dimensions: [{ Name: 'Year' }, { Name: 'Region' }] },
+            Axes: [
+                {
+                    Cardinality: 1,
+                    Tuples: [{ Members: [{ Name: '2024' }] }]
+                },
+                {
+                    Cardinality: 2,
+                    Tuples: [
+                        { Members: [{ Name: 'NA' }] },
+                        { Members: [{ Name: 'EU' }] },
+                    ]
+                },
+            ],
+            Cells: [{ Value: 10 }, { Value: 20 }],
+        };
+
+        it('golden-test: produces correct CSV string', () => {
+            const csv = buildCsvFromCellsetDict(
+                ['[Region].[Region]'],
+                ['[Year].[Year]'],
+                raw2x2,
+                { lineSeparator: '\r\n', valueSeparator: ',' }
+            );
+            expect(csv).toContain('Region');
+            expect(csv).toContain('Year');
+            expect(csv).toContain('10');
+            expect(csv).toContain('20');
+        });
+
+        it('empty cellset → returns ""', () => {
+            const emptyCellset: RawCellsetDict = {
+                Cube: { Name: 'C', Dimensions: [] },
+                Axes: [],
+                Cells: [],
+            };
+            const csv = buildCsvFromCellsetDict([], [], emptyCellset);
+            expect(csv).toBe('');
+        });
+
+        it('default lineSeparator is CRLF', () => {
+            const csv = buildCsvFromCellsetDict(['[Region].[Region]'], ['[Year].[Year]'], raw2x2);
+            expect(csv).toContain('\r\n');
+        });
+
+        it('custom valueSeparator', () => {
+            const csv = buildCsvFromCellsetDict(
+                ['[Region].[Region]'], ['[Year].[Year]'], raw2x2,
+                { valueSeparator: '~' }
+            );
+            expect(csv).toContain('~');
+        });
+
+        it('includeHeaders=false → no header row', () => {
+            const csv = buildCsvFromCellsetDict(
+                ['[Region].[Region]'], ['[Year].[Year]'], raw2x2,
+                { includeHeaders: false }
+            );
+            expect(csv).not.toContain('Region');
+            expect(csv).not.toContain('Year');
+            expect(csv).toContain('10');
+        });
+
+        it('quotes commas, embedded newlines, double-quotes', () => {
+            const raw: RawCellsetDict = {
+                Cube: { Name: 'C', Dimensions: [{ Name: 'Region' }] },
+                Axes: [
+                    {
+                        Cardinality: 1,
+                        Tuples: [{ Members: [{ Name: 'London, UK' }] }]
+                    }
+                ],
+                Cells: [{ Value: 'Hello, "World"\r\nNewline' }],
+            };
+            const csv = buildCsvFromCellsetDict([], ['[Region].[Region]'], raw, { includeHeaders: false });
+            expect(csv).toContain('"London, UK"');
+            expect(csv).toContain('"Hello, ""World""\r\nNewline"');
+        });
+
+        it('csvDialect overrides lineSeparator/valueSeparator', () => {
+            const csv = buildCsvFromCellsetDict(
+                ['[Region].[Region]'], ['[Year].[Year]'], raw2x2,
+                { csvDialect: { delimiter: '|', lineterminator: '\n' } }
+            );
+            expect(csv).toContain('|');
+            expect(csv).not.toContain('\r\n');
+        });
+
+        it('mdxHeaders=true → headers are full unique names', () => {
+            const csv = buildCsvFromCellsetDict(
+                ['[Region].[Region]'], ['[Year].[Year]'], raw2x2,
+                { mdxHeaders: true }
+            );
+            expect(csv).toContain('[Region].[Region]');
+            expect(csv).toContain('[Year].[Year]');
+        });
+    });
+});
+
+// ─── URL builder tests ────────────────────────────────────────────────────────
+
+describe('_buildCellsetRawUrl (via extractCellsetRaw URL inspection)', () => {
+    let rest: jest.Mocked<RestService>;
+    let svc: CellService;
+
+    beforeEach(() => {
+        rest = makeMockRest();
+        svc = makeCellService(rest);
+        // always return an empty raw cellset so extractCellsetRaw completes
+        rest.get.mockResolvedValue(mockResp({
+            Cube: { Name: 'C', Dimensions: [] },
+            Axes: [],
+            Cells: [],
+        }));
+        rest.delete.mockResolvedValue(mockResp({}));
+    });
+
+    async function captureUrl(opts: ExtractCellsetRawOptions): Promise<string> {
+        rest.get.mockResolvedValue(mockResp({
+            Cube: { Name: 'C', Dimensions: [] },
+            Axes: [],
+            Cells: [],
+        }));
+        await svc.extractCellsetRaw('CS1', { ...opts, deleteCellset: false });
+        return (rest.get.mock.calls[0][0] as string);
+    }
+
+    it('builds default URL with cellProperties=[Value]', async () => {
+        const url = await captureUrl({});
+        expect(url).toContain("/Cellsets('CS1')?$expand=");
+        expect(url).toContain('Cube($select=Name;$expand=Dimensions($select=Name))');
+        expect(url).toContain('Cells($select=Value)');
+        expect(url).toContain('$select=Name');  // member properties default
+    });
+
+    it('appends Ordinal when skip is set', async () => {
+        const url = await captureUrl({ skip: 5 });
+        expect(url).toContain('Value,Ordinal');
+        expect(url).toContain(';$skip=5');
+    });
+
+    it('appends RuleDerived+Updateable when skipRuleDerivedCells', async () => {
+        const url = await captureUrl({ skipRuleDerivedCells: true });
+        expect(url).toContain('Value,RuleDerived,Updateable');
+    });
+
+    it('appends Consolidated when skipConsolidatedCells', async () => {
+        const url = await captureUrl({ skipConsolidatedCells: true });
+        expect(url).toContain('Value,Consolidated');
+    });
+
+    it('adds top to tuples when top && !skip', async () => {
+        const url = await captureUrl({ top: 10 });
+        // top in tuples and cells
+        expect(url).toContain(';$top=10');
+    });
+
+    it('does NOT add top to tuples when skip is also set', async () => {
+        const url = await captureUrl({ top: 10, skip: 5 });
+        // top in cells, no top in tuples
+        const axesPart = url.split('Cells(')[0];
+        expect(axesPart).not.toContain(';$top=10');
+        expect(url).toContain(';$skip=5');
+    });
+
+    it('uses !sandbox query param not $sandbox', async () => {
+        const url = await captureUrl({ sandboxName: 'sb1' });
+        expect(url).toContain('&!sandbox=sb1');
+        expect(url).not.toContain('$sandbox');
+    });
+
+    it('combines filters with " and " for all 3 skip flags', async () => {
+        const url = await captureUrl({ skipZeros: true, skipConsolidatedCells: true, skipRuleDerivedCells: true });
+        expect(url).toContain("Value ne 0 and Value ne null and Value ne ''");
+        expect(url).toContain('Consolidated eq false');
+        expect(url).toContain('RuleDerived eq false');
+    });
+
+    it('applies includeHierarchies', async () => {
+        const url = await captureUrl({ includeHierarchies: true });
+        expect(url).toContain('Hierarchies($select=Name;$expand=Dimension($select=Name))');
+    });
+
+    it('filterAxis included when skipContexts=true', async () => {
+        const url = await captureUrl({ skipContexts: true });
+        expect(url).toContain('$filter=Ordinal ne 2;');
+    });
+});
+
+// ─── Tidy / cleanup tests ─────────────────────────────────────────────────────
+
+describe('extractCellsetRaw tidy / cleanup', () => {
+    let rest: jest.Mocked<RestService>;
+    let svc: CellService;
+    const emptyRaw = {
+        Cube: { Name: 'C', Dimensions: [] },
+        Axes: [],
+        Cells: [],
+    };
+
+    beforeEach(() => {
+        rest = makeMockRest();
+        svc = makeCellService(rest);
+        rest.get.mockResolvedValue(mockResp(emptyRaw));
+        rest.delete.mockResolvedValue(mockResp({}));
+    });
+
+    it('calls _safeDeleteCellset by default', async () => {
+        const spy = jest.spyOn(svc, '_safeDeleteCellset').mockResolvedValue();
+        await svc.extractCellsetRaw('CS1');
+        expect(spy).toHaveBeenCalledTimes(1);
+        expect(spy).toHaveBeenCalledWith('CS1', undefined);
+    });
+
+    it('skips cleanup when deleteCellset=false', async () => {
+        const spy = jest.spyOn(svc, '_safeDeleteCellset').mockResolvedValue();
+        await svc.extractCellsetRaw('CS1', { deleteCellset: false });
+        expect(spy).not.toHaveBeenCalled();
+    });
+
+    it('still cleans up when inner GET throws', async () => {
+        rest.get.mockRejectedValueOnce(new Error('network'));
+        const spy = jest.spyOn(svc, '_safeDeleteCellset').mockResolvedValue();
+        await expect(svc.extractCellsetRaw('CS1')).rejects.toThrow('network');
+        expect(spy).toHaveBeenCalledTimes(1);
+    });
+
+    it('_safeDeleteCellset suppresses 404 only', async () => {
+        rest.delete.mockRejectedValueOnce({ status: 404 });
+        await expect(svc._safeDeleteCellset('CS1')).resolves.toBeUndefined();
+
+        rest.delete.mockRejectedValueOnce({ status: 500 });
+        await expect(svc._safeDeleteCellset('CS1')).rejects.toMatchObject({ status: 500 });
+    });
+});
+
+// ─── extractCellset (new signature) ──────────────────────────────────────────
+
+describe('extractCellset (returns CaseAndSpaceInsensitiveTuplesDict)', () => {
+    let rest: jest.Mocked<RestService>;
+    let svc: CellService;
+
+    beforeEach(() => {
+        rest = makeMockRest();
+        svc = makeCellService(rest);
+        rest.delete.mockResolvedValue(mockResp({}));
+    });
+
+    it('4-cell 2x2 cellset → dict with 4 entries', async () => {
+        const raw: RawCellsetDict = {
+            Cube: { Name: 'C', Dimensions: [{ Name: 'Year' }, { Name: 'Region' }] },
+            Axes: [
+                {
+                    Cardinality: 2,
+                    Tuples: [
+                        { Members: [{ Element: { UniqueName: '[Year].[Year].[2024]' }, UniqueName: '' }] },
+                        { Members: [{ Element: { UniqueName: '[Year].[Year].[2025]' }, UniqueName: '' }] },
+                    ]
+                },
+                {
+                    Cardinality: 2,
+                    Tuples: [
+                        { Members: [{ Element: { UniqueName: '[Region].[Region].[NA]' }, UniqueName: '' }] },
+                        { Members: [{ Element: { UniqueName: '[Region].[Region].[EU]' }, UniqueName: '' }] },
+                    ]
+                },
+            ],
+            Cells: [
+                { Value: 10 }, { Value: 20 }, { Value: 30 }, { Value: 40 }
+            ],
+        };
+
+        rest.get.mockResolvedValue(mockResp(raw));
+
+        const result = await svc.extractCellset('CS1');
+        expect(result).toBeInstanceOf(CaseAndSpaceInsensitiveTuplesDict);
+        expect(result.size).toBe(4);
+    });
+
+    it('applies top truncation', async () => {
+        const raw: RawCellsetDict = {
+            Cube: { Name: 'C', Dimensions: [{ Name: 'D' }] },
+            Axes: [
+                {
+                    Cardinality: 3,
+                    Tuples: [
+                        { Members: [{ UniqueName: '[D].[D].[a]', Element: null as any }] },
+                        { Members: [{ UniqueName: '[D].[D].[b]', Element: null as any }] },
+                        { Members: [{ UniqueName: '[D].[D].[c]', Element: null as any }] },
+                    ]
+                }
+            ],
+            Cells: [{ Value: 1 }, { Value: 2 }, { Value: 3 }],
+        };
+        rest.get.mockResolvedValue(mockResp(raw));
+
+        const result = await svc.extractCellset('CS1', { top: 2 });
+        expect(result.size).toBe(2);
+    });
+
+    it('skipCellProperties=true returns Value not full cell object', async () => {
+        const raw: RawCellsetDict = {
+            Cube: { Name: 'C', Dimensions: [{ Name: 'D' }] },
+            Axes: [
+                { Cardinality: 1, Tuples: [{ Members: [{ UniqueName: '[D].[D].[x]', Element: null as any }] }] }
+            ],
+            Cells: [{ Value: 42, Ordinal: 0, RuleDerived: false }],
+        };
+        rest.get.mockResolvedValue(mockResp(raw));
+
+        const result = await svc.extractCellset('CS1', { skipCellProperties: true });
+        const val = result.get('[d].[d].[x]');
+        expect(val).toBe(42);
+    });
+
+    it('elementUniqueNames=false returns short element names as keys', async () => {
+        const raw: RawCellsetDict = {
+            Cube: { Name: 'C', Dimensions: [{ Name: 'D' }] },
+            Axes: [
+                { Cardinality: 1, Tuples: [{ Members: [{ UniqueName: '[D].[D].[elem1]', Element: null as any }] }] }
+            ],
+            Cells: [{ Value: 99 }],
+        };
+        rest.get.mockResolvedValue(mockResp(raw));
+
+        const result = await svc.extractCellset('CS1', { elementUniqueNames: false });
+        expect(result.has('elem1')).toBe(true);
+    });
+});
+
+// ─── extractCellsetCellsRaw ───────────────────────────────────────────────────
+
+describe('extractCellsetCellsRaw', () => {
+    let rest: jest.Mocked<RestService>;
+    let svc: CellService;
+
+    beforeEach(() => {
+        rest = makeMockRest();
+        svc = makeCellService(rest);
+        rest.get.mockResolvedValue(mockResp({ Cells: [{ Value: 1 }] }));
+    });
+
+    it('URL has only Cells expand, no Cube/Axes', async () => {
+        await svc.extractCellsetCellsRaw('CS1');
+        const url = rest.get.mock.calls[0][0] as string;
+        expect(url).toContain("?$expand=Cells(");
+        expect(url).not.toContain('Cube');
+        expect(url).not.toContain('Axes');
+    });
+
+    it('withCompactJson wraps when useCompactJson=true', async () => {
+        const spy = jest.spyOn(rest, 'add_compact_json_header').mockReturnValue('application/json');
+        rest.get.mockResolvedValue(mockResp({
+            '@odata.context': '$metadata#Cellsets(Cells(Value))/$entity',
+            value: [['CS_ID'], [[42]]]
+        }));
+        await svc.extractCellsetCellsRaw('CS1', { useCompactJson: true });
+        expect(spy).toHaveBeenCalled();
+    });
+});
+
+// ─── extractCellsetAxesRawAsync ───────────────────────────────────────────────
+
+describe('extractCellsetAxesRawAsync', () => {
+    let rest: jest.Mocked<RestService>;
+    let svc: CellService;
+
+    beforeEach(() => {
+        rest = makeMockRest();
+        svc = makeCellService(rest);
+    });
+
+    it('throws when asyncAxis >= cardinality.Axes.length', async () => {
+        rest.get.mockResolvedValueOnce(mockResp({ Axes: [{ Cardinality: 5 }, { Cardinality: 3 }] }));
+        await expect(svc.extractCellsetAxesRawAsync('CS1', { asyncAxis: 2 }))
+            .rejects.toThrow("'async_axis'");
+    });
+
+    it('fans out maxWorkers chunked requests', async () => {
+        // Call 1: cardinality
+        rest.get
+            .mockResolvedValueOnce(mockResp({ Axes: [{ Cardinality: 100 }, { Cardinality: 50 }] }))
+            // Call 2: fetch non-async axis (axis 0 when asyncAxis=1)
+            .mockResolvedValueOnce(mockResp({ Axes: [{ Tuples: [] }] }))
+            // Calls 3-6: 4 chunk requests for axis 1 (maxWorkers=4)
+            .mockResolvedValue(mockResp({ Axes: [{ Tuples: [] }] }));
+        // Call for context axis
+        // total: 1 + 1 + 4 + 1 = 7
+
+        await svc.extractCellsetAxesRawAsync('CS1', { asyncAxis: 1, maxWorkers: 4 });
+        // 1 cardinality + 1 other-axis + 4 chunks + 1 context = 7
+        expect(rest.get).toHaveBeenCalledTimes(7);
+    });
+
+    it('skipContexts=true skips context fetch', async () => {
+        rest.get
+            .mockResolvedValueOnce(mockResp({ Axes: [{ Cardinality: 100 }, { Cardinality: 50 }] }))
+            .mockResolvedValueOnce(mockResp({ Axes: [{ Tuples: [] }] }))
+            .mockResolvedValue(mockResp({ Axes: [{ Tuples: [] }] }));
+
+        await svc.extractCellsetAxesRawAsync('CS1', { asyncAxis: 1, maxWorkers: 4, skipContexts: true });
+        // 1 cardinality + 1 other-axis + 4 chunks = 6 (no context call)
+        expect(rest.get).toHaveBeenCalledTimes(6);
+    });
+
+    it('concatenates Tuples in order across chunks', async () => {
+        const chunk1Tuples = [{ Ordinal: 0, Members: [] }, { Ordinal: 1, Members: [] }];
+        const chunk2Tuples = [{ Ordinal: 2, Members: [] }];
+
+        rest.get
+            .mockResolvedValueOnce(mockResp({ Axes: [{ Cardinality: 3 }, { Cardinality: 1 }] }))
+            .mockResolvedValueOnce(mockResp({ Axes: [{ Tuples: [{ Ordinal: 0, Members: [] }] }] }))
+            .mockResolvedValueOnce(mockResp({ Axes: [{ Tuples: chunk1Tuples }] }))
+            .mockResolvedValueOnce(mockResp({ Axes: [{ Tuples: chunk2Tuples }] }))
+            .mockResolvedValue(mockResp({ Axes: [] })); // context
+
+        const result = await svc.extractCellsetAxesRawAsync('CS1', { asyncAxis: 1, maxWorkers: 2, skipContexts: true });
+        const asyncAxisData = result.Axes[1];
+        expect(asyncAxisData.Tuples).toHaveLength(3);
+    });
+});
+
+// ─── extractCellsetCellsRawAsync ──────────────────────────────────────────────
+
+describe('extractCellsetCellsRawAsync', () => {
+    let rest: jest.Mocked<RestService>;
+    let svc: CellService;
+
+    beforeEach(() => {
+        rest = makeMockRest();
+        svc = makeCellService(rest);
+    });
+
+    it('cellcount=0 → returns {Cells: []} without error', async () => {
+        // getCellsetCellsCount returns 0
+        rest.get.mockResolvedValueOnce(mockResp(0));
+        const result = await svc.extractCellsetCellsRawAsync('CS1');
+        expect(result.Cells).toEqual([]);
+    });
+
+    it('cellcount=100 maxWorkers=4 → 4 GETs + 1 count', async () => {
+        rest.get
+            .mockResolvedValueOnce(mockResp(100))   // getCellsetCellsCount
+            .mockResolvedValue(mockResp({ '@odata.context': 'ctx', ID: 'id', Cells: [] }));
+
+        await svc.extractCellsetCellsRawAsync('CS1', { maxWorkers: 4 });
+        expect(rest.get).toHaveBeenCalledTimes(5); // 1 count + 4 chunk
+    });
+
+    it('applies skipZeros filter to all chunks', async () => {
+        rest.get
+            .mockResolvedValueOnce(mockResp(10))
+            .mockResolvedValue(mockResp({ '@odata.context': '', ID: '', Cells: [] }));
+
+        await svc.extractCellsetCellsRawAsync('CS1', { maxWorkers: 2, skipZeros: true });
+        // Verify each chunk URL contains the filter
+        const chunkUrls = rest.get.mock.calls.slice(1).map(c => c[0] as string);
+        for (const url of chunkUrls) {
+            expect(url).toContain("Value ne 0 and Value ne null and Value ne ''");
+        }
+    });
+
+    it('chunk failure rejects via Promise.all', async () => {
+        rest.get
+            .mockResolvedValueOnce(mockResp(10))
+            .mockRejectedValueOnce(new Error('chunk failed'))
+            .mockResolvedValue(mockResp({ '@odata.context': '', ID: '', Cells: [] }));
+
+        await expect(svc.extractCellsetCellsRawAsync('CS1', { maxWorkers: 2 }))
+            .rejects.toThrow('chunk failed');
+    });
+});
+
+// ─── extractCellsetComposition ────────────────────────────────────────────────
+
+describe('extractCellsetComposition', () => {
+    let rest: jest.Mocked<RestService>;
+    let svc: CellService;
+
+    beforeEach(() => {
+        rest = makeMockRest();
+        svc = makeCellService(rest);
+    });
+
+    it('1-axis cellset → only columns populated', async () => {
+        rest.get.mockResolvedValue(mockResp({
+            Cube: { Name: 'MyCube' },
+            Axes: [{ Hierarchies: [{ UniqueName: '[Year].[Year]' }] }]
+        }));
+        const result = await svc.extractCellsetComposition('CS1');
+        expect(result.cube).toBe('MyCube');
+        expect(result.columns).toEqual(['[Year].[Year]']);
+        expect(result.rows).toEqual([]);
+        expect(result.titles).toEqual([]);
+    });
+
+    it('2-axis → columns + rows, no titles', async () => {
+        rest.get.mockResolvedValue(mockResp({
+            Cube: { Name: 'C' },
+            Axes: [
+                { Hierarchies: [{ UniqueName: '[Year].[Year]' }] },
+                { Hierarchies: [{ UniqueName: '[Region].[Region]' }] },
+            ]
+        }));
+        const result = await svc.extractCellsetComposition('CS1');
+        expect(result.columns).toEqual(['[Year].[Year]']);
+        expect(result.rows).toEqual(['[Region].[Region]']);
+        expect(result.titles).toEqual([]);
+    });
+
+    it('3-axis → columns + rows + titles', async () => {
+        rest.get.mockResolvedValue(mockResp({
+            Cube: { Name: 'C' },
+            Axes: [
+                { Hierarchies: [{ UniqueName: '[Year].[Year]' }] },
+                { Hierarchies: [{ UniqueName: '[Region].[Region]' }] },
+                { Hierarchies: [{ UniqueName: '[Version].[Version]' }] },
+            ]
+        }));
+        const result = await svc.extractCellsetComposition('CS1');
+        expect(result.titles).toEqual(['[Version].[Version]']);
+    });
+
+    it('URL is correct shape', async () => {
+        rest.get.mockResolvedValue(mockResp({
+            Cube: { Name: 'C' },
+            Axes: [{ Hierarchies: [] }]
+        }));
+        await svc.extractCellsetComposition('CS1');
+        const url = rest.get.mock.calls[0][0] as string;
+        expect(url).toContain("Cellsets('CS1')");
+        expect(url).toContain('Cube($select=Name)');
+        expect(url).toContain('Axes($expand=Hierarchies($select=UniqueName))');
+    });
+});
+
+// ─── extractCellsetCsv ────────────────────────────────────────────────────────
+
+describe('extractCellsetCsv', () => {
+    let rest: jest.Mocked<RestService>;
+    let svc: CellService;
+
+    const compositionResp = {
+        Cube: { Name: 'C' },
+        Axes: [
+            { Hierarchies: [{ UniqueName: '[Year].[Year]' }] },
+            { Hierarchies: [{ UniqueName: '[Region].[Region]' }] },
+        ]
+    };
+
+    const rawCellset: RawCellsetDict = {
+        Cube: { Name: 'C', Dimensions: [{ Name: 'Year' }, { Name: 'Region' }] },
+        Axes: [
+            { Cardinality: 1, Tuples: [{ Members: [{ Name: '2024' }] }] },
+            { Cardinality: 2, Tuples: [
+                { Members: [{ Name: 'NA' }] },
+                { Members: [{ Name: 'EU' }] },
+            ]},
+        ],
+        Cells: [{ Value: 10 }, { Value: 0 }, { Value: 30 }],
+    };
+
+    beforeEach(() => {
+        rest = makeMockRest();
+        svc = makeCellService(rest);
+        rest.delete.mockResolvedValue(mockResp({}));
+    });
+
+    it('default skipZeros=true', async () => {
+        rest.get
+            .mockResolvedValueOnce(mockResp(compositionResp))
+            .mockResolvedValueOnce(mockResp({
+                ...rawCellset,
+                Cells: [{ Value: 10 }, { Value: 0 }]
+            }));
+        const url1 = await captureRawUrl(svc, rest, compositionResp, {
+            ...rawCellset,
+            Cells: [{ Value: 10 }, { Value: 0 }]
+        });
+        expect(url1).toContain("Value ne 0 and Value ne null and Value ne ''");
+    });
+
+    it('default lineSeparator is CRLF', async () => {
+        rest.get
+            .mockResolvedValueOnce(mockResp(compositionResp))
+            .mockResolvedValueOnce(mockResp(rawCellset));
+        const csv = await svc.extractCellsetCsv('CS1', { skipZeros: false });
+        expect(csv).toContain('\r\n');
+    });
+
+    it('valueSeparator=~', async () => {
+        rest.get
+            .mockResolvedValueOnce(mockResp(compositionResp))
+            .mockResolvedValueOnce(mockResp(rawCellset));
+        const csv = await svc.extractCellsetCsv('CS1', { valueSeparator: '~', skipZeros: false });
+        expect(csv).toContain('~');
+    });
+
+    it('includeHeaders=false → no header row', async () => {
+        rest.get
+            .mockResolvedValueOnce(mockResp(compositionResp))
+            .mockResolvedValueOnce(mockResp(rawCellset));
+        const csv = await svc.extractCellsetCsv('CS1', { includeHeaders: false, skipZeros: false });
+        expect(csv).not.toContain('Year');
+        expect(csv).not.toContain('Region');
+    });
+
+    it('mdxHeaders=true → headers are full unique names', async () => {
+        rest.get
+            .mockResolvedValueOnce(mockResp(compositionResp))
+            .mockResolvedValueOnce(mockResp(rawCellset));
+        const csv = await svc.extractCellsetCsv('CS1', { mdxHeaders: true, skipZeros: false });
+        expect(csv).toContain('[Year].[Year]');
+        expect(csv).toContain('[Region].[Region]');
+    });
+
+    it('empty cellset → returns ""', async () => {
+        rest.get
+            .mockResolvedValueOnce(mockResp(compositionResp))
+            .mockResolvedValueOnce(mockResp({
+                ...rawCellset,
+                Cells: []
+            }));
+        const csv = await svc.extractCellsetCsv('CS1');
+        expect(csv).toBe('');
+    });
+});
+
+async function captureRawUrl(
+    svc: CellService,
+    rest: jest.Mocked<RestService>,
+    compositionResp: any,
+    rawCellset: any
+): Promise<string> {
+    rest.get
+        .mockResolvedValueOnce(mockResp(compositionResp))
+        .mockResolvedValueOnce(mockResp(rawCellset));
+    await svc.extractCellsetCsv('CS1');
+    // second call is extractCellsetRaw URL
+    return rest.get.mock.calls[1][0] as string;
+}
+
+// ─── extractCellsetCsvIterJson ────────────────────────────────────────────────
+
+describe('extractCellsetCsvIterJson', () => {
+    let rest: jest.Mocked<RestService>;
+    let svc: CellService;
+
+    const compositionResp = {
+        Cube: { Name: 'C' },
+        Axes: [
+            { Hierarchies: [{ UniqueName: '[Year].[Year]' }] },
+            { Hierarchies: [{ UniqueName: '[Region].[Region]' }] },
+        ]
+    };
+
+    beforeEach(() => {
+        rest = makeMockRest();
+        svc = makeCellService(rest);
+        rest.delete.mockResolvedValue(mockResp({}));
+    });
+
+    function makeReadableStream(data: any) {
+        // Create a mock readable stream from a Buffer
+        const { Readable } = require('stream');
+        const json = JSON.stringify(data);
+        return Readable.from([json]);
+    }
+
+    it('empty cellset → returns ""', async () => {
+        const rawData = {
+            Cube: { Name: 'C', Dimensions: [{ Name: 'Year' }, { Name: 'Region' }] },
+            Axes: [
+                { Ordinal: 0, Tuples: [{ Ordinal: 0, Members: [{ Name: '2024' }] }] },
+                { Ordinal: 1, Tuples: [] }
+            ],
+            Cells: []
+        };
+
+        rest.get
+            .mockResolvedValueOnce(mockResp(compositionResp))
+            .mockResolvedValueOnce(mockResp(makeReadableStream(rawData)));
+
+        const csv = await svc.extractCellsetCsvIterJson('CS1');
+        expect(csv).toBe('');
+    });
+
+    it('produces CSV with correct headers and values', async () => {
+        const rawData = {
+            Cube: { Name: 'C', Dimensions: [{ Name: 'Year' }, { Name: 'Region' }] },
+            Axes: [
+                {
+                    Ordinal: 0,
+                    Tuples: [{ Ordinal: 0, Members: [{ Name: 'Jan' }] }]
+                },
+                {
+                    Ordinal: 1,
+                    Tuples: [
+                        { Ordinal: 0, Members: [{ Name: 'North' }] },
+                        { Ordinal: 1, Members: [{ Name: 'South' }] },
+                    ]
+                }
+            ],
+            Cells: [{ Value: 10, Ordinal: 0 }, { Value: 20, Ordinal: 1 }]
+        };
+
+        rest.get
+            .mockResolvedValueOnce(mockResp(compositionResp))
+            .mockResolvedValueOnce(mockResp(makeReadableStream(rawData)));
+
+        const csv = await svc.extractCellsetCsvIterJson('CS1');
+        expect(csv).toContain('Year');
+        expect(csv).toContain('Region');
+        expect(csv).toContain('Jan');
+        expect(csv).toContain('North');
+        expect(csv).toContain('10');
+        expect(csv).toContain('20');
+    });
+
+    it('mdxHeaders=true → fully-qualified column/row headers', async () => {
+        const rawData = {
+            Cube: { Name: 'C', Dimensions: [{ Name: 'Year' }, { Name: 'Region' }] },
+            Axes: [
+                { Ordinal: 0, Tuples: [{ Ordinal: 0, Members: [{ Name: 'Jan' }] }] },
+                { Ordinal: 1, Tuples: [{ Ordinal: 0, Members: [{ Name: 'North' }] }] }
+            ],
+            Cells: [{ Value: 10, Ordinal: 0 }]
+        };
+
+        rest.get
+            .mockResolvedValueOnce(mockResp(compositionResp))
+            .mockResolvedValueOnce(mockResp(makeReadableStream(rawData)));
+
+        const csv = await svc.extractCellsetCsvIterJson('CS1', { mdxHeaders: true });
+        expect(csv).toContain('[Region].[Region]');
+        expect(csv).toContain('[Year].[Year]');
+    });
+
+    it('JSON tokens split across chunks produce same result', async () => {
+        const rawData = {
+            Cube: { Name: 'C', Dimensions: [{ Name: 'Year' }, { Name: 'Region' }] },
+            Axes: [
+                { Ordinal: 0, Tuples: [{ Ordinal: 0, Members: [{ Name: 'Jan' }] }] },
+                { Ordinal: 1, Tuples: [{ Ordinal: 0, Members: [{ Name: 'North' }] }] }
+            ],
+            Cells: [{ Value: 42, Ordinal: 0 }]
+        };
+
+        const { Readable } = require('stream');
+        const json = JSON.stringify(rawData);
+        // Split into 2 chunks
+        const half = Math.floor(json.length / 2);
+        const splitStream = Readable.from([json.slice(0, half), json.slice(half)]);
+
+        rest.get
+            .mockResolvedValueOnce(mockResp(compositionResp))
+            .mockResolvedValueOnce(mockResp(splitStream));
+
+        const csv = await svc.extractCellsetCsvIterJson('CS1');
+        expect(csv).toContain('42');
+    });
+});

--- a/src/tests/cellServiceExtract.test.ts
+++ b/src/tests/cellServiceExtract.test.ts
@@ -309,6 +309,49 @@ describe('Utils helpers', () => {
             expect(csv).toBe('2024,');
         });
 
+        it('quotes values containing bare \\n (tm1py csv.writer QUOTE_MINIMAL parity)', () => {
+            const cellsetWithNewline: RawCellsetDict = {
+                Cube: { Name: 'C', Dimensions: [{ Name: 'Year' }] },
+                Axes: [
+                    { Cardinality: 1, Tuples: [{ Members: [{ Name: 'foo\nbar' }] }] },
+                ],
+                Cells: [{ Value: 1 }],
+            };
+            const csv = buildCsvFromCellsetDict([], ['[Year].[Year]'], cellsetWithNewline,
+                { includeHeaders: false });
+            // bare \n inside default lineterminator '\r\n' must trigger quoting.
+            expect(csv).toBe('"foo\nbar",1');
+        });
+
+        it('quotes values containing bare \\r (tm1py csv.writer QUOTE_MINIMAL parity)', () => {
+            const cellsetWithCR: RawCellsetDict = {
+                Cube: { Name: 'C', Dimensions: [{ Name: 'Year' }] },
+                Axes: [
+                    { Cardinality: 1, Tuples: [{ Members: [{ Name: 'foo\rbar' }] }] },
+                ],
+                Cells: [{ Value: 1 }],
+            };
+            const csv = buildCsvFromCellsetDict([], ['[Year].[Year]'], cellsetWithCR,
+                { includeHeaders: false });
+            expect(csv).toBe('"foo\rbar",1');
+        });
+
+        it('prefers Element.Name over member.Name (tm1py Utils.py:641-656)', () => {
+            const cellset: RawCellsetDict = {
+                Cube: { Name: 'C', Dimensions: [{ Name: 'Year' }] },
+                Axes: [
+                    {
+                        Cardinality: 1,
+                        Tuples: [{ Members: [{ Name: 'fallback', Element: { Name: 'preferred' } }] }],
+                    },
+                ],
+                Cells: [{ Value: 1 }],
+            };
+            const csv = buildCsvFromCellsetDict([], ['[Year].[Year]'], cellset,
+                { includeHeaders: false });
+            expect(csv).toBe('preferred,1');
+        });
+
         it('default lineSeparator is CRLF', () => {
             const csv = buildCsvFromCellsetDict(['[Region].[Region]'], ['[Year].[Year]'], raw2x2);
             expect(csv).toContain('\r\n');
@@ -1033,5 +1076,25 @@ describe('extractCellsetCsvIterJson', () => {
 
         const csv = await svc.extractCellsetCsvIterJson('CS1');
         expect(csv).toContain('42');
+    });
+
+    it('rejects when visit() throws (Cells.item.Value before any axes tuples)', async () => {
+        // tm1py raises ZeroDivisionError when divmod(ordinal, len(axes0_list))
+        // sees axes0_list==[] — port mirrors via explicit throw. Stream-data
+        // listener throws don't auto-propagate, so we catch+reject explicitly.
+        const malformedRawData = {
+            Cube: { Name: 'C', Dimensions: [{ Name: 'Year' }, { Name: 'Region' }] },
+            // No Axes population (no Axes.item.Tuples.item.Members.item.Name event
+            // fires before Cells.item.Value).
+            Axes: [],
+            Cells: [{ Value: 42, Ordinal: 0 }]
+        };
+
+        rest.get
+            .mockResolvedValueOnce(mockResp(compositionResp))
+            .mockResolvedValueOnce(mockResp(makeReadableStream(malformedRawData)));
+
+        await expect(svc.extractCellsetCsvIterJson('CS1'))
+            .rejects.toThrow(/division by zero/);
     });
 });

--- a/src/tests/enhancedCellService.test.ts
+++ b/src/tests/enhancedCellService.test.ts
@@ -326,29 +326,38 @@ describe('Enhanced CellService Tests', () => {
         });
 
         test('extractCellsetCsv should extract cellset as CSV with headers', async () => {
-            const mockCellset = {
+            // extractCellsetCsv now makes 2 REST calls:
+            // 1. extractCellsetComposition → GET Cube+Axes(Hierarchies)
+            // 2. extractCellsetRaw → GET full cellset
+            const mockComposition = {
+                Cube: { Name: 'SalesCube' },
+                Axes: [
+                    { Hierarchies: [{ UniqueName: '[Year].[Year]' }] },   // columns axis 0
+                    { Hierarchies: [{ UniqueName: '[Region].[Region]' }] }, // rows axis 1
+                ]
+            };
+            const mockRawCellset = {
+                Cube: { Name: 'SalesCube', Dimensions: [{ Name: 'Year' }, { Name: 'Region' }] },
                 Axes: [
                     {
-                        Hierarchies: [
-                            { Dimension: { Name: 'Year' } },
-                            { Dimension: { Name: 'Region' } }
-                        ],
-                        Tuples: []
+                        Cardinality: 1,
+                        Tuples: [{ Members: [{ Name: '2024', UniqueName: '[Year].[Year].[2024]' }] }]
                     },
                     {
+                        Cardinality: 2,
                         Tuples: [
-                            { Members: [{ Name: '2024' }, { Name: 'London' }] },
-                            { Members: [{ Name: '2024' }, { Name: 'Paris' }] }
+                            { Members: [{ Name: 'London', UniqueName: '[Region].[Region].[London]' }] },
+                            { Members: [{ Name: 'Paris', UniqueName: '[Region].[Region].[Paris]' }] }
                         ]
                     }
                 ],
-                Cells: [
-                    { Value: 100 },
-                    { Value: 200 }
-                ]
+                Cells: [{ Value: 100 }, { Value: 200 }]
             };
 
-            mockRestService.get.mockResolvedValue(createMockResponse(mockCellset));
+            mockRestService.get
+                .mockResolvedValueOnce(createMockResponse(mockComposition))
+                .mockResolvedValueOnce(createMockResponse(mockRawCellset));
+            mockRestService.delete = jest.fn().mockResolvedValue({});
 
             const csv = await cellService.extractCellsetCsv('cellset-123');
 
@@ -364,22 +373,29 @@ describe('Enhanced CellService Tests', () => {
         });
 
         test('extractCellsetCsv should extract cellset as CSV without headers', async () => {
-            const mockCellset = {
+            const mockComposition = {
+                Cube: { Name: 'SalesCube' },
+                Axes: [
+                    { Hierarchies: [{ UniqueName: '[Year].[Year]' }] },
+                ]
+            };
+            const mockRawCellset = {
+                Cube: { Name: 'SalesCube', Dimensions: [{ Name: 'Year' }] },
                 Axes: [
                     {
-                        Hierarchies: [{ Dimension: { Name: 'Year' } }],
-                        Tuples: []
-                    },
-                    {
-                        Tuples: [{ Members: [{ Name: '2024' }] }]
+                        Cardinality: 1,
+                        Tuples: [{ Members: [{ Name: '2024', UniqueName: '[Year].[Year].[2024]' }] }]
                     }
                 ],
                 Cells: [{ Value: 100 }]
             };
 
-            mockRestService.get.mockResolvedValue(createMockResponse(mockCellset));
+            mockRestService.get
+                .mockResolvedValueOnce(createMockResponse(mockComposition))
+                .mockResolvedValueOnce(createMockResponse(mockRawCellset));
+            mockRestService.delete = jest.fn().mockResolvedValue({});
 
-            const csv = await cellService.extractCellsetCsv('cellset-123', undefined, false);
+            const csv = await cellService.extractCellsetCsv('cellset-123', { includeHeaders: false });
 
             expect(csv).not.toContain('Year');
             expect(csv).toContain('100');
@@ -388,15 +404,27 @@ describe('Enhanced CellService Tests', () => {
         });
 
         test('extractCellsetCsv should handle special characters in CSV', async () => {
-            const mockCellset = {
+            const mockComposition = {
+                Cube: { Name: 'SalesCube' },
                 Axes: [
-                    { Hierarchies: [{ Dimension: { Name: 'Region' } }], Tuples: [] },
-                    { Tuples: [{ Members: [{ Name: 'London, UK' }] }] }
+                    { Hierarchies: [{ UniqueName: '[Region].[Region]' }] },
+                ]
+            };
+            const mockRawCellset = {
+                Cube: { Name: 'SalesCube', Dimensions: [{ Name: 'Region' }] },
+                Axes: [
+                    {
+                        Cardinality: 1,
+                        Tuples: [{ Members: [{ Name: 'London, UK', UniqueName: '[Region].[Region].[London, UK]' }] }]
+                    }
                 ],
                 Cells: [{ Value: 'Test, Value' }]
             };
 
-            mockRestService.get.mockResolvedValue(createMockResponse(mockCellset));
+            mockRestService.get
+                .mockResolvedValueOnce(createMockResponse(mockComposition))
+                .mockResolvedValueOnce(createMockResponse(mockRawCellset));
+            mockRestService.delete = jest.fn().mockResolvedValue({});
 
             const csv = await cellService.extractCellsetCsv('cellset-123');
 

--- a/src/utils/Utils.ts
+++ b/src/utils/Utils.ts
@@ -738,3 +738,345 @@ export function extractCompactJsonCellset(
     }
     return cellsData;
 }
+
+// ─── Cellset interfaces ────────────────────────────────────────────────────
+
+export interface CellsetAxis {
+    Ordinal?: number;
+    Cardinality: number;
+    Tuples: Array<{ Ordinal?: number; Members: any[] }>;
+    Hierarchies?: Array<{ Name: string; UniqueName?: string; Dimension?: { Name: string } }>;
+}
+
+export interface RawCellsetDict {
+    Cube?: { Name: string; Dimensions: Array<{ Name: string }> };
+    Axes: CellsetAxis[];
+    Cells: Array<Record<string, any>>;
+    '@odata.context'?: string;
+    ID?: string;
+}
+
+// ─── Element-name helpers (tm1py Utils.py:835-861) ────────────────────────
+
+/**
+ * Extract the dimension name from an element unique name like [Dim].[Hier].[Elem].
+ * Mirrors tm1py's `dimension_name_from_element_unique_name` (Utils.py:835-836).
+ */
+export function dimensionNameFromElementUniqueName(uniqueName: string): string {
+    return uniqueName.substring(1, uniqueName.indexOf('].['));
+}
+
+/**
+ * Extract the hierarchy name from an element unique name like [Dim].[Hier].[Elem].
+ * Mirrors tm1py's `hierarchy_name_from_element_unique_name` (Utils.py:839-840).
+ */
+export function hierarchyNameFromElementUniqueName(uniqueName: string): string {
+    return uniqueName.substring(uniqueName.indexOf('].[')+3, uniqueName.lastIndexOf('].['));
+}
+
+/**
+ * Extract the element name from an element unique name like [Dim].[Hier].[Elem].
+ * Mirrors tm1py's `element_name_from_element_unique_name` (Utils.py:843-844).
+ * Unescapes `]]` → `]`.
+ */
+export function elementNameFromElementUniqueName(uniqueName: string): string {
+    return uniqueName
+        .substring(uniqueName.lastIndexOf('].[')+3, uniqueName.length - 1)
+        .replace(/\]\]/g, ']');
+}
+
+/**
+ * Get tuple of dimension names from iterable of element unique names.
+ * Mirrors tm1py's `dimension_names_from_element_unique_names` (Utils.py:855-860).
+ */
+export function dimensionNamesFromElementUniqueNames(uniqueNames: Iterable<string>): string[] {
+    return Array.from(uniqueNames, dimensionNameFromElementUniqueName);
+}
+
+// ─── Cellset shape helpers (tm1py Utils.py:313-365) ───────────────────────
+
+/**
+ * Extract non-empty axes from a raw cellset dict.
+ * Mirrors tm1py's `extract_axes_from_cellset` (Utils.py:313-322).
+ */
+export function extractAxesFromCellset(rawCellset: RawCellsetDict): CellsetAxis[] {
+    const rawAxes = rawCellset.Axes || [];
+    const axes: CellsetAxis[] = [];
+    for (const axis of rawAxes) {
+        if (axis && Array.isArray(axis.Tuples) && axis.Tuples.length > 0) {
+            axes.push(axis);
+        }
+    }
+    return axes;
+}
+
+/**
+ * Extract list of unique names from members in a cellset response.
+ * Mirrors tm1py's `extract_unique_names_from_members` (Utils.py:325-335):
+ * prefers `m.Element.UniqueName`, falls back to `m.UniqueName`.
+ */
+export function extractUniqueNamesFromMembers(members: Iterable<any>): string[] {
+    const out: string[] = [];
+    for (const m of members) {
+        out.push(m?.Element?.UniqueName ?? m.UniqueName);
+    }
+    return out;
+}
+
+/**
+ * Sort coordinate unique names by cube dimension order.
+ * Mirrors tm1py's `sort_coordinates` (Utils.py:351-365).
+ * When `elementUniqueNames` is false, strips to bare element names.
+ */
+export function sortCoordinates(
+    cubeDimensions: Iterable<string>,
+    unsortedCoordinates: string[],
+    elementUniqueNames: boolean = true
+): string[] {
+    const sorted: string[] = [];
+    for (const dim of cubeDimensions) {
+        const prefix = '[' + dim + '].';
+        for (const addr of unsortedCoordinates) {
+            if (!addr.startsWith(prefix)) continue;
+            sorted.push(elementUniqueNames ? addr : elementNameFromElementUniqueName(addr));
+        }
+    }
+    return sorted;
+}
+
+// ─── Content builder (tm1py Utils.py:368-414) ─────────────────────────────
+
+/**
+ * Transform raw cellset data into a CaseAndSpaceInsensitiveTuplesDict.
+ * Mirrors tm1py's `build_content_from_cellset_dict` (Utils.py:368-414).
+ */
+export function buildContentFromCellsetDict(
+    rawCellset: RawCellsetDict,
+    top: number | null = null,
+    elementUniqueNames: boolean = true,
+    skipCellProperties: boolean = false,
+    skipSandboxDimension: boolean = false
+): CaseAndSpaceInsensitiveTuplesDict<any> {
+    let cubeDimensions = (rawCellset.Cube?.Dimensions || []).map(d => d.Name);
+    if (skipSandboxDimension && cubeDimensions[0]?.toLowerCase() === 'sandboxes') {
+        cubeDimensions = cubeDimensions.slice(1);
+    }
+    const cells = rawCellset.Cells || [];
+    const axes = extractAxesFromCellset(rawCellset);
+    const result = new CaseAndSpaceInsensitiveTuplesDict<any>();
+    const limit = top ?? cells.length;
+    for (let enumOrdinal = 0; enumOrdinal < limit; enumOrdinal++) {
+        const cell = cells[enumOrdinal];
+        // if skip is used we must use the original ordinal from the cell
+        const cellOrdinal: number = cell.Ordinal ?? enumOrdinal;
+        const coords: string[] = [];
+        for (let ai = 0; ai < axes.length; ai++) {
+            const axis = axes[ai];
+            let idx: number;
+            if (ai === 0) {
+                idx = cellOrdinal % axis.Cardinality;
+            } else {
+                let t = cellOrdinal;
+                for (let pre = 0; pre < ai; pre++) t = Math.floor(t / axes[pre].Cardinality);
+                idx = t % axis.Cardinality;
+            }
+            coords.push(...extractUniqueNamesFromMembers(axis.Tuples[idx].Members));
+        }
+        const sorted = sortCoordinates(cubeDimensions, coords, elementUniqueNames);
+        result.set(sorted.join(','), skipCellProperties ? cell.Value : cell);
+    }
+    return result;
+}
+
+// ─── CSV builder (tm1py Utils.py:417-556) ────────────────────────────────
+
+export interface CsvDialect {
+    delimiter: string;
+    lineterminator: string;
+    quoteAll?: boolean;
+}
+
+/**
+ * Build CSV field from member tuple, optionally including attributes.
+ * Mirrors tm1py's `_build_csv_line_items_from_axis_tuple`.
+ */
+function buildCsvLineItemsFromAxisTuple(
+    members: any[],
+    includeAttributes: boolean
+): string[] {
+    const items: string[] = [];
+    for (const member of members) {
+        items.push(member.Name ?? String(member));
+        if (includeAttributes && member.Attributes) {
+            for (const attr of Object.keys(member.Attributes)) {
+                items.push(member.Attributes[attr] !== null && member.Attributes[attr] !== undefined
+                    ? String(member.Attributes[attr]) : '');
+            }
+        }
+    }
+    return items;
+}
+
+/**
+ * Build CSV header row.
+ * Mirrors tm1py's `_build_headers_for_csv` (Utils.py:417-459).
+ */
+function buildHeadersForCsv(
+    rowAxis: CellsetAxis | null,
+    columnAxis: CellsetAxis,
+    rowDimensions: string[],
+    columnDimensions: string[],
+    includeAttributes: boolean,
+    mdxHeaders: boolean = false
+): string[] {
+    if (!includeAttributes) {
+        return [
+            ...(rowDimensions.concat(columnDimensions)).map(d =>
+                mdxHeaders ? d : dimensionNameFromElementUniqueName(d)
+            ),
+            'Value'
+        ];
+    }
+
+    const headers: string[] = [];
+    if (rowAxis && rowAxis.Tuples.length > 0) {
+        const members = rowAxis.Tuples[0].Members;
+        for (let i = 0; i < rowDimensions.length; i++) {
+            const dimension = rowDimensions[i];
+            const member = members[i];
+            if (mdxHeaders) {
+                headers.push(dimension);
+                if (member?.Attributes) {
+                    for (const attr of Object.keys(member.Attributes)) {
+                        headers.push(dimension + '.[' + attr + ']');
+                    }
+                }
+            } else {
+                headers.push(dimensionNameFromElementUniqueName(dimension));
+                if (member?.Attributes) {
+                    for (const attr of Object.keys(member.Attributes)) {
+                        headers.push(attr);
+                    }
+                }
+            }
+        }
+    }
+    if (columnAxis.Tuples.length > 0) {
+        const members = columnAxis.Tuples[0].Members;
+        for (let i = 0; i < columnDimensions.length; i++) {
+            const dimension = columnDimensions[i];
+            const member = members[i];
+            if (mdxHeaders) {
+                headers.push(dimension);
+                if (member?.Attributes) {
+                    for (const attr of Object.keys(member.Attributes)) {
+                        headers.push(dimension + '.[' + attr + ']');
+                    }
+                }
+            } else {
+                headers.push(dimensionNameFromElementUniqueName(dimension));
+                if (member?.Attributes) {
+                    for (const attr of Object.keys(member.Attributes)) {
+                        headers.push(attr);
+                    }
+                }
+            }
+        }
+    }
+    return headers.concat(['Value']);
+}
+
+/**
+ * Escape a single CSV field value using Excel dialect rules.
+ * Wraps in quotes when value contains delimiter, line terminator, or `"`.
+ * Doubles internal quotes.
+ */
+function csvEscapeField(value: string, delimiter: string, lineterminator: string): string {
+    if (value.includes(delimiter) || value.includes(lineterminator) || value.includes('"')) {
+        return '"' + value.replace(/"/g, '""') + '"';
+    }
+    return value;
+}
+
+/**
+ * Serialize an array of string values into one CSV line (with line terminator).
+ */
+function csvRowToString(values: string[], delimiter: string, lineterminator: string): string {
+    return values.map(v => csvEscapeField(v, delimiter, lineterminator)).join(delimiter) + lineterminator;
+}
+
+/**
+ * Transform raw cellset data into CSV string.
+ * Mirrors tm1py's `build_csv_from_cellset_dict` (Utils.py:462-556).
+ * Returns empty string for empty cellsets (tm1py parity, Utils.py:491-492).
+ */
+export function buildCsvFromCellsetDict(
+    rowDimensions: string[],
+    columnDimensions: string[],
+    rawCellset: RawCellsetDict,
+    options: {
+        top?: number | null;
+        csvDialect?: CsvDialect;
+        lineSeparator?: string;
+        valueSeparator?: string;
+        includeAttributes?: boolean;
+        includeHeaders?: boolean;
+        mdxHeaders?: boolean;
+    } = {}
+): string {
+    const cells = rawCellset.Cells || [];
+    // empty cellsets → "" (tm1py parity)
+    if (cells.length === 0) return '';
+
+    const delimiter = options.csvDialect?.delimiter ?? options.valueSeparator ?? ',';
+    const lineterminator = options.csvDialect?.lineterminator ?? options.lineSeparator ?? '\r\n';
+    const includeAttributes = options.includeAttributes === true;
+    const includeHeaders = options.includeHeaders !== false;
+    const mdxHeaders = options.mdxHeaders === true;
+
+    const axes = extractAxesFromCellset(rawCellset);
+    const columnAxis = axes[0];
+    const rowAxis = axes.length > 1 ? axes[1] : null;
+
+    const rows: string[] = [];
+    let numHeaders = 0;
+
+    if (includeHeaders) {
+        const headers = buildHeadersForCsv(
+            rowAxis, columnAxis, rowDimensions, columnDimensions, includeAttributes, mdxHeaders
+        );
+        rows.push(csvRowToString(headers, delimiter, lineterminator));
+        numHeaders = headers.length;
+    }
+
+    const limit = options.top ?? cells.length;
+    for (let enumOrdinal = 0; enumOrdinal < limit; enumOrdinal++) {
+        const cell = cells[enumOrdinal];
+        // if skip was used, use original ordinal from cell
+        const ordinal: number = cell.Ordinal ?? enumOrdinal;
+
+        const line: string[] = [];
+        if (columnAxis && rowAxis) {
+            const indexRows = Math.floor(ordinal / columnAxis.Cardinality) % rowAxis.Cardinality;
+            const indexCols = ordinal % columnAxis.Cardinality;
+            line.push(...buildCsvLineItemsFromAxisTuple(rowAxis.Tuples[indexRows].Members, includeAttributes));
+            line.push(...buildCsvLineItemsFromAxisTuple(columnAxis.Tuples[indexCols].Members, includeAttributes));
+        } else if (columnAxis) {
+            const indexRows = ordinal % columnAxis.Cardinality;
+            line.push(...buildCsvLineItemsFromAxisTuple(columnAxis.Tuples[indexRows].Members, includeAttributes));
+        }
+
+        line.push(String(cell.Value ?? ''));
+
+        if (includeAttributes && includeHeaders && line.length !== numHeaders) {
+            throw new Error(
+                "Invalid response. With 'includeAttributes' as true," +
+                " Attributes must be requested explicitly as PROPERTIES in the MDX"
+            );
+        }
+        rows.push(csvRowToString(line, delimiter, lineterminator));
+    }
+
+    // tm1py parity: strip trailing whitespace from final output (Utils.py:556)
+    return rows.join('').replace(/\s+$/, '');
+}

--- a/src/utils/Utils.ts
+++ b/src/utils/Utils.ts
@@ -1001,7 +1001,7 @@ function csvEscapeField(value: string, delimiter: string, lineterminator: string
 /**
  * Serialize an array of string values into one CSV line (with line terminator).
  */
-function csvRowToString(values: string[], delimiter: string, lineterminator: string): string {
+export function csvRowToString(values: string[], delimiter: string, lineterminator: string): string {
     return values.map(v => csvEscapeField(v, delimiter, lineterminator)).join(delimiter) + lineterminator;
 }
 

--- a/src/utils/Utils.ts
+++ b/src/utils/Utils.ts
@@ -872,8 +872,10 @@ export function buildContentFromCellsetDict(
     const cells = rawCellset.Cells || [];
     const axes = extractAxesFromCellset(rawCellset);
     const result = new CaseAndSpaceInsensitiveTuplesDict<any>();
-    // tm1py: cells[: top or len(cells)] — Python slicing clamps; never indexes past end.
-    const limit = Math.min(top ?? cells.length, cells.length);
+    // tm1py: cells[: top or len(cells)] — Python `or` treats 0 as falsy, so
+    // top=0 means "no limit". JS `||` matches; `??` would honor 0 and slice empty.
+    // Math.min still clamps top > cells.length (parity with Python slice).
+    const limit = Math.min(top || cells.length, cells.length);
     for (let enumOrdinal = 0; enumOrdinal < limit; enumOrdinal++) {
         const cell = cells[enumOrdinal];
         // if skip is used we must use the original ordinal from the cell
@@ -924,8 +926,10 @@ function buildCsvLineItemsFromAxisTuple(
         items.push(member?.Element?.Name ?? member.Name ?? String(member));
         if (includeAttributes && member.Attributes) {
             for (const attr of Object.keys(member.Attributes)) {
-                items.push(member.Attributes[attr] !== null && member.Attributes[attr] !== undefined
-                    ? String(member.Attributes[attr]) : '');
+                // tm1py: str(attribute_value) if attribute_value else "" (Utils.py:654)
+                // — Python truthy: 0/false/""/None all become "". JS `?` matches.
+                const v = member.Attributes[attr];
+                items.push(v ? String(v) : '');
             }
         }
     }
@@ -1071,8 +1075,9 @@ export function buildCsvFromCellsetDict(
         numHeaders = headers.length;
     }
 
-    // tm1py: cells[: top or len(cells)] — Python slicing clamps; never indexes past end.
-    const limit = Math.min(options.top ?? cells.length, cells.length);
+    // tm1py: cells[: top or len(cells)] — Python `or` treats 0 as falsy, so
+    // top=0 means "no limit". `||` matches; `??` would honor 0 and slice empty.
+    const limit = Math.min(options.top || cells.length, cells.length);
     for (let enumOrdinal = 0; enumOrdinal < limit; enumOrdinal++) {
         const cell = cells[enumOrdinal];
         // if skip was used, use original ordinal from cell

--- a/src/utils/Utils.ts
+++ b/src/utils/Utils.ts
@@ -847,6 +847,14 @@ export function sortCoordinates(
 // ─── Content builder (tm1py Utils.py:368-414) ─────────────────────────────
 
 /**
+ * Separator used to flatten tuple coordinates into a single string key for
+ * CaseAndSpaceInsensitiveTuplesDict. NUL (\x00) is illegal in TM1 element
+ * names, so it can never collide with content. Mirrors the role of Python's
+ * native tuple-as-dict-key in tm1py (Utils.py:412-413).
+ */
+export const TUPLE_KEY_SEPARATOR = '\x00';
+
+/**
  * Transform raw cellset data into a CaseAndSpaceInsensitiveTuplesDict.
  * Mirrors tm1py's `build_content_from_cellset_dict` (Utils.py:368-414).
  */
@@ -884,7 +892,11 @@ export function buildContentFromCellsetDict(
             coords.push(...extractUniqueNamesFromMembers(axis.Tuples[idx].Members));
         }
         const sorted = sortCoordinates(cubeDimensions, coords, elementUniqueNames);
-        result.set(sorted.join(','), skipCellProperties ? cell.Value : cell);
+        // tm1py keys content_as_dict by Python tuples (Utils.py:412-413). Joining with ','
+        // collides when element names contain ','. \x00 (NUL) is illegal in TM1 element
+        // names, so it's a safe in-band separator. Callers building keys for .get() must
+        // use the same separator (e.g. coords.join(TUPLE_KEY_SEPARATOR)).
+        result.set(sorted.join(TUPLE_KEY_SEPARATOR), skipCellProperties ? cell.Value : cell);
     }
     return result;
 }

--- a/src/utils/Utils.ts
+++ b/src/utils/Utils.ts
@@ -907,7 +907,9 @@ function buildCsvLineItemsFromAxisTuple(
 ): string[] {
     const items: string[] = [];
     for (const member of members) {
-        items.push(member.Name ?? String(member));
+        // tm1py: member["Element"]["Name"] if "Element" in member and member["Element"]
+        // else member["Name"] (Utils.py:641-656). Element is preferred when present.
+        items.push(member?.Element?.Name ?? member.Name ?? String(member));
         if (includeAttributes && member.Attributes) {
             for (const attr of Object.keys(member.Attributes)) {
                 items.push(member.Attributes[attr] !== null && member.Attributes[attr] !== undefined
@@ -993,7 +995,14 @@ function buildHeadersForCsv(
  * Doubles internal quotes.
  */
 function csvEscapeField(value: string, delimiter: string, lineterminator: string): string {
-    if (value.includes(delimiter) || value.includes(lineterminator) || value.includes('"')) {
+    // Python csv.writer with QUOTE_MINIMAL quotes when value contains delimiter,
+    // quotechar, escapechar, OR ANY character in lineterminator (not the
+    // substring as a whole). Default lineterminator '\r\n' → \r alone or \n
+    // alone must trigger quoting. (tm1py Utils.py:495-499)
+    const needsQuote = value.includes(delimiter)
+        || value.includes('"')
+        || [...lineterminator].some(c => value.includes(c));
+    if (needsQuote) {
         return '"' + value.replace(/"/g, '""') + '"';
     }
     return value;

--- a/src/utils/Utils.ts
+++ b/src/utils/Utils.ts
@@ -864,7 +864,8 @@ export function buildContentFromCellsetDict(
     const cells = rawCellset.Cells || [];
     const axes = extractAxesFromCellset(rawCellset);
     const result = new CaseAndSpaceInsensitiveTuplesDict<any>();
-    const limit = top ?? cells.length;
+    // tm1py: cells[: top or len(cells)] — Python slicing clamps; never indexes past end.
+    const limit = Math.min(top ?? cells.length, cells.length);
     for (let enumOrdinal = 0; enumOrdinal < limit; enumOrdinal++) {
         const cell = cells[enumOrdinal];
         // if skip is used we must use the original ordinal from the cell
@@ -1049,7 +1050,8 @@ export function buildCsvFromCellsetDict(
         numHeaders = headers.length;
     }
 
-    const limit = options.top ?? cells.length;
+    // tm1py: cells[: top or len(cells)] — Python slicing clamps; never indexes past end.
+    const limit = Math.min(options.top ?? cells.length, cells.length);
     for (let enumOrdinal = 0; enumOrdinal < limit; enumOrdinal++) {
         const cell = cells[enumOrdinal];
         // if skip was used, use original ordinal from cell
@@ -1066,7 +1068,8 @@ export function buildCsvFromCellsetDict(
             line.push(...buildCsvLineItemsFromAxisTuple(columnAxis.Tuples[indexRows].Members, includeAttributes));
         }
 
-        line.push(String(cell.Value ?? ''));
+        // tm1py: str(cell["Value"] or "") — Python `or` treats 0/false/"" as falsy too.
+        line.push(String(cell.Value || ''));
 
         if (includeAttributes && includeHeaders && line.length !== numHeaders) {
             throw new Error(


### PR DESCRIPTION
## Summary

Closes #67. Brings CellService extract methods to 100% tm1py parity with strict byte-for-byte fidelity.

- Added 5 new methods: `extractCellsetRaw`, `extractCellsetCellsRaw`, `extractCellsetAxesRawAsync`, `extractCellsetCellsRawAsync`, `extractCellsetCsvIterJson`.
- Rewrote 4 methods with breaking signature changes (documented in CHANGELOG v2.2.0): `extractCellset`, `extractCellsetCsv`, `extractCellsetRawResponse`, `extractCellsetComposition`.
- Added 8 cellset-shaping helpers to `Utils.ts` (`buildContentFromCellsetDict`, `buildCsvFromCellsetDict`, `extractAxesFromCellset`, `sortCoordinates`, etc.).
- New runtime deps: `stream-json ^2.1.0`, `stream-chain ^3.0.0` (used by `extractCellsetCsvIterJson` to mirror Python's `ijson` streaming).

22 atomic commits — 13 implementation + 1 simplify + 8 review-feedback rounds (each addressing real parity defects flagged by Codex).

> **Issue text correction:** the original issue body said `extractCellsetCsv` should switch to a `/Content` endpoint with `$value` and add `use_blob`. tm1py does NOT do this — it uses client-side conversion via `build_csv_from_cellset_dict` and has no `use_blob` parameter on this method. Per project CLAUDE.md strict-parity rule, the implementation follows tm1py source.

## Test plan
- [x] 185/185 cellService unit tests pass (69 new tests added in `cellServiceExtract.test.ts`).
- [x] `tsc --noEmit` clean.
- [x] Build and full Jest suite green (the 3 always-failing suites in CI are credential-gated integration tests requiring `.env`; unaffected).
- [x] Manually traced every new method against `tm1py/Services/CellService.py` and `tm1py/Utils/Utils.py` (URL templates, parameter defaults, decorator semantics).
- [ ] Smoke-test in a downstream consumer that ports tm1py code to confirm the new options-object signatures are ergonomic.