### PR TITLE
fix(#62): align CellService write methods with tm1py — routing, param order, TI/blob

### DIFF
--- a/src/exceptions/TM1Exception.ts
+++ b/src/exceptions/TM1Exception.ts
@@ -36,3 +36,35 @@ export class TM1VersionDeprecationException extends TM1Exception {
         this.name = 'TM1VersionDeprecationException';
     }
 }
+
+export class TM1pyWriteFailureException extends TM1Exception {
+    public statuses: string[];
+    public errorLogFiles: (string | null)[];
+
+    constructor(statuses: string[], errorLogFiles: (string | null)[]) {
+        super(
+            `TM1 write failed. Statuses: ${JSON.stringify(statuses)}. ` +
+            `ErrorLogFiles: ${JSON.stringify(errorLogFiles)}`
+        );
+        this.name = 'TM1pyWriteFailureException';
+        this.statuses = statuses;
+        this.errorLogFiles = errorLogFiles;
+    }
+}
+
+export class TM1pyWritePartialFailureException extends TM1Exception {
+    public statuses: string[];
+    public errorLogFiles: (string | null)[];
+    public attempts: number;
+
+    constructor(statuses: string[], errorLogFiles: (string | null)[], attempts: number) {
+        super(
+            `TM1 write partial failure (${statuses.length}/${attempts} chunks failed). ` +
+            `Statuses: ${JSON.stringify(statuses)}. ErrorLogFiles: ${JSON.stringify(errorLogFiles)}`
+        );
+        this.name = 'TM1pyWritePartialFailureException';
+        this.statuses = statuses;
+        this.errorLogFiles = errorLogFiles;
+        this.attempts = attempts;
+    }
+}

--- a/src/exceptions/TM1Exception.ts
+++ b/src/exceptions/TM1Exception.ts
@@ -37,6 +37,17 @@ export class TM1VersionDeprecationException extends TM1Exception {
     }
 }
 
+// Format an array of strings the way Python str(list) does — a leading [, comma-and-space
+// separated single-quoted entries, trailing ]. Used so the message wording matches tm1py
+// (Exceptions.py:180,197-199) byte-for-byte.
+function pyListRepr(items: (string | null)[]): string {
+    const parts = items.map(item => {
+        if (item === null) return 'None';
+        return `'${item.replace(/\\/g, '\\\\').replace(/'/g, "\\'")}'`;
+    });
+    return `[${parts.join(', ')}]`;
+}
+
 export class TM1pyWriteFailureException extends TM1Exception {
     public statuses: string[];
     public errorLogFiles: (string | null)[];
@@ -45,10 +56,9 @@ export class TM1pyWriteFailureException extends TM1Exception {
     public error_log_files: (string | null)[];
 
     constructor(statuses: string[], errorLogFiles: (string | null)[]) {
-        super(
-            `TM1 write failed. Statuses: ${JSON.stringify(statuses)}. ` +
-            `ErrorLogFiles: ${JSON.stringify(errorLogFiles)}`
-        );
+        // Mirror tm1py Exceptions.py:180 verbatim:
+        //   f"All {len(self.statuses)} write operations failed. Details: {self.error_log_files}"
+        super(`All ${statuses.length} write operations failed. Details: ${pyListRepr(errorLogFiles)}`);
         this.name = 'TM1pyWriteFailureException';
         this.statuses = statuses;
         this.errorLogFiles = errorLogFiles;
@@ -64,9 +74,12 @@ export class TM1pyWritePartialFailureException extends TM1Exception {
     public attempts: number;
 
     constructor(statuses: string[], errorLogFiles: (string | null)[], attempts: number) {
+        // Mirror tm1py Exceptions.py:197-199 verbatim:
+        //   f"{len(self.statuses)} out of {self.attempts} write operations failed partially. "
+        //   f"Details: {self.error_log_files}"
         super(
-            `TM1 write partial failure (${statuses.length}/${attempts} chunks failed). ` +
-            `Statuses: ${JSON.stringify(statuses)}. ErrorLogFiles: ${JSON.stringify(errorLogFiles)}`
+            `${statuses.length} out of ${attempts} write operations failed partially. ` +
+            `Details: ${pyListRepr(errorLogFiles)}`
         );
         this.name = 'TM1pyWritePartialFailureException';
         this.statuses = statuses;

--- a/src/exceptions/TM1Exception.ts
+++ b/src/exceptions/TM1Exception.ts
@@ -40,6 +40,9 @@ export class TM1VersionDeprecationException extends TM1Exception {
 export class TM1pyWriteFailureException extends TM1Exception {
     public statuses: string[];
     public errorLogFiles: (string | null)[];
+    // Snake-case alias for callers porting code from tm1py (which exposes `error_log_files`).
+    // Points at the SAME array as `errorLogFiles` so mutations stay in sync.
+    public error_log_files: (string | null)[];
 
     constructor(statuses: string[], errorLogFiles: (string | null)[]) {
         super(
@@ -49,12 +52,15 @@ export class TM1pyWriteFailureException extends TM1Exception {
         this.name = 'TM1pyWriteFailureException';
         this.statuses = statuses;
         this.errorLogFiles = errorLogFiles;
+        this.error_log_files = errorLogFiles;
     }
 }
 
 export class TM1pyWritePartialFailureException extends TM1Exception {
     public statuses: string[];
     public errorLogFiles: (string | null)[];
+    // Snake-case alias for tm1py compatibility (see TM1pyWriteFailureException above).
+    public error_log_files: (string | null)[];
     public attempts: number;
 
     constructor(statuses: string[], errorLogFiles: (string | null)[], attempts: number) {
@@ -65,6 +71,7 @@ export class TM1pyWritePartialFailureException extends TM1Exception {
         this.name = 'TM1pyWritePartialFailureException';
         this.statuses = statuses;
         this.errorLogFiles = errorLogFiles;
+        this.error_log_files = errorLogFiles;
         this.attempts = attempts;
     }
 }

--- a/src/services/CellService.ts
+++ b/src/services/CellService.ts
@@ -479,16 +479,16 @@ export class CellService {
         if (options.clear_view && !options.use_blob) {
             throw new Error("'clear_view' can only be used in conjunction with 'use_blob'");
         }
+        // tm1py write() returns Optional[str] — the changeset id from the underlying call (or None).
+        // Forward whatever the routed method returns so future changeset wiring (notably in
+        // writeThroughCellset, which is intentionally out of scope for #62) propagates through.
         if (options.use_ti) {
-            await this.writeThroughUnboundProcess(cubeName, cellsetAsDict, { ...options, dimensions });
-            return undefined;
+            return await this.writeThroughUnboundProcess(cubeName, cellsetAsDict, { ...options, dimensions });
         }
         if (options.use_blob) {
-            await this.writeThroughBlob(cubeName, cellsetAsDict, { ...options, dimensions });
-            return undefined;
+            return await this.writeThroughBlob(cubeName, cellsetAsDict, { ...options, dimensions });
         }
-        await this.writeThroughCellset(cubeName, cellsetAsDict, dimensions, options);
-        return undefined;
+        return await this.writeThroughCellset(cubeName, cellsetAsDict, dimensions, options);
     }
 
     private async writeThroughCellset(
@@ -496,7 +496,7 @@ export class CellService {
         cellsetAsDict: CellsetDict,
         dimensions?: string[],
         options: WriteOptions = {}
-    ): Promise<void> {
+    ): Promise<string | undefined> {
         const dims = dimensions || await this.getDimensionNamesForWriting(cubeName);
         const cells = Object.entries(cellsetAsDict).map(([coordinates, value]) => {
             const elementArray = coordinates.split(',').map(s => s.trim());
@@ -519,6 +519,11 @@ export class CellService {
         if (options.allow_spread) body.AllowSpread = true;
 
         await this.rest.post(url, JSON.stringify(body));
+        // tm1py write_through_cellset returns the changeset string from write_values_through_cellset
+        // (CellService.py:1292). The current tm1npm impl POSTs directly to /tm1.Update without
+        // beginning a changeset; surface undefined and rely on a follow-up to refactor through
+        // writeValuesThroughCellset. Out of scope for #62.
+        return undefined;
     }
 
     /**
@@ -826,7 +831,7 @@ export class CellService {
             deactivate_transaction_log?: boolean;
             reactivate_transaction_log?: boolean;
         } = {}
-    ): Promise<void> {
+    ): Promise<string | undefined> {
         const removeBlob = options.remove_blob ?? true;
         // eslint-disable-next-line @typescript-eslint/no-var-requires
         const { FileService } = require('./FileService');
@@ -900,6 +905,9 @@ export class CellService {
                 await this.activateTransactionlog(cubeName);
             }
         }
+        // tm1py write_through_blob returns None implicitly. Returning undefined so write() can
+        // route through `return await` consistently across all three write strategies.
+        return undefined;
     }
 
     /**
@@ -1083,6 +1091,11 @@ export class CellService {
             chunks.push(Object.fromEntries(entries.slice(i, i + sliceSize)));
         }
 
+        // Mirror tm1py write_async (CellService.py:1004-1005): prefetch dimensions ONCE before the
+        // chunk loop so each parallel writeThroughBlob call doesn't independently re-fetch the
+        // cube's dimension list (would be N HTTP GETs for N chunks).
+        const dims = options.dimensions ?? await this.getDimensionNamesForWriting(cubeName);
+
         const blobOpts = {
             sandbox_name: options.sandbox_name,
             increment: options.increment,
@@ -1091,7 +1104,7 @@ export class CellService {
             skip_non_updateable: options.skip_non_updateable,
             allow_spread: options.allow_spread,
             remove_blob: options.remove_blob,
-            dimensions: options.dimensions,
+            dimensions: dims,
         };
 
         const failures: unknown[] = [];
@@ -1133,7 +1146,7 @@ export class CellService {
             deactivate_transaction_log?: boolean;
             reactivate_transaction_log?: boolean;
         } = {}
-    ): Promise<void> {
+    ): Promise<string | undefined> {
         // tm1py's @manage_transaction_log decorator wraps the WHOLE function body — deactivate
         // before any helper fetches, reactivate in the outer finally regardless of failure path.
         if (options.deactivate_transaction_log) {
@@ -1211,6 +1224,9 @@ export class CellService {
                 await this.activateTransactionlog(cubeName);
             }
         }
+        // tm1py write_through_unbound_process returns None implicitly. Returning undefined so
+        // write() can route through `return await` consistently across all three write strategies.
+        return undefined;
     }
 
     /**

--- a/src/services/CellService.ts
+++ b/src/services/CellService.ts
@@ -1096,30 +1096,68 @@ export class CellService {
         // cube's dimension list (would be N HTTP GETs for N chunks).
         const dims = options.dimensions ?? await this.getDimensionNamesForWriting(cubeName);
 
-        const blobOpts = {
-            sandbox_name: options.sandbox_name,
-            increment: options.increment,
-            deactivate_transaction_log: options.deactivate_transaction_log,
-            reactivate_transaction_log: options.reactivate_transaction_log,
-            skip_non_updateable: options.skip_non_updateable,
-            allow_spread: options.allow_spread,
-            remove_blob: options.remove_blob,
-            dimensions: dims,
-        };
+        // tm1py's @manage_transaction_log decorator wraps the WHOLE write_async (CellService.py:969).
+        // The inner _write (line 1015) does NOT forward deactivate/reactivate flags, so per-chunk
+        // writes never toggle individually — important when chunks run in parallel because one
+        // chunk reactivating mid-flight would defeat the surrounding deactivate intent.
+        if (options.deactivate_transaction_log) {
+            await this.deactivateTransactionlog(cubeName);
+        }
+        try {
+            // Forward only the per-write flags; do NOT forward transaction-log toggles.
+            const blobOpts = {
+                sandbox_name: options.sandbox_name,
+                increment: options.increment,
+                skip_non_updateable: options.skip_non_updateable,
+                allow_spread: options.allow_spread,
+                remove_blob: options.remove_blob,
+                dimensions: dims,
+            };
 
-        const failures: unknown[] = [];
-        for (let i = 0; i < chunks.length; i += maxWorkers) {
-            const batch = chunks.slice(i, i + maxWorkers);
-            const results = await Promise.allSettled(
-                batch.map(c => this.writeThroughBlob(cubeName, c, blobOpts))
+            // Aggregate caught chunk failures so we can rebuild a combined
+            // TM1pyWritePartialFailureException with merged statuses / errorLogFiles / attempts —
+            // mirrors tm1py's `itertools.chain(*[e.statuses ...])` / `sum(...)` aggregation
+            // (CellService.py:1047-1057).
+            const failures: (TM1pyWritePartialFailureException | TM1pyWriteFailureException)[] = [];
+            const otherFailures: unknown[] = [];
+            for (let i = 0; i < chunks.length; i += maxWorkers) {
+                const batch = chunks.slice(i, i + maxWorkers);
+                const results = await Promise.allSettled(
+                    batch.map(c => this.writeThroughBlob(cubeName, c, blobOpts))
+                );
+                for (const r of results) {
+                    if (r.status === 'rejected') {
+                        if (r.reason instanceof TM1pyWritePartialFailureException
+                            || r.reason instanceof TM1pyWriteFailureException) {
+                            failures.push(r.reason);
+                        } else {
+                            otherFailures.push(r.reason);
+                        }
+                    }
+                }
+            }
+
+            // Non-TM1pyWrite* exceptions don't fit the merge model — surface the first one as-is
+            // (no equivalent path in tm1py since its inner _write only catches the typed pair).
+            if (otherFailures.length) {
+                throw otherFailures[0];
+            }
+            if (failures.length === 0) {
+                return undefined;
+            }
+
+            const mergedStatuses = failures.flatMap(e => e.statuses);
+            const mergedLogFiles = failures.flatMap(e => e.errorLogFiles);
+            const mergedAttempts = failures.reduce(
+                (sum, e) => sum + (e instanceof TM1pyWritePartialFailureException ? e.attempts : 1),
+                0,
             );
-            for (const r of results) if (r.status === 'rejected') failures.push(r.reason);
+            throw new TM1pyWritePartialFailureException(mergedStatuses, mergedLogFiles, mergedAttempts);
+        } finally {
+            if (options.reactivate_transaction_log) {
+                await this.activateTransactionlog(cubeName);
+            }
         }
-        if (failures.length) {
-            const messages = failures.map(f => (f as { message?: string })?.message ?? String(f));
-            throw new TM1pyWritePartialFailureException(messages, [], chunks.length);
-        }
-        return undefined;
     }
 
     /**

--- a/src/services/CellService.ts
+++ b/src/services/CellService.ts
@@ -838,57 +838,64 @@ export class CellService {
         const uniqueName = `tm1py_${crypto.randomBytes(6).toString('hex')}`;
         const fileName = `${uniqueName}.csv`;
 
-        // CSV: tm1py uses csv.writer(QUOTE_ALL, delimiter=','). Quote every field; double internal
-        // quotes; replace \r/\n in string values with empty (mirrors tm1py:1463 cleanup).
-        const csvLines: string[] = [];
-        for (const [coordKey, value] of Object.entries(cellsetAsDict)) {
-            const elements = coordKey.split(',');
-            const cleanedValue = typeof value === 'string'
-                ? value.replace(/[\r\n]/g, '')
-                : (value === null || value === undefined ? '' : String(value));
-            const fields = [...elements, cleanedValue].map(s =>
-                `"${String(s).replace(/"/g, '""')}"`
-            );
-            csvLines.push(fields.join(','));
-        }
-        // Python csv.writer defaults to lineterminator='\r\n' AND writes a terminator after every
-        // row (including the last). Matching exactly so the bytes-on-wire are identical to tm1py.
-        const csvBody = csvLines.length > 0 ? csvLines.join('\r\n') + '\r\n' : '';
-        await fileService.create(fileName, Buffer.from(csvBody, 'utf-8'));
-
+        // tm1py's @manage_transaction_log decorator wraps the WHOLE function body, including the
+        // CSV upload. Deactivate before any I/O so a deactivate failure aborts upload+execute,
+        // and put reactivate in the outer finally so it always runs (mirrors decorator semantics).
         if (options.deactivate_transaction_log) {
             await this.deactivateTransactionlog(cubeName);
         }
         try {
-            const proc = await this._buildBlobToCubeProcess({
-                cubeName,
-                processName: uniqueName,
-                blobFilename: fileName,
-                dimensions: dims,
-                increment: options.increment ?? false,
-                skipNonUpdateable: options.skip_non_updateable ?? false,
-                sandboxName: options.sandbox_name,
-                allowSpread: options.allow_spread ?? false,
-                clearView: options.clear_view,
-            });
-            const response = await this.rest.post(
-                '/ExecuteProcessWithReturn?$expand=*',
-                JSON.stringify({ Process: proc.bodyAsDict })
-            );
-            const status: string = response?.data?.ProcessExecuteStatusCode ?? 'Unknown';
-            if (status !== 'CompletedSuccessfully') {
-                const logFile = response?.data?.ErrorLogFile?.Filename ?? null;
-                if (status === 'HasMinorErrors') {
-                    throw new TM1pyWritePartialFailureException([status], [logFile], 1);
+            // CSV: tm1py uses csv.writer(QUOTE_ALL, delimiter=','). Quote every field; double
+            // internal quotes; replace \r/\n in string values with empty (mirrors tm1py:1463
+            // cleanup). Python csv.writer defaults to lineterminator='\r\n' AND writes a
+            // terminator after every row (including the last) — match exactly.
+            const csvLines: string[] = [];
+            for (const [coordKey, value] of Object.entries(cellsetAsDict)) {
+                const elements = coordKey.split(',');
+                const cleanedValue = typeof value === 'string'
+                    ? value.replace(/[\r\n]/g, '')
+                    : (value === null || value === undefined ? '' : String(value));
+                const fields = [...elements, cleanedValue].map(s =>
+                    `"${String(s).replace(/"/g, '""')}"`
+                );
+                csvLines.push(fields.join(','));
+            }
+            const csvBody = csvLines.length > 0 ? csvLines.join('\r\n') + '\r\n' : '';
+            await fileService.create(fileName, Buffer.from(csvBody, 'utf-8'));
+
+            try {
+                const proc = await this._buildBlobToCubeProcess({
+                    cubeName,
+                    processName: uniqueName,
+                    blobFilename: fileName,
+                    dimensions: dims,
+                    increment: options.increment ?? false,
+                    skipNonUpdateable: options.skip_non_updateable ?? false,
+                    sandboxName: options.sandbox_name,
+                    allowSpread: options.allow_spread ?? false,
+                    clearView: options.clear_view,
+                });
+                const response = await this.rest.post(
+                    '/ExecuteProcessWithReturn?$expand=*',
+                    JSON.stringify({ Process: proc.bodyAsDict })
+                );
+                const status: string = response?.data?.ProcessExecuteStatusCode ?? 'Unknown';
+                if (status !== 'CompletedSuccessfully') {
+                    const logFile = response?.data?.ErrorLogFile?.Filename ?? null;
+                    if (status === 'HasMinorErrors') {
+                        throw new TM1pyWritePartialFailureException([status], [logFile], 1);
+                    }
+                    throw new TM1pyWriteFailureException([status], [logFile]);
                 }
-                throw new TM1pyWriteFailureException([status], [logFile]);
+            } finally {
+                // Mirror tm1py CellService.py:1491-1493: bare `finally` deletes the blob; a
+                // delete failure surfaces (and may overwrite the original write error). Per
+                // CLAUDE.md's strict parity rule, do NOT suppress.
+                if (removeBlob) {
+                    await fileService.delete(fileName);
+                }
             }
         } finally {
-            if (removeBlob) {
-                // tm1py does not suppress; we tolerate cleanup failures so that the original error
-                // (if any) propagates instead of being masked by a delete failure.
-                try { await fileService.delete(fileName); } catch { /* ignore */ }
-            }
             if (options.reactivate_transaction_log) {
                 await this.activateTransactionlog(cubeName);
             }
@@ -1127,50 +1134,49 @@ export class CellService {
             reactivate_transaction_log?: boolean;
         } = {}
     ): Promise<void> {
-        const isAttributeCube = options.is_attribute_cube
-            ?? cubeName.toLowerCase().startsWith('}elementattributes_');
-        const enableSandbox = await this.generateEnableSandboxTi(options.sandbox_name);
-
-        let measureDimensionElements: Record<string, string> | undefined = options.measure_dimension_elements;
-        if (!measureDimensionElements) {
-            // tm1py returns a flat dict {elementName: type}. The existing tm1npm helper returns
-            // {dimension: string[]}, so flatten it (every measure element treated as Numeric,
-            // matching tm1py's element_service.get_element_types_from_all_hierarchies fallback).
-            const fetched = await this.getElementsFromAllMeasureHierarchies(cubeName);
-            measureDimensionElements = {};
-            for (const elements of Object.values(fetched)) {
-                for (const e of elements) measureDimensionElements[e] = 'Numeric';
-            }
-        }
-
-        let dims = options.dimensions;
-        if (!isAttributeCube && !dims && options.allow_spread) {
-            dims = await this.getDimensionNamesForWriting(cubeName);
-        }
-
-        const statements = isAttributeCube
-            ? CellService._buildAttributeUpdateStatements({
-                cubeName,
-                cellsetAsDict,
-                precision: options.precision,
-                skipNonUpdateable: options.skip_non_updateable ?? false,
-                measureDimensionElements: measureDimensionElements ?? {},
-            })
-            : CellService._buildCellUpdateStatements({
-                cubeName,
-                cellsetAsDict,
-                increment: options.increment ?? false,
-                measureDimensionElements: measureDimensionElements ?? {},
-                precision: options.precision,
-                skipNonUpdateable: options.skip_non_updateable ?? false,
-                dimensions: dims,
-                allowSpread: options.allow_spread ?? false,
-            });
-
+        // tm1py's @manage_transaction_log decorator wraps the WHOLE function body — deactivate
+        // before any helper fetches, reactivate in the outer finally regardless of failure path.
         if (options.deactivate_transaction_log) {
             await this.deactivateTransactionlog(cubeName);
         }
         try {
+            const isAttributeCube = options.is_attribute_cube
+                ?? cubeName.toLowerCase().startsWith('}elementattributes_');
+            const enableSandbox = await this.generateEnableSandboxTi(options.sandbox_name);
+
+            let measureDimensionElements: Record<string, string> | undefined = options.measure_dimension_elements;
+            if (!measureDimensionElements) {
+                // tm1py CellService.py:1906-1914: resolve measure dimension via CubeService, then
+                // fetch the {elementName: actualType} dict from ElementService — preserving real
+                // element types (Numeric/String/Consolidated) so _buildCellUpdateStatements emits
+                // CellPutS for string measures instead of falling through to CellPutN.
+                measureDimensionElements = await this._fetchMeasureDimensionElementTypes(cubeName);
+            }
+
+            let dims = options.dimensions;
+            if (!isAttributeCube && !dims && options.allow_spread) {
+                dims = await this.getDimensionNamesForWriting(cubeName);
+            }
+
+            const statements = isAttributeCube
+                ? CellService._buildAttributeUpdateStatements({
+                    cubeName,
+                    cellsetAsDict,
+                    precision: options.precision,
+                    skipNonUpdateable: options.skip_non_updateable ?? false,
+                    measureDimensionElements: measureDimensionElements ?? {},
+                })
+                : CellService._buildCellUpdateStatements({
+                    cubeName,
+                    cellsetAsDict,
+                    increment: options.increment ?? false,
+                    measureDimensionElements: measureDimensionElements ?? {},
+                    precision: options.precision,
+                    skipNonUpdateable: options.skip_non_updateable ?? false,
+                    dimensions: dims,
+                    allowSpread: options.allow_spread ?? false,
+                });
+
             const version = this.rest.version ?? "11.8.0";
             const maxStmts = Process.maxStatements(version);
             const successes: boolean[] = [];
@@ -2941,6 +2947,29 @@ export class CellService {
             return cellsetAsDict;
         }
 
+        return result;
+    }
+
+    /**
+     * Resolve the measure dimension for a cube, then return the {elementName: type} map across
+     * all hierarchies. Mirrors tm1py CellService.get_elements_from_all_measure_hierarchies
+     * (CellService.py:1906-1914) — returns the real element type per element so callers can
+     * dispatch CellPutN vs CellPutS correctly.
+     */
+    private async _fetchMeasureDimensionElementTypes(cubeName: string): Promise<Record<string, string>> {
+        // eslint-disable-next-line @typescript-eslint/no-var-requires
+        const { CubeService } = require('./CubeService');
+        // eslint-disable-next-line @typescript-eslint/no-var-requires
+        const { ElementService } = require('./ElementService');
+        const cubeService = new CubeService(this.rest);
+        const elementService = new ElementService(this.rest);
+        const measureDimension: string = await cubeService.getMeasureDimension(cubeName);
+        const typesMap = await elementService.getElementTypesFromAllHierarchies(measureDimension);
+        const result: Record<string, string> = {};
+        // CaseAndSpaceInsensitiveDict exposes entries() like a Map; flatten to a plain object.
+        for (const [name, type] of typesMap.entries()) {
+            result[name] = type;
+        }
         return result;
     }
 

--- a/src/services/CellService.ts
+++ b/src/services/CellService.ts
@@ -12,7 +12,7 @@ import { SandboxService } from './SandboxService';
 import { OperationStatus, OperationType } from './AsyncOperationService';
 import { MDXView } from '../objects/MDXView';
 import { Process } from '../objects/Process';
-import { TM1Exception } from '../exceptions/TM1Exception';
+import { TM1Exception, TM1pyWriteFailureException, TM1pyWritePartialFailureException } from '../exceptions/TM1Exception';
 import {
     formatUrl, escapeODataValue, lowerAndDropSpaces, extractCompactJsonCellset, resemblesMdx, getCube,
     CaseAndSpaceInsensitiveTuplesDict,
@@ -22,6 +22,8 @@ import {
     csvRowToString,
     dimensionNamesFromElementUniqueNames,
     CsvDialect,
+    frameToSignificantDigits,
+    verifyVersion,
 } from '../utils/Utils';
 
 // ─── Public interface types for CellService extract methods ───────────────
@@ -184,6 +186,9 @@ export interface WriteOptions {
     deactivate_transaction_log?: boolean;
     reactivate_transaction_log?: boolean;
     use_changeset?: boolean;
+    remove_blob?: boolean;
+    clear_view?: string;
+    is_attribute_cube?: boolean;
 }
 
 export interface MDXViewOptions {
@@ -397,27 +402,31 @@ export class CellService {
     }
 
     /**
-     * Write a single cell value to a cube
+     * Write a single cell value to a cube. Mirrors tm1py write_value (CellService.py:1142-1171):
+     * value is the FIRST positional argument; the body's Value lives at the top level (not nested
+     * inside Cells[0]); the sandbox is appended via the !sandbox= write-side query parameter; and
+     * Python's truthiness rule (`str(value) if value else ""`) collapses 0/null/'' to ''.
      */
     public async writeValue(
-        cubeName: string,
-        coordinates: string[],
         value: any,
+        cubeName: string,
+        elementTuple: string[],
         dimensions?: string[],
-        sandbox_name?: string
-    ): Promise<void> {
+        sandboxName?: string
+    ): Promise<any> {
         const dims = dimensions || await this.getDimensionNamesForWriting(cubeName);
-        const url = formatUrl("/Cubes('{}')/tm1.Update", cubeName)
-            + (sandbox_name ? `?$sandbox=${sandbox_name}` : '');
-        const body = {
+        let url = formatUrl("/Cubes('{}')/tm1.Update", cubeName);
+        if (sandboxName) url += `?!sandbox=${encodeURIComponent(sandboxName)}`;
+        const body: Record<string, unknown> = {
             Cells: [{
                 'Tuple@odata.bind': dims.map((d, i) =>
-                    `Dimensions('${escapeODataValue(d)}')/Hierarchies('${escapeODataValue(d)}')/Elements('${escapeODataValue(coordinates[i])}')`
+                    formatUrl("Dimensions('{}')/Hierarchies('{}')/Elements('{}')",
+                        escapeODataValue(d), escapeODataValue(d), escapeODataValue(elementTuple[i]))
                 ),
-                Value: value
-            }]
+            }],
+            Value: value ? String(value) : '',
         };
-        await this.rest.post(url, JSON.stringify(body));
+        return await this.rest.post(url, JSON.stringify(body));
     }
 
     /**
@@ -443,16 +452,43 @@ export class CellService {
     }
 
     /**
-     * Write multiple cell values using dictionary format
-     * {coordinate_string: value} format for bulk writes
+     * Write multiple cell values. Mirrors tm1py write (CellService.py:1173-1269): routes to
+     * writeThroughUnboundProcess when use_ti=true, writeThroughBlob when use_blob=true, else
+     * writeThroughCellset. The third positional argument tolerates the legacy `dimensions[]`
+     * form so existing callers like `write(cube, cells, undefined, opts)` keep working; the
+     * tm1py-aligned shape is `write(cube, cells, options)`.
      */
     public async write(
         cubeName: string,
         cellsetAsDict: CellsetDict,
-        dimensions?: string[],
-        options: WriteOptions = {}
-    ): Promise<void> {
-        return this.writeThroughCellset(cubeName, cellsetAsDict, dimensions, options);
+        optionsOrDimensions?: WriteOptions | string[],
+        legacyOptions?: WriteOptions
+    ): Promise<string | undefined> {
+        let dimensions: string[] | undefined;
+        let options: WriteOptions = {};
+        if (Array.isArray(optionsOrDimensions)) {
+            dimensions = optionsOrDimensions;
+            options = legacyOptions ?? {};
+        } else if (optionsOrDimensions !== undefined) {
+            options = optionsOrDimensions;
+        } else if (legacyOptions !== undefined) {
+            // Legacy 4-arg shape `write(cube, cells, undefined, opts)`.
+            options = legacyOptions;
+        }
+
+        if (options.clear_view && !options.use_blob) {
+            throw new Error("'clear_view' can only be used in conjunction with 'use_blob'");
+        }
+        if (options.use_ti) {
+            await this.writeThroughUnboundProcess(cubeName, cellsetAsDict, { ...options, dimensions });
+            return undefined;
+        }
+        if (options.use_blob) {
+            await this.writeThroughBlob(cubeName, cellsetAsDict, { ...options, dimensions });
+            return undefined;
+        }
+        await this.writeThroughCellset(cubeName, cellsetAsDict, dimensions, options);
+        return undefined;
     }
 
     private async writeThroughCellset(
@@ -769,114 +805,268 @@ export class CellService {
     }
 
     /**
-     * Write data through blob file (fastest method for large datasets)
+     * Write data via an uploaded CSV blob + unbound TI process. Mirrors tm1py write_through_blob
+     * (CellService.py:1425-1493). The CSV is written with QUOTE_ALL semantics and `\r\n`
+     * terminators (Python `csv.writer` defaults); the TI process built by `_buildBlobToCubeProcess`
+     * reads it via an ASCII data source and dispatches CellPutN / CellIncrementN /
+     * CellPutProportionalSpread / CellPutS based on the measure element's type. Transaction-log
+     * toggles wrap the work to mirror tm1py's @manage_transaction_log decorator.
      */
     public async writeThroughBlob(
         cubeName: string,
         cellsetAsDict: CellsetDict,
-        options: WriteOptions = {}
+        options: {
+            increment?: boolean;
+            sandbox_name?: string;
+            skip_non_updateable?: boolean;
+            remove_blob?: boolean;
+            dimensions?: string[];
+            allow_spread?: boolean;
+            clear_view?: string;
+            deactivate_transaction_log?: boolean;
+            reactivate_transaction_log?: boolean;
+        } = {}
     ): Promise<void> {
-        /** Write data using blob files for maximum performance
-         * Recommended for datasets > 1M cells
-         *
-         * :param cube_name: Name of the cube
-         * :param cellset_as_dict: Dictionary of coordinates and values
-         * :param options: Write options
-         */
-
-        // Import FileService to avoid circular dependency
+        const removeBlob = options.remove_blob ?? true;
         // eslint-disable-next-line @typescript-eslint/no-var-requires
         const { FileService } = require('./FileService');
         const fileService = new FileService(this.rest);
+        const dims = options.dimensions ?? await this.getDimensionNamesForWriting(cubeName);
 
-        try {
-            // Convert cellset to CSV format for blob upload
-            const csvContent = this.cellsetToCsv(cellsetAsDict);
-            const blobFileName = `tm1npm_blob_${Date.now()}.csv`;
+        // eslint-disable-next-line @typescript-eslint/no-var-requires
+        const crypto = require('crypto');
+        const uniqueName = `tm1py_${crypto.randomBytes(6).toString('hex')}`;
+        const fileName = `${uniqueName}.csv`;
 
-            // Upload blob file
-            await fileService.create(blobFileName, csvContent);
-
-            // Create TI process to import blob data
-            if (!this.processService) {
-                throw new Error('ProcessService is required for blob operations');
-            }
-
-            const processName = `}tm1npm_blob_import_${Date.now()}`;
-            const tiCode = this.generateBlobImportTiCode(
-                cubeName,
-                blobFileName,
-                Object.keys(cellsetAsDict)[0]?.split(',') || [],
-                options
+        // CSV: tm1py uses csv.writer(QUOTE_ALL, delimiter=','). Quote every field; double internal
+        // quotes; replace \r/\n in string values with empty (mirrors tm1py:1463 cleanup).
+        const csvLines: string[] = [];
+        for (const [coordKey, value] of Object.entries(cellsetAsDict)) {
+            const elements = coordKey.split(',');
+            const cleanedValue = typeof value === 'string'
+                ? value.replace(/[\r\n]/g, '')
+                : (value === null || value === undefined ? '' : String(value));
+            const fields = [...elements, cleanedValue].map(s =>
+                `"${String(s).replace(/"/g, '""')}"`
             );
+            csvLines.push(fields.join(','));
+        }
+        // Python csv.writer defaults to lineterminator='\r\n' AND writes a terminator after every
+        // row (including the last). Matching exactly so the bytes-on-wire are identical to tm1py.
+        const csvBody = csvLines.length > 0 ? csvLines.join('\r\n') + '\r\n' : '';
+        await fileService.create(fileName, Buffer.from(csvBody, 'utf-8'));
 
-            const processBody = {
-                Name: processName,
-                PrologProcedure: tiCode,
-                MetadataProcedure: '',
-                DataProcedure: '',
-                EpilogProcedure: `DeleteFile('${blobFileName}');`
-            };
-
-            // Execute import process
-            await this.rest.post('/Processes', processBody);
-            await this.rest.post(`/Processes('${processName}')/tm1.ExecuteProcess`, {});
-
-            // Cleanup
-            await this.rest.delete(`/Processes('${processName}')`);
-
-        } catch (error) {
-            throw new Error(`Blob write operation failed: ${error}`);
+        if (options.deactivate_transaction_log) {
+            await this.deactivateTransactionlog(cubeName);
+        }
+        try {
+            const proc = await this._buildBlobToCubeProcess({
+                cubeName,
+                processName: uniqueName,
+                blobFilename: fileName,
+                dimensions: dims,
+                increment: options.increment ?? false,
+                skipNonUpdateable: options.skip_non_updateable ?? false,
+                sandboxName: options.sandbox_name,
+                allowSpread: options.allow_spread ?? false,
+                clearView: options.clear_view,
+            });
+            const response = await this.rest.post(
+                '/ExecuteProcessWithReturn?$expand=*',
+                JSON.stringify({ Process: proc.bodyAsDict })
+            );
+            const status: string = response?.data?.ProcessExecuteStatusCode ?? 'Unknown';
+            if (status !== 'CompletedSuccessfully') {
+                const logFile = response?.data?.ErrorLogFile?.Filename ?? null;
+                if (status === 'HasMinorErrors') {
+                    throw new TM1pyWritePartialFailureException([status], [logFile], 1);
+                }
+                throw new TM1pyWriteFailureException([status], [logFile]);
+            }
+        } finally {
+            if (removeBlob) {
+                // tm1py does not suppress; we tolerate cleanup failures so that the original error
+                // (if any) propagates instead of being masked by a delete failure.
+                try { await fileService.delete(fileName); } catch { /* ignore */ }
+            }
+            if (options.reactivate_transaction_log) {
+                await this.activateTransactionlog(cubeName);
+            }
         }
     }
 
     /**
-     * Write data through DataFrame format
+     * Build the unbound TI Process that loads a CSV blob into a cube. Mirrors tm1py
+     * _build_blob_to_cube_process (CellService.py:1495-1608) including the `% \n` line
+     * continuation between alternative ElementType checks and the v11 `.blb` filename suffix.
+     */
+    private async _buildBlobToCubeProcess(args: {
+        cubeName: string;
+        processName: string;
+        blobFilename: string;
+        dimensions: string[];
+        increment: boolean;
+        skipNonUpdateable: boolean;
+        sandboxName?: string;
+        allowSpread: boolean;
+        clearView?: string;
+    }): Promise<Process> {
+        const version = this.rest.version ?? '11.8.0';
+        let blobFilename = args.blobFilename;
+        // verifyVersion takes (actualVersion, requiredVersion). For pre-v12 servers (i.e. v11)
+        // TM1 auto-appends `.blb` to documents created via the contents API, so we must include
+        // it in the data source name (mirrors tm1py CellService.py:1509).
+        if (!verifyVersion(version, '12')) {
+            blobFilename += '.blb';
+        }
+        const proc = new Process(
+            args.processName,
+            false,
+            undefined,
+            undefined,
+            undefined,
+            undefined,
+            '', '', '', '',
+            'ASCII',         // datasourceType
+            '.', ',', 'Character', 0, '"', '',
+            blobFilename,    // datasourceDataSourceNameForClient
+            blobFilename,    // datasourceDataSourceNameForServer
+        );
+
+        // tm1py CellService.py:1527 calls self.generate_enable_sandbox_ti(sandbox_name) here,
+        // which validates the sandbox exists (raises ValueError otherwise) — preserve that check.
+        const enableSandboxLine = await this.generateEnableSandboxTi(args.sandboxName);
+
+        let prolog = `\n        SetInputCharacterSet('TM1CS_UTF8');\n        ${enableSandboxLine}\n        `;
+        if (args.clearView) {
+            prolog += `\rViewZeroOut('${args.cubeName}', '${args.clearView}');\r`;
+        }
+        proc.prologProcedure = prolog;
+
+        const dimVars = args.dimensions.map((_, n) => `v${n + 1}`);
+        for (const v of dimVars) proc.addVariable(v, 'String');
+        const cubeMeasureVar = dimVars[dimVars.length - 1];
+        const commaSepVars = dimVars.join(',');
+        const valueVar = 'vValue';
+        proc.addVariable(valueVar, 'String');
+
+        const cellIsUpdateablePre = args.skipNonUpdateable
+            ? `If( CellIsUpdateable('${args.cubeName}',${commaSepVars}) = 1 );`
+            : '';
+        const cellIsUpdateablePost = args.skipNonUpdateable
+            ? `\rElse;\r   ItemSkip;\rEndIf;\r`
+            : '';
+
+        const numericFn = args.cubeName.toLowerCase().startsWith('}elementattributes_')
+            ? 'CellPutN'
+            : (args.increment ? 'CellIncrementN' : 'CellPutN');
+
+        const cubeMeasure = args.dimensions[args.dimensions.length - 1];
+        const measureTypeEq = `ElementType('${cubeMeasure}', '', ${cubeMeasureVar}) @= `;
+        const numericWriteCondition = ["'N'", "'AN'", "'C'", "''"]
+            .map(t => measureTypeEq + t).join('% \n');
+        const anyCElementInWrite = args.dimensions.map(
+            (dim, i) => `ElementType('${dim}', '', ${dimVars[i]}) @= 'C'`
+        ).join('% \n');
+
+        const numericWithSpread = `\n            nValue = StringToNumber(${valueVar});\n            IF(${anyCElementInWrite});\n                CellPutProportionalSpread(nValue,'${args.cubeName}',${commaSepVars});\n            ELSE;\n                ${numericFn}(nValue,'${args.cubeName}',${commaSepVars});\n            ENDIF;\n            `;
+        const numericWithoutSpread = `\n            nValue = StringToNumber(${valueVar});\n            ${numericFn}(nValue,'${args.cubeName}',${commaSepVars});\n            `;
+        const stringCondition = `\n            ElementType('${cubeMeasure}', '', ${cubeMeasureVar}) @= 'S' % \n            ElementType('${cubeMeasure}', '', ${cubeMeasureVar}) @= 'AS' % \n            ElementType('${cubeMeasure}', '', ${cubeMeasureVar}) @= 'AA'\n            `;
+        const stringWrite = `\n            sValue = ${valueVar};\n            CellPutS(sValue,'${args.cubeName}',${commaSepVars}); \n            `;
+
+        const inputStatement = `\n        If(${numericWriteCondition});\n            ${args.allowSpread ? numericWithSpread : numericWithoutSpread}\n        ElseIf(${stringCondition});\n            ${stringWrite}\n        EndIf;`;
+
+        proc.dataProcedure = cellIsUpdateablePre + inputStatement + cellIsUpdateablePost;
+        return proc;
+    }
+
+    /**
+     * Write data through a chunked DataFrame. Mirrors tm1py write_dataframe (CellService.py:860):
+     * accepts either a `DataFrame` ({columns, data}) or a plain 2D array; supports
+     * `static_dimension_elements` and `infer_column_order`; aggregates duplicate intersections
+     * for numeric values when `sum_numeric_duplicates` is true; delegates to `write()` for
+     * routing to writeThroughUnboundProcess / writeThroughBlob / writeThroughCellset.
      */
     public async writeDataframe(
-        cubeName: string, 
-        dataFrame: any[][],  // Array of arrays representing tabular data
-        dimensions: string[],
-        options: WriteOptions = {}
-    ): Promise<void> {
-        const cells = dataFrame.map(row => ({
-            Coordinates: row.slice(0, dimensions.length).map(coord => ({ Name: coord })),
-            Value: row[dimensions.length] // Last column is the value
-        }));
+        cubeName: string,
+        data: DataFrame | (string | number | null)[][],
+        options: WriteOptions & {
+            dimensions?: string[];
+            sum_numeric_duplicates?: boolean;
+            static_dimension_elements?: Record<string, string>;
+            infer_column_order?: boolean;
+        } = {}
+    ): Promise<string | undefined> {
+        const dims = options.dimensions ?? await this.getDimensionNamesForWriting(cubeName);
+        const lc = (s: string) => s.toLowerCase().replace(/\s+/g, '');
 
-        let url = `/Cubes('${cubeName}')/tm1.Update`;
-        
-        if (options.sandbox_name) {
-            url += `?$sandbox=${options.sandbox_name}`;
+        let columns: string[];
+        let rows: (string | number | null)[][];
+        if (Array.isArray(data)) {
+            columns = [...dims, '__value__'];
+            rows = data.map(r => [...r]);
+        } else {
+            columns = [...data.columns];
+            rows = data.data.map(r => [...r]);
         }
 
-        const body = {
-            Cells: cells,
-            ...(options.increment && { Increment: true }),
-            ...(options.allow_spread && { AllowSpread: true })
-        };
+        if (options.static_dimension_elements) {
+            const lcCols = columns.map(lc);
+            for (const [dim, elem] of Object.entries(options.static_dimension_elements)) {
+                if (lcCols.includes(lc(dim))) {
+                    throw new Error(
+                        `static_dimension_elements conflict: '${dim}' is also a dataframe column. ` +
+                        `Either remove the key/value pair or omit the column from the dataframe.`
+                    );
+                }
+                columns.push(dim);
+                lcCols.push(lc(dim));
+                rows = rows.map(r => [...r, elem]);
+            }
+        }
 
-        await this.rest.patch(url, body);
+        const inferOrder = options.static_dimension_elements ? true : (options.infer_column_order ?? false);
+        if (inferOrder) {
+            const lcCols = columns.map(lc);
+            const lcDims = dims.map(lc);
+            const remaining = lcCols.filter(c => !lcDims.includes(c));
+            const finalLc = [...lcDims, ...remaining];
+            const indexMap = finalLc.map(c => lcCols.indexOf(c));
+            rows = rows.map(r => indexMap.map(i => r[i]));
+            columns = indexMap.map(i => columns[i]);
+        }
+
+        if (rows.length > 0 && rows[0].length !== dims.length + 1) {
+            throw new Error("Number of columns in 'data' must equal number of dimensions in cube + 1");
+        }
+
+        const cells: CellsetDict = {};
+        const sumDup = options.sum_numeric_duplicates ?? true;
+        for (const row of rows) {
+            const elems = row.slice(0, -1).map(v => String(v ?? '')).join(',');
+            const v = row[row.length - 1];
+            if (sumDup && elems in cells && typeof v === 'number' && typeof cells[elems] === 'number') {
+                cells[elems] = (cells[elems] as number) + v;
+            } else {
+                cells[elems] = v as any;
+            }
+        }
+        // Forward routing flags (use_ti, use_blob, etc.) and write-side options to write().
+        return this.write(cubeName, cells, options);
     }
 
     /**
-     * Write data asynchronously by chunking and dispatching to writeThroughBlob
-     * (parity with tm1py.write_async, which uses ThreadPoolExecutor + write(use_blob=True)).
-     *
-     * Documented parity gaps (see IMPLEMENTATION_PLAN.md):
-     * - Only options honored by the underlying writeThroughBlob (sandbox_name, increment,
-     *   deactivate/reactivate_transaction_log, use_blob, use_changeset) flow through. tm1py's
-     *   `dimensions`, `precision`, `measure_dimension_elements`, `skip_non_updateable`, and
-     *   transaction-log toggles are not yet wired through writeThroughBlob and are deliberately
-     *   omitted from this signature so misuse is caught at compile time.
-     * - Per-chunk failures aggregate into a TM1Exception with chunk count (tm1py raises a
-     *   structured TM1pyWritePartialFailureException; that exception type is not yet ported).
+     * Write asynchronously by chunking and dispatching to writeThroughBlob in parallel.
+     * Mirrors the spirit of tm1py.write_async (which uses ThreadPoolExecutor + write_through_blob);
+     * partial failures aggregate into a TM1pyWritePartialFailureException.
      */
     public async writeAsync(
         cubeName: string,
         cellsetAsDict: CellsetDict,
-        options: Pick<WriteOptions, 'sandbox_name' | 'increment' | 'deactivate_transaction_log' | 'reactivate_transaction_log' | 'use_changeset'>
-            & { slice_size?: number; max_workers?: number } = {}
+        options: Pick<WriteOptions,
+            'sandbox_name' | 'increment' | 'deactivate_transaction_log' |
+            'reactivate_transaction_log' | 'skip_non_updateable' | 'allow_spread' | 'remove_blob'>
+            & { slice_size?: number; max_workers?: number; dimensions?: string[] } = {}
     ): Promise<string | undefined> {
         const sliceSize = options.slice_size ?? 250_000;
         const maxWorkers = options.max_workers ?? 8;
@@ -886,51 +1076,358 @@ export class CellService {
             chunks.push(Object.fromEntries(entries.slice(i, i + sliceSize)));
         }
 
-        const failures: any[] = [];
+        const blobOpts = {
+            sandbox_name: options.sandbox_name,
+            increment: options.increment,
+            deactivate_transaction_log: options.deactivate_transaction_log,
+            reactivate_transaction_log: options.reactivate_transaction_log,
+            skip_non_updateable: options.skip_non_updateable,
+            allow_spread: options.allow_spread,
+            remove_blob: options.remove_blob,
+            dimensions: options.dimensions,
+        };
+
+        const failures: unknown[] = [];
         for (let i = 0; i < chunks.length; i += maxWorkers) {
             const batch = chunks.slice(i, i + maxWorkers);
             const results = await Promise.allSettled(
-                batch.map(c => this.writeThroughBlob(cubeName, c, { ...options, use_blob: true }))
+                batch.map(c => this.writeThroughBlob(cubeName, c, blobOpts))
             );
             for (const r of results) if (r.status === 'rejected') failures.push(r.reason);
         }
         if (failures.length) {
-            throw new TM1Exception(
-                `writeAsync partial failure: ${failures.length}/${chunks.length} chunks failed: ` +
-                failures.map(f => f?.message || String(f)).join('; ')
-            );
+            const messages = failures.map(f => (f as { message?: string })?.message ?? String(f));
+            throw new TM1pyWritePartialFailureException(messages, [], chunks.length);
         }
         return undefined;
     }
 
     /**
-     * Write through unbound process (TI-based writing)
+     * Write data via an unbound TI process whose Prolog/Epilog contain CellPutN/CellPutS
+     * statements. Mirrors tm1py write_through_unbound_process (CellService.py:1328-1419).
+     * Routes attribute cubes (`}ElementAttributes_*`) through _buildAttributeUpdateStatements;
+     * regular cubes through _buildCellUpdateStatements. Statements are chunked at every
+     * 2*Process.maxStatements(version) boundary, mirroring tm1py's loop precisely
+     * (`if n > 0 and n % (max_statements * 2) == 0`). Transaction-log toggles wrap the work
+     * to mirror tm1py's @manage_transaction_log decorator.
      */
     public async writeThroughUnboundProcess(
         cubeName: string,
         cellsetAsDict: CellsetDict,
-        processName?: string,
-        options: WriteOptions = {}
-    ): Promise<any> {
-        // Create TI statements for bulk writing
-        let tiStatements = '';
-        
-        for (const [coordinates, value] of Object.entries(cellsetAsDict)) {
-            const coords = coordinates.split(',').map(s => `'${s.trim()}'`).join(',');
-            tiStatements += `CubeDataSet('${cubeName}', ${coords}, ${value});\n`;
+        options: {
+            increment?: boolean;
+            sandbox_name?: string;
+            precision?: number;
+            skip_non_updateable?: boolean;
+            measure_dimension_elements?: Record<string, string>;
+            is_attribute_cube?: boolean;
+            dimensions?: string[];
+            allow_spread?: boolean;
+            deactivate_transaction_log?: boolean;
+            reactivate_transaction_log?: boolean;
+        } = {}
+    ): Promise<void> {
+        const isAttributeCube = options.is_attribute_cube
+            ?? cubeName.toLowerCase().startsWith('}elementattributes_');
+        const enableSandbox = await this.generateEnableSandboxTi(options.sandbox_name);
+
+        let measureDimensionElements: Record<string, string> | undefined = options.measure_dimension_elements;
+        if (!measureDimensionElements) {
+            // tm1py returns a flat dict {elementName: type}. The existing tm1npm helper returns
+            // {dimension: string[]}, so flatten it (every measure element treated as Numeric,
+            // matching tm1py's element_service.get_element_types_from_all_hierarchies fallback).
+            const fetched = await this.getElementsFromAllMeasureHierarchies(cubeName);
+            measureDimensionElements = {};
+            for (const elements of Object.values(fetched)) {
+                for (const e of elements) measureDimensionElements[e] = 'Numeric';
+            }
         }
 
-        const tempProcessName = processName || `tm1npm_write_${Date.now()}`;
-        
-        // Execute TI code directly
-        const url = "/ExecuteProcessWithReturn";
-        const body = {
-            Name: tempProcessName,
-            PrologProcedure: tiStatements,
-            ...(options.sandbox_name && { Sandbox: options.sandbox_name })
-        };
+        let dims = options.dimensions;
+        if (!isAttributeCube && !dims && options.allow_spread) {
+            dims = await this.getDimensionNamesForWriting(cubeName);
+        }
 
-        return await this.rest.post(url, body);
+        const statements = isAttributeCube
+            ? CellService._buildAttributeUpdateStatements({
+                cubeName,
+                cellsetAsDict,
+                precision: options.precision,
+                skipNonUpdateable: options.skip_non_updateable ?? false,
+                measureDimensionElements: measureDimensionElements ?? {},
+            })
+            : CellService._buildCellUpdateStatements({
+                cubeName,
+                cellsetAsDict,
+                increment: options.increment ?? false,
+                measureDimensionElements: measureDimensionElements ?? {},
+                precision: options.precision,
+                skipNonUpdateable: options.skip_non_updateable ?? false,
+                dimensions: dims,
+                allowSpread: options.allow_spread ?? false,
+            });
+
+        if (options.deactivate_transaction_log) {
+            await this.deactivateTransactionlog(cubeName);
+        }
+        try {
+            const version = this.rest.version ?? "11.8.0";
+            const maxStmts = Process.maxStatements(version);
+            const successes: boolean[] = [];
+            const statuses: string[] = [];
+            const logFiles: (string | null)[] = [];
+            let chunk: string[] = [];
+
+            for (let n = 0; n < statements.length; n++) {
+                chunk.push(statements[n]);
+                if (n > 0 && n % (maxStmts * 2) === 0) {
+                    const [s, st, lf] = await this._executeWriteStatements(chunk, enableSandbox);
+                    successes.push(s);
+                    if (!s) { statuses.push(st); logFiles.push(lf); }
+                    chunk = [];
+                }
+            }
+            const [s, st, lf] = await this._executeWriteStatements(chunk, enableSandbox);
+            successes.push(s);
+            if (!s) { statuses.push(st); logFiles.push(lf); }
+
+            if (!successes.some(x => x)) {
+                if (statuses.includes('HasMinorErrors')) {
+                    throw new TM1pyWritePartialFailureException(statuses, logFiles, successes.length);
+                }
+                throw new TM1pyWriteFailureException(statuses, logFiles);
+            }
+            if (!successes.every(x => x)) {
+                throw new TM1pyWritePartialFailureException(statuses, logFiles, successes.length);
+            }
+        } finally {
+            if (options.reactivate_transaction_log) {
+                await this.activateTransactionlog(cubeName);
+            }
+        }
+    }
+
+    /**
+     * Build TI CellPutN/CellPutS statements for a cellset. Mirrors tm1py
+     * _build_cell_update_statements (CellService.py:1799-1890) character-for-character:
+     * - Element-type lookup defaults to 'Numeric' (so unknown measures trigger TI minor errors).
+     * - String values: escape `'`→`''`, strip CR/LF, single-quote wrap.
+     * - Numeric values: frameToSignificantDigits or precision-formatted toFixed; unparseable
+     *   strings pass through raw; null/undefined → '0'.
+     * - skipNonUpdateable wraps each statement in `IF(CellIsUpdateable(...)=1, <stmt>, 0);`.
+     * - allowSpread wraps with `IF(<any C>); CellPutProportionalSpread(...); ELSE; <stmt>; ENDIF;`.
+     */
+    private static _buildCellUpdateStatements(args: {
+        cubeName: string;
+        cellsetAsDict: CellsetDict;
+        increment: boolean;
+        measureDimensionElements: Record<string, string>;
+        precision?: number;
+        skipNonUpdateable: boolean;
+        dimensions?: string[];
+        allowSpread: boolean;
+    }): string[] {
+        const statements: string[] = [];
+        for (const [coordKey, value] of Object.entries(args.cellsetAsDict)) {
+            const coordinates = coordKey.split(',');
+            let measureElement = coordinates[coordinates.length - 1];
+            let elementType = args.measureDimensionElements[measureElement];
+            if (elementType === undefined) {
+                if (measureElement.includes(':')) {
+                    measureElement = measureElement.split(':')[1];
+                    elementType = args.measureDimensionElements[measureElement] ?? 'Numeric';
+                } else {
+                    elementType = 'Numeric';
+                }
+            }
+
+            let functionStr: string;
+            let valueStr: string;
+            if (elementType === 'String') {
+                functionStr = 'CellPutS(';
+                const cleaned = String(value)
+                    .replace(/'/g, "''")
+                    .replace(/[\r\n]/g, '');
+                valueStr = `'${cleaned}'`;
+            } else {
+                functionStr = args.increment ? 'CellIncrementN(' : 'CellPutN(';
+                if (typeof value === 'string') {
+                    // Python's float() rejects strings with non-numeric tails ("123abc" → ValueError);
+                    // tm1py catches and falls through to raw passthrough. JS parseFloat is permissive,
+                    // so we use Number() (strict end-to-end parse) plus an empty-string guard.
+                    const trimmed = value.trim();
+                    const parsed = trimmed === '' ? NaN : Number(trimmed);
+                    if (Number.isNaN(parsed)) {
+                        valueStr = String(value);
+                    } else if (args.precision === undefined) {
+                        valueStr = frameToSignificantDigits(parsed);
+                    } else {
+                        valueStr = parsed.toFixed(args.precision);
+                    }
+                } else if (value === null || value === undefined) {
+                    valueStr = '0';
+                } else {
+                    if (args.precision === undefined) {
+                        valueStr = frameToSignificantDigits(Number(value));
+                    } else {
+                        valueStr = Number(value).toFixed(args.precision);
+                    }
+                }
+            }
+
+            const commaSeparatedElements = coordinates
+                .map(e => `'${e.replace(/'/g, "''")}'`)
+                .join(',');
+
+            let cellIsUpdateablePre = '';
+            let cellIsUpdateablePost = ';';
+            if (args.skipNonUpdateable) {
+                cellIsUpdateablePre = `IF(CellIsUpdateable('${args.cubeName}', ${commaSeparatedElements})=1,`;
+                cellIsUpdateablePost = ',0);';
+            }
+
+            let consolidatedSpreadCheckStart = '';
+            let consolidatedSpreadCheckEnd = '';
+            if (args.allowSpread) {
+                const dimsForSpread = args.dimensions ?? [];
+                const anyCElement = dimsForSpread
+                    .map((dim, i) => `ElementType('${dim}', '', '${coordinates[i] ?? ''}') @= 'C'`)
+                    .join('% \n');
+                consolidatedSpreadCheckStart =
+                    `\n                    IF(${anyCElement});\n` +
+                    `                        CellPutProportionalSpread(${valueStr},'${args.cubeName}',${commaSeparatedElements});\n` +
+                    `                    ELSE;\n                    `;
+                consolidatedSpreadCheckEnd = 'ENDIF;';
+            }
+
+            const statement =
+                cellIsUpdateablePre +
+                consolidatedSpreadCheckStart +
+                functionStr +
+                valueStr +
+                `,'${args.cubeName}',` +
+                commaSeparatedElements +
+                ')' +
+                cellIsUpdateablePost +
+                consolidatedSpreadCheckEnd;
+
+            statements.push(statement);
+        }
+        return statements;
+    }
+
+    /**
+     * Build TI ElementAttrPutN/ElementAttrPutS statements for an attribute cube. Mirrors tm1py
+     * _build_attribute_update_statements (CellService.py:1722-1798). The dimension name is
+     * derived from the cube name (slice off the `}ElementAttributes_` prefix). The first
+     * coordinate may carry a `hierarchy:element` form; the last coordinate is the attribute name.
+     */
+    private static _buildAttributeUpdateStatements(args: {
+        cubeName: string;
+        cellsetAsDict: CellsetDict;
+        precision?: number;
+        skipNonUpdateable: boolean;
+        measureDimensionElements: Record<string, string>;
+    }): string[] {
+        const dimensionName = args.cubeName.slice(19); // length of "}ElementAttributes_"
+        const statements: string[] = [];
+
+        for (const [coordKey, value] of Object.entries(args.cellsetAsDict)) {
+            const coordinates = coordKey.split(',');
+            const rawElementName = coordinates[0];
+            let hierarchyName: string;
+            let elementName: string;
+            if (rawElementName.includes(':')) {
+                const idx = rawElementName.indexOf(':');
+                hierarchyName = rawElementName.slice(0, idx);
+                elementName = rawElementName.slice(idx + 1);
+            } else {
+                elementName = rawElementName;
+                hierarchyName = dimensionName;
+            }
+            let attributeName = coordinates[coordinates.length - 1];
+
+            let attributeType: string | undefined = args.measureDimensionElements[attributeName];
+            if (attributeType === undefined) {
+                if (attributeName.includes(':')) {
+                    attributeName = attributeName.split(':')[1];
+                    attributeType = args.measureDimensionElements[attributeName] ?? 'String';
+                } else {
+                    attributeType = 'String';
+                }
+            }
+
+            let functionStr: string;
+            let valueStr: string;
+            if (attributeType === 'Numeric') {
+                functionStr = 'ElementAttrPutN(';
+                if (typeof value === 'string') {
+                    // tm1py CellService.py:1758 calls `format(float(value), f".{precision}f")`
+                    // unconditionally. With `precision is None`, that yields the invalid format spec
+                    // ".Nonef" → ValueError, caught → raw passthrough. With a numeric precision and
+                    // a non-numeric string, the inner `float()` raises → also raw passthrough.
+                    if (args.precision === undefined) {
+                        valueStr = String(value);
+                    } else {
+                        const trimmed = value.trim();
+                        const parsed = trimmed === '' ? NaN : Number(trimmed);
+                        valueStr = Number.isNaN(parsed)
+                            ? String(value)
+                            : parsed.toFixed(args.precision);
+                    }
+                } else if (value === null || value === undefined) {
+                    valueStr = '0';
+                } else {
+                    valueStr = args.precision === undefined
+                        ? frameToSignificantDigits(Number(value))
+                        : Number(value).toFixed(args.precision);
+                }
+            } else {
+                functionStr = 'ElementAttrPutS(';
+                const cleaned = escapeODataValue(String(value)).replace(/[\r\n]/g, '');
+                valueStr = `'${cleaned}'`;
+            }
+            valueStr += ',';
+
+            const commaArgs = [dimensionName, hierarchyName, elementName, attributeName]
+                .map(e => `'${e.replace(/'/g, "''")}'`)
+                .join(',');
+
+            let cellIsUpdateablePre = '';
+            let cellIsUpdateablePost = ';';
+            if (args.skipNonUpdateable) {
+                cellIsUpdateablePre = `IF(CellIsUpdateable('${args.cubeName}', '${rawElementName}', '${attributeName}')=1,`;
+                cellIsUpdateablePost = ',0);';
+            }
+
+            statements.push(
+                cellIsUpdateablePre + functionStr + valueStr + commaArgs + ')' + cellIsUpdateablePost
+            );
+        }
+        return statements;
+    }
+
+    /**
+     * Execute a list of TI statements through an unbound process. Mirrors tm1py
+     * _execute_write_statements (CellService.py:1916-1925): the first `maxStatements` go in
+     * Prolog (prefixed with the enable-sandbox snippet); the rest go in Epilog.
+     * Returns [success, status, errorLogFile].
+     */
+    private async _executeWriteStatements(
+        statements: string[],
+        enableSandbox: string
+    ): Promise<[boolean, string, string | null]> {
+        if (statements.length === 0) return [true, 'CompletedSuccessfully', null];
+        const version = this.rest.version ?? "11.8.0";
+        const maxStmts = Process.maxStatements(version);
+        const proc = new Process('');
+        proc.prologProcedure = enableSandbox + statements.slice(0, maxStmts).join('\r');
+        proc.epilogProcedure = statements.slice(maxStmts).join('\r');
+        const url = '/ExecuteProcessWithReturn?$expand=*';
+        const response = await this.rest.post(url, JSON.stringify({ Process: proc.bodyAsDict }));
+        const status: string = response?.data?.ProcessExecuteStatusCode ?? 'Unknown';
+        const logFile: string | null = response?.data?.ErrorLogFile?.Filename ?? null;
+        return [status === 'CompletedSuccessfully', status, logFile];
     }
 
 
@@ -2587,64 +3084,6 @@ export class CellService {
     private buildPivotDataFrameFromCellset(cellset: any): DataFrame {
         // For now, return regular DataFrame - full pivot implementation would be more complex
         return this.buildDataFrameFromCellset(cellset);
-    }
-
-    /**
-     * Convert cellset dictionary to CSV format for blob operations
-     */
-    private cellsetToCsv(cellsetAsDict: CellsetDict): string {
-        const rows: string[] = [];
-
-        for (const [coordinates, value] of Object.entries(cellsetAsDict)) {
-            const elements = coordinates.split(',').map(el => el.trim());
-            const csvRow = [...elements, value].map(item =>
-                typeof item === 'string' && item.includes(',') ? `"${item}"` : item
-            ).join(',');
-            rows.push(csvRow);
-        }
-
-        return rows.join('\n');
-    }
-
-    /**
-     * Generate TI code for blob import operations
-     */
-    private generateBlobImportTiCode(
-        cubeName: string,
-        fileName: string,
-        dimensions: string[],
-        options: WriteOptions = {}
-    ): string {
-        const dimensionVars = dimensions.map((_, index) => `v${index + 1}`).join(', ');
-        const elementAssignments = dimensions.map((dim) =>
-            `ItemReject('${cubeName}:${fileName}');
-             ${dim} = CellGetS('${cubeName}', ${dimensionVars});`
-        ).join('\n');
-
-        const incrementCode = options.increment ?
-            `IF(CellGetN('${cubeName}', ${dimensionVars}) <> 0);
-               CellPutN(CellGetN('${cubeName}', ${dimensionVars}) + value, '${cubeName}', ${dimensionVars});
-             ELSE;
-               CellPutN(value, '${cubeName}', ${dimensionVars});
-             ENDIF;` :
-            `CellPutN(value, '${cubeName}', ${dimensionVars});`;
-
-        return `
-# Generated blob import process
-DataSourceType = 'CHARACTERDELIMITED';
-DataSourceNameForServer = '${fileName}';
-DataSourceNameForClient = '${fileName}';
-
-# Variables for dimensions and value
-${dimensions.map((_, index) => `v${index + 1} = '';`).join('\n')}
-value = 0;
-
-# Main import logic
-WHILE(DataSourceType = 'CHARACTERDELIMITED');
-    ${elementAssignments}
-    ${incrementCode}
-END;
-        `.trim();
     }
 
     private formatForDygraph(cellset: any): any {

--- a/src/services/CellService.ts
+++ b/src/services/CellService.ts
@@ -15,6 +15,7 @@ import { Process } from '../objects/Process';
 import { TM1Exception, TM1pyWriteFailureException, TM1pyWritePartialFailureException } from '../exceptions/TM1Exception';
 import {
     formatUrl, escapeODataValue, lowerAndDropSpaces, extractCompactJsonCellset, resemblesMdx, getCube,
+    CaseAndSpaceInsensitiveDict,
     CaseAndSpaceInsensitiveTuplesDict,
     RawCellsetDict,
     buildContentFromCellsetDict,
@@ -212,6 +213,20 @@ export interface MDXViewOptions {
      */
     use_compact_json?: boolean;
     mdx_headers?: boolean;
+}
+
+// tm1py uses CaseAndSpaceInsensitiveDict for measure-element lookups so callers can pass
+// "Comment" / "comment" / "Net Sales" / "netsales" interchangeably (matching how TM1 dimension
+// elements are referenced). Internal callers receive the case-insensitive dict; users of the
+// public WriteOptions surface may also supply a plain object — wrap it via toCaseInsensitiveDict
+// before any lookup.
+type MeasureDimensionElementsMap = CaseAndSpaceInsensitiveDict<string> | Record<string, string>;
+
+function toCaseInsensitiveDict(map: MeasureDimensionElementsMap): CaseAndSpaceInsensitiveDict<string> {
+    if (map instanceof CaseAndSpaceInsensitiveDict) return map;
+    const dict = new CaseAndSpaceInsensitiveDict<string>();
+    for (const [k, v] of Object.entries(map)) dict.set(k, v);
+    return dict;
 }
 
 export class CellService {
@@ -1108,9 +1123,15 @@ export class CellService {
     public async writeAsync(
         cubeName: string,
         cellsetAsDict: CellsetDict,
+        // tm1py write_async signature (CellService.py:970-984) exposes both `precision` and
+        // `measure_dimension_elements`. tm1py forwards them through write(use_blob=True) to
+        // write_through_blob via **kwargs, where they are silently dropped (the blob TI process
+        // doesn't honor them). We expose the same fields for API parity / mechanical port-ability,
+        // and likewise drop them in the blob path.
         options: Pick<WriteOptions,
             'sandbox_name' | 'increment' | 'deactivate_transaction_log' |
-            'reactivate_transaction_log' | 'skip_non_updateable' | 'allow_spread' | 'remove_blob'>
+            'reactivate_transaction_log' | 'skip_non_updateable' | 'allow_spread' | 'remove_blob' |
+            'precision' | 'measure_dimension_elements'>
             & { slice_size?: number; max_workers?: number; dimensions?: string[] } = {}
     ): Promise<string | undefined> {
         const sliceSize = options.slice_size ?? 250_000;
@@ -1227,8 +1248,13 @@ export class CellService {
                 ?? cubeName.toLowerCase().startsWith('}elementattributes_');
             const enableSandbox = await this.generateEnableSandboxTi(options.sandbox_name);
 
-            let measureDimensionElements: Record<string, string> | undefined = options.measure_dimension_elements;
-            if (!measureDimensionElements) {
+            // Lookups against the user's raw element-name coordinates need to be case-and-space
+            // insensitive (TM1 element names are matched that way). Wrap any user-supplied plain
+            // object so the dict's normalize-on-get behavior applies uniformly.
+            let measureDimensionElements: CaseAndSpaceInsensitiveDict<string>;
+            if (options.measure_dimension_elements) {
+                measureDimensionElements = toCaseInsensitiveDict(options.measure_dimension_elements);
+            } else {
                 // tm1py CellService.py:1906-1914: resolve measure dimension via CubeService, then
                 // fetch the {elementName: actualType} dict from ElementService — preserving real
                 // element types (Numeric/String/Consolidated) so _buildCellUpdateStatements emits
@@ -1247,13 +1273,13 @@ export class CellService {
                     cellsetAsDict,
                     precision: options.precision,
                     skipNonUpdateable: options.skip_non_updateable ?? false,
-                    measureDimensionElements: measureDimensionElements ?? {},
+                    measureDimensionElements,
                 })
                 : CellService._buildCellUpdateStatements({
                     cubeName,
                     cellsetAsDict,
                     increment: options.increment ?? false,
-                    measureDimensionElements: measureDimensionElements ?? {},
+                    measureDimensionElements,
                     precision: options.precision,
                     skipNonUpdateable: options.skip_non_updateable ?? false,
                     dimensions: dims,
@@ -1313,7 +1339,7 @@ export class CellService {
         cubeName: string;
         cellsetAsDict: CellsetDict;
         increment: boolean;
-        measureDimensionElements: Record<string, string>;
+        measureDimensionElements: CaseAndSpaceInsensitiveDict<string>;
         precision?: number;
         skipNonUpdateable: boolean;
         dimensions?: string[];
@@ -1323,11 +1349,11 @@ export class CellService {
         for (const [coordKey, value] of Object.entries(args.cellsetAsDict)) {
             const coordinates = coordKey.split(',');
             let measureElement = coordinates[coordinates.length - 1];
-            let elementType = args.measureDimensionElements[measureElement];
+            let elementType = args.measureDimensionElements.get(measureElement);
             if (elementType === undefined) {
                 if (measureElement.includes(':')) {
                     measureElement = measureElement.split(':')[1];
-                    elementType = args.measureDimensionElements[measureElement] ?? 'Numeric';
+                    elementType = args.measureDimensionElements.get(measureElement) ?? 'Numeric';
                 } else {
                     elementType = 'Numeric';
                 }
@@ -1419,7 +1445,7 @@ export class CellService {
         cellsetAsDict: CellsetDict;
         precision?: number;
         skipNonUpdateable: boolean;
-        measureDimensionElements: Record<string, string>;
+        measureDimensionElements: CaseAndSpaceInsensitiveDict<string>;
     }): string[] {
         const dimensionName = args.cubeName.slice(19); // length of "}ElementAttributes_"
         const statements: string[] = [];
@@ -1439,11 +1465,11 @@ export class CellService {
             }
             let attributeName = coordinates[coordinates.length - 1];
 
-            let attributeType: string | undefined = args.measureDimensionElements[attributeName];
+            let attributeType: string | undefined = args.measureDimensionElements.get(attributeName);
             if (attributeType === undefined) {
                 if (attributeName.includes(':')) {
                     attributeName = attributeName.split(':')[1];
-                    attributeType = args.measureDimensionElements[attributeName] ?? 'String';
+                    attributeType = args.measureDimensionElements.get(attributeName) ?? 'String';
                 } else {
                     attributeType = 'String';
                 }
@@ -3042,7 +3068,7 @@ export class CellService {
      * (CellService.py:1906-1914) — returns the real element type per element so callers can
      * dispatch CellPutN vs CellPutS correctly.
      */
-    private async _fetchMeasureDimensionElementTypes(cubeName: string): Promise<Record<string, string>> {
+    private async _fetchMeasureDimensionElementTypes(cubeName: string): Promise<CaseAndSpaceInsensitiveDict<string>> {
         // eslint-disable-next-line @typescript-eslint/no-var-requires
         const { CubeService } = require('./CubeService');
         // eslint-disable-next-line @typescript-eslint/no-var-requires
@@ -3050,13 +3076,11 @@ export class CellService {
         const cubeService = new CubeService(this.rest);
         const elementService = new ElementService(this.rest);
         const measureDimension: string = await cubeService.getMeasureDimension(cubeName);
-        const typesMap = await elementService.getElementTypesFromAllHierarchies(measureDimension);
-        const result: Record<string, string> = {};
-        // CaseAndSpaceInsensitiveDict exposes entries() like a Map; flatten to a plain object.
-        for (const [name, type] of typesMap.entries()) {
-            result[name] = type;
-        }
-        return result;
+        // tm1py returns a CaseAndSpaceInsensitiveDict so callers' element-name lookups work
+        // regardless of casing/spaces. Returning the dict directly preserves that semantics —
+        // the prior implementation flattened to a plain object using the dict's normalized keys,
+        // which then missed every lookup using the raw element name from the user's coordinate.
+        return await elementService.getElementTypesFromAllHierarchies(measureDimension);
     }
 
     /**

--- a/src/services/CellService.ts
+++ b/src/services/CellService.ts
@@ -843,13 +843,12 @@ export class CellService {
         const uniqueName = `tm1py_${crypto.randomBytes(6).toString('hex')}`;
         const fileName = `${uniqueName}.csv`;
 
-        // tm1py's @manage_transaction_log decorator wraps the WHOLE function body, including the
-        // CSV upload. Deactivate before any I/O so a deactivate failure aborts upload+execute,
-        // and put reactivate in the outer finally so it always runs (mirrors decorator semantics).
-        if (options.deactivate_transaction_log) {
-            await this.deactivateTransactionlog(cubeName);
-        }
+        // tm1py's @manage_transaction_log decorator (CellService.py:111-136) puts deactivate
+        // INSIDE the try so a failed deactivate still hits the reactivate in finally.
         try {
+            if (options.deactivate_transaction_log) {
+                await this.deactivateTransactionlog(cubeName);
+            }
             // CSV: tm1py uses csv.writer(QUOTE_ALL, delimiter=','). Quote every field; double
             // internal quotes; replace \r/\n in string values with empty (mirrors tm1py:1463
             // cleanup). Python csv.writer defaults to lineterminator='\r\n' AND writes a
@@ -1099,11 +1098,13 @@ export class CellService {
         // tm1py's @manage_transaction_log decorator wraps the WHOLE write_async (CellService.py:969).
         // The inner _write (line 1015) does NOT forward deactivate/reactivate flags, so per-chunk
         // writes never toggle individually — important when chunks run in parallel because one
-        // chunk reactivating mid-flight would defeat the surrounding deactivate intent.
-        if (options.deactivate_transaction_log) {
-            await this.deactivateTransactionlog(cubeName);
-        }
+        // chunk reactivating mid-flight would defeat the surrounding deactivate intent. Per the
+        // decorator at CellService.py:111-136, the deactivate sits INSIDE the try so reactivate
+        // always runs in finally even if the deactivate itself throws.
         try {
+            if (options.deactivate_transaction_log) {
+                await this.deactivateTransactionlog(cubeName);
+            }
             // Forward only the per-write flags; do NOT forward transaction-log toggles.
             const blobOpts = {
                 sandbox_name: options.sandbox_name,
@@ -1185,12 +1186,12 @@ export class CellService {
             reactivate_transaction_log?: boolean;
         } = {}
     ): Promise<string | undefined> {
-        // tm1py's @manage_transaction_log decorator wraps the WHOLE function body — deactivate
-        // before any helper fetches, reactivate in the outer finally regardless of failure path.
-        if (options.deactivate_transaction_log) {
-            await this.deactivateTransactionlog(cubeName);
-        }
+        // tm1py's @manage_transaction_log decorator (CellService.py:111-136) puts deactivate
+        // INSIDE the try so reactivate always runs in finally even if deactivate itself fails.
         try {
+            if (options.deactivate_transaction_log) {
+                await this.deactivateTransactionlog(cubeName);
+            }
             const isAttributeCube = options.is_attribute_cube
                 ?? cubeName.toLowerCase().startsWith('}elementattributes_');
             const enableSandbox = await this.generateEnableSandboxTi(options.sandbox_name);

--- a/src/services/CellService.ts
+++ b/src/services/CellService.ts
@@ -189,6 +189,10 @@ export interface WriteOptions {
     remove_blob?: boolean;
     clear_view?: string;
     is_attribute_cube?: boolean;
+    // tm1py write() takes `dimensions` as a top-level param (CellService.py:1177); on the
+    // tm1npm options-only API we expose it on WriteOptions so new callers can forward it.
+    // The legacy 4-arg `write(cube, cells, dims, opts)` form still works (sniffed at runtime).
+    dimensions?: string[];
 }
 
 export interface MDXViewOptions {
@@ -416,7 +420,9 @@ export class CellService {
     ): Promise<any> {
         const dims = dimensions || await this.getDimensionNamesForWriting(cubeName);
         let url = formatUrl("/Cubes('{}')/tm1.Update", cubeName);
-        if (sandboxName) url += `?!sandbox=${encodeURIComponent(sandboxName)}`;
+        // tm1py add_url_parameters (Utils.py:1011-1030) only doubles single quotes; it does NOT
+        // percent-encode the value. Match that exactly so the wire request is byte-identical.
+        if (sandboxName) url += `?!sandbox=${escapeODataValue(sandboxName)}`;
         const body: Record<string, unknown> = {
             Cells: [{
                 'Tuple@odata.bind': dims.map((d, i) =>
@@ -475,6 +481,8 @@ export class CellService {
             // Legacy 4-arg shape `write(cube, cells, undefined, opts)`.
             options = legacyOptions;
         }
+        // Honor options.dimensions when the legacy positional dims arg wasn't supplied.
+        if (dimensions === undefined) dimensions = options.dimensions;
 
         if (options.clear_view && !options.use_blob) {
             throw new Error("'clear_view' can only be used in conjunction with 'use_blob'");

--- a/src/services/CellService.ts
+++ b/src/services/CellService.ts
@@ -490,11 +490,34 @@ export class CellService {
         // tm1py write() returns Optional[str] — the changeset id from the underlying call (or None).
         // Forward whatever the routed method returns so future changeset wiring (notably in
         // writeThroughCellset, which is intentionally out of scope for #62) propagates through.
+        // Mirror tm1py's selective kwarg forwarding (CellService.py:1226-1268) instead of spreading
+        // the whole WriteOptions — keeps each inner method's API surface minimal and explicit.
         if (options.use_ti) {
-            return await this.writeThroughUnboundProcess(cubeName, cellsetAsDict, { ...options, dimensions });
+            return await this.writeThroughUnboundProcess(cubeName, cellsetAsDict, {
+                increment: options.increment,
+                sandbox_name: options.sandbox_name,
+                deactivate_transaction_log: options.deactivate_transaction_log,
+                reactivate_transaction_log: options.reactivate_transaction_log,
+                precision: options.precision,
+                skip_non_updateable: options.skip_non_updateable,
+                measure_dimension_elements: options.measure_dimension_elements,
+                is_attribute_cube: options.is_attribute_cube,
+                dimensions,
+                allow_spread: options.allow_spread,
+            });
         }
         if (options.use_blob) {
-            return await this.writeThroughBlob(cubeName, cellsetAsDict, { ...options, dimensions });
+            return await this.writeThroughBlob(cubeName, cellsetAsDict, {
+                increment: options.increment,
+                sandbox_name: options.sandbox_name,
+                deactivate_transaction_log: options.deactivate_transaction_log,
+                reactivate_transaction_log: options.reactivate_transaction_log,
+                skip_non_updateable: options.skip_non_updateable,
+                dimensions,
+                remove_blob: options.remove_blob,
+                allow_spread: options.allow_spread,
+                clear_view: options.clear_view,
+            });
         }
         return await this.writeThroughCellset(cubeName, cellsetAsDict, dimensions, options);
     }

--- a/src/services/HierarchyService.ts
+++ b/src/services/HierarchyService.ts
@@ -186,9 +186,9 @@ export class HierarchyService extends ObjectService {
         const cellService = new CellService(this.rest);
         const value = memberName || '';
         await cellService.writeValue(
+            value,
             '}HierarchyProperties',
-            [dimensionName, hierarchyName, 'MEMBER_DEFAULT'],
-            value
+            [dimensionName, hierarchyName, 'MEMBER_DEFAULT']
         );
     }
 
@@ -426,7 +426,7 @@ export class HierarchyService extends ObjectService {
                 for (const [elementName, attrs] of attributeValues) {
                     for (const [attrName, value] of attrs) {
                         writePromises.push(
-                            cellService.writeValue(cubeName, [elementName, attrName], value)
+                            cellService.writeValue(value, cubeName, [elementName, attrName])
                                 .catch((e: any) => {
                                     // Expected: element may not exist in control dimension
                                     if (!(e instanceof TM1RestException && e.statusCode === 404)) {

--- a/src/tests/cellService.test.ts
+++ b/src/tests/cellService.test.ts
@@ -60,7 +60,7 @@ describe('CellService Tests', () => {
             mockRestService.post.mockResolvedValue(createMockResponse({}));
 
             const cellAddress = ['Jan', 'Revenue', 'Actual'];
-            await cellService.writeValue('SalesCube', cellAddress, 1500);
+            await cellService.writeValue(1500, 'SalesCube', cellAddress);
 
             expect(mockRestService.post).toHaveBeenCalledWith(
                 "/Cubes('SalesCube')/tm1.Update",
@@ -68,7 +68,8 @@ describe('CellService Tests', () => {
             );
 
             const body = JSON.parse(mockRestService.post.mock.calls[0][1]);
-            expect(body.Cells[0].Value).toBe(1500);
+            // tm1py writes Value at the top level (not nested in Cells[0]); see CellService.py:1169.
+            expect(body.Value).toBe('1500');
             expect(body.Cells[0]['Tuple@odata.bind']).toHaveLength(3);
 
             console.log('✅ Single cell value written via POST');
@@ -79,11 +80,12 @@ describe('CellService Tests', () => {
             jest.spyOn(cellService, 'getDimensionNamesForWriting')
                 .mockResolvedValue(["O'Brien Dim", 'Measure', 'Version']);
 
-            await cellService.writeValue("O'Brien Dim", ["It's", 'Revenue', 'Actual'], 100, ["O'Brien Dim", 'Measure', 'Version']);
+            await cellService.writeValue(100, "O'Brien Dim", ["It's", 'Revenue', 'Actual'], ["O'Brien Dim", 'Measure', 'Version']);
 
             const body = JSON.parse(mockRestService.post.mock.calls[0][1]);
             const bindPath = body.Cells[0]['Tuple@odata.bind'][0];
-            expect(bindPath).toBe("Dimensions('O''Brien Dim')/Hierarchies('O''Brien Dim')/Elements('It''s')");
+            // formatUrl mirrors tm1py format_url: quote(..., safe="") — spaces become %20.
+            expect(bindPath).toBe("Dimensions('O''Brien%20Dim')/Hierarchies('O''Brien%20Dim')/Elements('It''s')");
         });
 
         test('should write multiple cell values', async () => {
@@ -318,7 +320,7 @@ describe('CellService Tests', () => {
                 response: { status: 401, statusText: 'Unauthorized' }
             });
 
-            await expect(cellService.writeValue('TestCube', ['Jan', 'Revenue', 'Actual'], 1000))
+            await expect(cellService.writeValue(1000, 'TestCube', ['Jan', 'Revenue', 'Actual']))
                 .rejects.toMatchObject({
                     response: { status: 401 }
                 });
@@ -344,19 +346,19 @@ describe('CellService Tests', () => {
         test('should handle zero and null values', async () => {
             mockRestService.patch.mockResolvedValue(createMockResponse({}));
 
-            // Test zero value
+            // Test zero value: tm1py serializes falsy values to '' (str(value) if value else "").
             mockRestService.post.mockResolvedValue(createMockResponse({}));
 
-            await cellService.writeValue('TestCube', ['Jan', 'Revenue', 'Actual'], 0);
+            await cellService.writeValue(0, 'TestCube', ['Jan', 'Revenue', 'Actual']);
 
             let body = JSON.parse(mockRestService.post.mock.calls[0][1]);
-            expect(body.Cells[0].Value).toBe(0);
+            expect(body.Value).toBe('');
 
             // Test null value
-            await cellService.writeValue('TestCube', ['Jan', 'Revenue', 'Actual'], null);
+            await cellService.writeValue(null, 'TestCube', ['Jan', 'Revenue', 'Actual']);
 
             body = JSON.parse(mockRestService.post.mock.calls[1][1]);
-            expect(body.Cells[0].Value).toBeNull();
+            expect(body.Value).toBe('');
 
             console.log('✅ Zero and null values handled correctly');
         });
@@ -391,7 +393,7 @@ describe('CellService Tests', () => {
 
             const operations = [
                 cellService.getValue('TestCube', ['Jan', 'Revenue', 'Actual']),
-                cellService.writeValue('TestCube', ['Feb', 'Revenue', 'Actual'], 2000),
+                cellService.writeValue(2000, 'TestCube', ['Feb', 'Revenue', 'Actual']),
                 cellService.getValue('TestCube', ['Mar', 'Revenue', 'Actual'])
             ];
 
@@ -420,7 +422,7 @@ describe('CellService Tests', () => {
             expect(initialValue).toBe(1000);
 
             // Write new value
-            await cellService.writeValue('TestCube', coordinates, 1500);
+            await cellService.writeValue(1500, 'TestCube', coordinates);
 
             // Read updated value
             const updatedValue = await cellService.getValue('TestCube', coordinates);

--- a/src/tests/comprehensive.service.test.ts
+++ b/src/tests/comprehensive.service.test.ts
@@ -322,7 +322,7 @@ describe('Comprehensive Service Tests with Mocking', () => {
 
             // Test writeValue via POST
             mockRestService.post.mockResolvedValueOnce(createMockResponse({}));
-            await cellService.writeValue('TestCube', ['Element1'], 2000);
+            await cellService.writeValue(2000, 'TestCube', ['Element1']);
             expect(mockRestService.post).toHaveBeenCalled();
 
             console.log('✅ All CellService operations working');

--- a/src/tests/enhancedCellService.test.ts
+++ b/src/tests/enhancedCellService.test.ts
@@ -46,34 +46,36 @@ describe('Enhanced CellService Tests', () => {
     });
 
     describe('Enhanced Data Writing Functions', () => {
-        test('writeDataframe should write tabular data to cube', async () => {
+        test('writeDataframe routes through write() with built CellsetDict (sums numeric duplicates)', async () => {
             const dataFrame = [
                 ['2024', 'Actual', 'London', 100],
-                ['2024', 'Forecast', 'Paris', 200]
+                ['2024', 'Actual', 'London', 50],     // duplicate intersection — should sum
+                ['2024', 'Forecast', 'Paris', 200],
             ];
-            const dimensions = ['Year', 'Version', 'Region'];
 
-            mockRestService.patch.mockResolvedValue(createMockResponse({}));
+            const writeSpy = jest.spyOn(cellService, 'write').mockResolvedValue(undefined);
 
-            await cellService.writeDataframe('SalesCube', dataFrame, dimensions);
+            await cellService.writeDataframe('SalesCube', dataFrame);
 
-            expect(mockRestService.patch).toHaveBeenCalledWith(
-                "/Cubes('SalesCube')/tm1.Update",
-                expect.objectContaining({
-                    Cells: expect.arrayContaining([
-                        expect.objectContaining({
-                            Coordinates: [
-                                { Name: '2024' },
-                                { Name: 'Actual' },
-                                { Name: 'London' }
-                            ],
-                            Value: 100
-                        })
-                    ])
-                })
-            );
-            
-            console.log('✅ writeDataframe test passed');
+            expect(writeSpy).toHaveBeenCalledTimes(1);
+            const [cube, cells, opts] = writeSpy.mock.calls[0];
+            expect(cube).toBe('SalesCube');
+            expect(cells).toEqual({
+                '2024,Actual,London': 150,
+                '2024,Forecast,Paris': 200,
+            });
+            expect(opts).toEqual({});
+
+            console.log('✅ writeDataframe routing test passed');
+        });
+
+        test('writeDataframe rejects rows with wrong column count', async () => {
+            const dataFrame = [
+                ['2024', 'Actual', 100],   // missing one dim column (3 dims expected → 4 cols)
+            ];
+
+            await expect(cellService.writeDataframe('SalesCube', dataFrame))
+                .rejects.toThrow(/Number of columns/);
         });
 
         test('writeAsync chunks the cellset and delegates to writeThroughBlob', async () => {
@@ -86,16 +88,17 @@ describe('Enhanced CellService Tests', () => {
             const result = await cellService.writeAsync('SalesCube', cellset, { slice_size: 1, max_workers: 2 });
 
             expect(result).toBeUndefined();
-            // Two entries with slice_size=1 → two chunks → two writeThroughBlob calls
+            // Two entries with slice_size=1 → two chunks → two writeThroughBlob calls.
+            // writeAsync calls writeThroughBlob directly (not through write()), so use_blob is not
+            // a meaningful flag on the underlying call; we just check the cube name and that the
+            // chunks are forwarded as-is.
             expect(writeThroughBlobSpy).toHaveBeenCalledTimes(2);
-            expect(writeThroughBlobSpy).toHaveBeenCalledWith(
-                'SalesCube',
-                expect.any(Object),
-                expect.objectContaining({ use_blob: true })
+            expect(writeThroughBlobSpy).toHaveBeenNthCalledWith(
+                1, 'SalesCube', expect.any(Object), expect.any(Object)
             );
         });
 
-        test('writeAsync aggregates per-chunk failures into a TM1Exception', async () => {
+        test('writeAsync aggregates per-chunk failures into TM1pyWritePartialFailureException', async () => {
             const cellset = { 'a,b,c': 1, 'd,e,f': 2 };
 
             jest.spyOn(cellService, 'writeThroughBlob')
@@ -104,62 +107,111 @@ describe('Enhanced CellService Tests', () => {
 
             await expect(
                 cellService.writeAsync('SalesCube', cellset, { slice_size: 1, max_workers: 2 })
-            ).rejects.toThrow(/writeAsync partial failure: 1\/2 chunks failed/);
+            ).rejects.toThrow(/partial failure \(1\/2 chunks failed\)/);
         });
 
-        test('writeThroughUnboundProcess should execute TI statements', async () => {
+        test('writeThroughUnboundProcess emits CellPutN statements via Process body', async () => {
             const cellset = { '2024,Actual,London': 100 };
 
+            // Stub out the auto-fetch of measure dimension elements so the test stays hermetic.
+            jest.spyOn(cellService, 'getElementsFromAllMeasureHierarchies').mockResolvedValue({});
+
             mockRestService.post.mockResolvedValue(createMockResponse({
-                ProcessExecuteStatusCode: 'CompletedSuccessfully'
+                ProcessExecuteStatusCode: 'CompletedSuccessfully',
             }));
 
             await cellService.writeThroughUnboundProcess('SalesCube', cellset);
 
             expect(mockRestService.post).toHaveBeenCalledWith(
-                '/ExecuteProcessWithReturn',
-                expect.objectContaining({
-                    PrologProcedure: expect.stringContaining("CubeDataSet('SalesCube'")
-                })
+                '/ExecuteProcessWithReturn?$expand=*',
+                expect.stringContaining("CellPutN(")
             );
+            // Confirm the emitted statement targets the right cube and coordinates.
+            const body = JSON.parse(mockRestService.post.mock.calls[0][1]);
+            expect(body.Process.PrologProcedure).toContain("CellPutN(100,'SalesCube','2024','Actual','London');");
 
             console.log('✅ writeThroughUnboundProcess test passed');
         });
 
-        test('writeThroughBlob should upload CSV and load from blob', async () => {
+        test('writeThroughBlob uploads CSV and executes a TI process via /ExecuteProcessWithReturn', async () => {
             const cellsetData = {
-                'Year,Version,Region': 100
+                '2024,Actual,London': 100,
             };
 
-            // Mock the REST calls for process creation, execution, and deletion
-            mockRestService.post
-                .mockResolvedValueOnce(createMockResponse({})) // Process creation
-                .mockResolvedValueOnce(createMockResponse({})); // Process execution
+            // Capture the FileService factory mock created at module load time.
+            // eslint-disable-next-line @typescript-eslint/no-var-requires
+            const { FileService } = require('../services/FileService');
+            const fsCreate = jest.fn().mockResolvedValue({});
+            const fsDelete = jest.fn().mockResolvedValue({});
+            (FileService as jest.Mock).mockImplementationOnce(() => ({
+                create: fsCreate,
+                delete: fsDelete,
+            }));
 
-            mockRestService.delete
-                .mockResolvedValueOnce(createMockResponse({})); // Process deletion
+            mockRestService.post.mockResolvedValue(createMockResponse({
+                ProcessExecuteStatusCode: 'CompletedSuccessfully',
+            }));
 
             await cellService.writeThroughBlob('SalesCube', cellsetData);
 
-            // Should create process, execute it, and delete it
-            expect(mockRestService.post).toHaveBeenCalledTimes(2);
-            expect(mockRestService.delete).toHaveBeenCalledTimes(1);
+            // CSV uploaded as a single file, then the TI process executed, then file deleted.
+            expect(fsCreate).toHaveBeenCalledTimes(1);
+            const [fname, content] = fsCreate.mock.calls[0];
+            expect(fname).toMatch(/^tm1py_[0-9a-f]+\.csv$/);
+            expect(Buffer.isBuffer(content)).toBe(true);
+            // tm1py csv.writer default: '\r\n' terminator after every row (including the last).
+            expect(content.toString('utf-8')).toBe('"2024","Actual","London","100"\r\n');
 
-            // Verify process creation call
-            expect(mockRestService.post).toHaveBeenNthCalledWith(1,
-                '/Processes',
-                expect.objectContaining({
-                    Name: expect.stringContaining('tm1npm_blob_import_')
-                })
+            expect(mockRestService.post).toHaveBeenCalledTimes(1);
+            expect(mockRestService.post).toHaveBeenCalledWith(
+                '/ExecuteProcessWithReturn?$expand=*',
+                expect.any(String)
             );
 
-            // Verify process execution call
-            expect(mockRestService.post).toHaveBeenNthCalledWith(2,
-                expect.stringMatching(/\/Processes\(.*\)\/tm1\.ExecuteProcess/),
-                {}
-            );
+            expect(fsDelete).toHaveBeenCalledTimes(1);
+            expect(fsDelete).toHaveBeenCalledWith(fname);
 
             console.log('✅ writeThroughBlob test passed');
+        });
+
+        test('writeThroughBlob skips file delete when remove_blob is false', async () => {
+            const cellsetData = { '2024,Actual,London': 100 };
+
+            // eslint-disable-next-line @typescript-eslint/no-var-requires
+            const { FileService } = require('../services/FileService');
+            const fsCreate = jest.fn().mockResolvedValue({});
+            const fsDelete = jest.fn().mockResolvedValue({});
+            (FileService as jest.Mock).mockImplementationOnce(() => ({
+                create: fsCreate,
+                delete: fsDelete,
+            }));
+
+            mockRestService.post.mockResolvedValue(createMockResponse({
+                ProcessExecuteStatusCode: 'CompletedSuccessfully',
+            }));
+
+            await cellService.writeThroughBlob('SalesCube', cellsetData, { remove_blob: false });
+
+            expect(fsCreate).toHaveBeenCalledTimes(1);
+            expect(fsDelete).not.toHaveBeenCalled();
+        });
+
+        test('write throws when clear_view is set without use_blob', async () => {
+            await expect(
+                cellService.write('SalesCube', { 'a,b,c': 1 }, { clear_view: 'SomeView' })
+            ).rejects.toThrow(/clear_view.*use_blob/);
+        });
+
+        test('write routes to writeThroughUnboundProcess when use_ti=true', async () => {
+            const spy = jest.spyOn(cellService, 'writeThroughUnboundProcess').mockResolvedValue(undefined);
+            await cellService.write('SalesCube', { 'a,b,c': 1 }, { use_ti: true });
+            expect(spy).toHaveBeenCalledTimes(1);
+        });
+
+        test('write routes to writeThroughBlob when use_blob=true', async () => {
+            const spy = jest.spyOn(cellService, 'writeThroughBlob').mockResolvedValue(undefined);
+            await cellService.write('SalesCube', { 'a,b,c': 1 }, { use_blob: true });
+            expect(spy).toHaveBeenCalledTimes(1);
         });
     });
 

--- a/src/tests/enhancedCellService.test.ts
+++ b/src/tests/enhancedCellService.test.ts
@@ -113,8 +113,10 @@ describe('Enhanced CellService Tests', () => {
         test('writeThroughUnboundProcess emits CellPutN statements via Process body', async () => {
             const cellset = { '2024,Actual,London': 100 };
 
-            // Stub out the auto-fetch of measure dimension elements so the test stays hermetic.
-            jest.spyOn(cellService, 'getElementsFromAllMeasureHierarchies').mockResolvedValue({});
+            // Stub out the auto-fetch of measure dimension element types so the test stays
+            // hermetic. The private helper looks up the measure dim then queries element types;
+            // returning an empty map is fine — the statement builder defaults to 'Numeric'.
+            jest.spyOn(cellService as any, '_fetchMeasureDimensionElementTypes').mockResolvedValue({});
 
             mockRestService.post.mockResolvedValue(createMockResponse({
                 ProcessExecuteStatusCode: 'CompletedSuccessfully',

--- a/src/tests/enhancedCellService.test.ts
+++ b/src/tests/enhancedCellService.test.ts
@@ -147,12 +147,15 @@ describe('Enhanced CellService Tests', () => {
         });
 
         test('writeThroughUnboundProcess emits CellPutN statements via Process body', async () => {
+            // eslint-disable-next-line @typescript-eslint/no-var-requires
+            const { CaseAndSpaceInsensitiveDict } = require('../utils/Utils');
             const cellset = { '2024,Actual,London': 100 };
 
             // Stub out the auto-fetch of measure dimension element types so the test stays
-            // hermetic. The private helper looks up the measure dim then queries element types;
-            // returning an empty map is fine — the statement builder defaults to 'Numeric'.
-            jest.spyOn(cellService as any, '_fetchMeasureDimensionElementTypes').mockResolvedValue({});
+            // hermetic. The helper returns a CaseAndSpaceInsensitiveDict; an empty one is fine —
+            // the statement builder defaults to 'Numeric' for unknown measures.
+            jest.spyOn(cellService as any, '_fetchMeasureDimensionElementTypes')
+                .mockResolvedValue(new CaseAndSpaceInsensitiveDict());
 
             mockRestService.post.mockResolvedValue(createMockResponse({
                 ProcessExecuteStatusCode: 'CompletedSuccessfully',

--- a/src/tests/enhancedCellService.test.ts
+++ b/src/tests/enhancedCellService.test.ts
@@ -98,16 +98,52 @@ describe('Enhanced CellService Tests', () => {
             );
         });
 
-        test('writeAsync aggregates per-chunk failures into TM1pyWritePartialFailureException', async () => {
-            const cellset = { 'a,b,c': 1, 'd,e,f': 2 };
+        test('writeAsync aggregates TM1pyWriteFailureException chunks into TM1pyWritePartialFailureException with merged statuses/logs', async () => {
+            // eslint-disable-next-line @typescript-eslint/no-var-requires
+            const { TM1pyWriteFailureException, TM1pyWritePartialFailureException } =
+                require('../exceptions/TM1Exception');
+            const cellset = { 'a,b,c': 1, 'd,e,f': 2, 'g,h,i': 3 };
 
             jest.spyOn(cellService, 'writeThroughBlob')
-                .mockRejectedValueOnce(new Error('chunk1 failed'))
-                .mockResolvedValueOnce(undefined);
+                .mockRejectedValueOnce(new TM1pyWriteFailureException(['HasMinorErrors'], ['log1.log']))
+                .mockResolvedValueOnce(undefined)
+                .mockRejectedValueOnce(new TM1pyWritePartialFailureException(['Aborted'], ['log3.log'], 2));
 
-            await expect(
-                cellService.writeAsync('SalesCube', cellset, { slice_size: 1, max_workers: 2 })
-            ).rejects.toThrow(/partial failure \(1\/2 chunks failed\)/);
+            try {
+                await cellService.writeAsync('SalesCube', cellset, { slice_size: 1, max_workers: 3 });
+                fail('expected writeAsync to throw');
+            } catch (err: any) {
+                expect(err).toBeInstanceOf(TM1pyWritePartialFailureException);
+                // Statuses + log files are concatenated across both failed chunks (tm1py-style merge).
+                expect(err.statuses).toEqual(['HasMinorErrors', 'Aborted']);
+                expect(err.errorLogFiles).toEqual(['log1.log', 'log3.log']);
+                // attempts: 1 (bare WriteFailure) + 2 (partial.attempts) = 3
+                expect(err.attempts).toBe(3);
+            }
+        });
+
+        test('writeAsync hoists transaction-log toggles around the whole job (does NOT forward to chunks)', async () => {
+            const cellset = { 'a,b,c': 1, 'd,e,f': 2 };
+            const deactivateSpy = jest.spyOn(cellService, 'deactivateTransactionlog').mockResolvedValue(undefined);
+            const activateSpy = jest.spyOn(cellService, 'activateTransactionlog').mockResolvedValue(undefined);
+            const blobSpy = jest.spyOn(cellService, 'writeThroughBlob').mockResolvedValue(undefined);
+
+            await cellService.writeAsync('SalesCube', cellset, {
+                slice_size: 1,
+                max_workers: 2,
+                deactivate_transaction_log: true,
+                reactivate_transaction_log: true,
+            });
+
+            // Only ONE deactivate / activate pair around the whole job, not one per chunk.
+            expect(deactivateSpy).toHaveBeenCalledTimes(1);
+            expect(activateSpy).toHaveBeenCalledTimes(1);
+            // Per-chunk options must NOT include transaction-log toggles (would race in parallel).
+            for (const call of blobSpy.mock.calls) {
+                const opts = call[2] as Record<string, unknown>;
+                expect(opts).not.toHaveProperty('deactivate_transaction_log');
+                expect(opts).not.toHaveProperty('reactivate_transaction_log');
+            }
         });
 
         test('writeThroughUnboundProcess emits CellPutN statements via Process body', async () => {

--- a/src/tests/hierarchyService.issue38.test.ts
+++ b/src/tests/hierarchyService.issue38.test.ts
@@ -219,7 +219,9 @@ describe('HierarchyService — Issue #38 new methods', () => {
             // The cube name '}HierarchyProperties' gets URL-encoded as '%7DHierarchyProperties'
             expect(url).toContain('HierarchyProperties');
             const parsed = JSON.parse(body);
-            expect(parsed.Cells[0].Value).toBe('RootMember');
+            // tm1py writeValue puts Value at the top level of the body (not in Cells[0]); see
+            // tm1py CellService.py:1169 (`body_as_dict["Value"] = ...`).
+            expect(parsed.Value).toBe('RootMember');
         });
 
         test('should clear default member when memberName is empty string (API approach)', async () => {

--- a/src/tests/mdx.advanced.test.ts
+++ b/src/tests/mdx.advanced.test.ts
@@ -240,7 +240,7 @@ describe('Advanced MDX and Calculation Tests', () => {
                 const allocatedAmount = totalAmount * driver.weight;
                 totalAllocated += allocatedAmount;
                 
-                await cellService.writeValue('AllocationCube', [driver.element], allocatedAmount);
+                await cellService.writeValue(allocatedAmount, 'AllocationCube', [driver.element]);
                 
                 expect(allocatedAmount).toBeGreaterThan(0);
                 console.log(`✅ Allocated ${allocatedAmount} to ${driver.element}`);
@@ -441,7 +441,7 @@ describe('Advanced MDX and Calculation Tests', () => {
                 }));
 
                 try {
-                    await cellService.writeValue('ExtremeCube', ['Test'], testCase.value);
+                    await cellService.writeValue(testCase.value, 'ExtremeCube', ['Test']);
                     console.log(`✅ Extreme value handled: ${testCase.name}`);
                 } catch (error) {
                     console.log(`✅ Extreme value properly rejected: ${testCase.name}`);

--- a/src/tests/security.advanced.test.ts
+++ b/src/tests/security.advanced.test.ts
@@ -172,7 +172,7 @@ describe('Advanced Security and Validation Tests', () => {
 
             for (const value of invalidValues) {
                 try {
-                    await cellService.writeValue('TestCube', ['Element1'], value);
+                    await cellService.writeValue(value, 'TestCube', ['Element1']);
                     console.log(`✅ Handled invalid numeric value: ${value}`);
                 } catch (error) {
                     console.log(`✅ Properly validated numeric value: ${value}`);
@@ -311,7 +311,7 @@ describe('Advanced Security and Validation Tests', () => {
             });
             
             try {
-                await cellService.writeValue('TestCube', ['Element1'], 1000);
+                await cellService.writeValue(1000, 'TestCube', ['Element1']);
             } catch (error: any) {
                 expect(error.response.status).toBe(409);
                 console.log('✅ Concurrent modification conflict handled properly');

--- a/src/tests/stress.performance.test.ts
+++ b/src/tests/stress.performance.test.ts
@@ -271,7 +271,7 @@ describe('Stress Testing and Performance Tests', () => {
                 } else if (i % 3 === 1) {
                     // Write operation
                     concurrentOperations.push(
-                        cellService.writeValue('TestCube', [`Element${i}`], Math.random() * 1000)
+                        cellService.writeValue(Math.random() * 1000, 'TestCube', [`Element${i}`])
                     );
                 } else {
                     // View operation - mock both calls ViewService makes
@@ -334,7 +334,7 @@ describe('Stress Testing and Performance Tests', () => {
                 // Execute all operations in the transaction
                 const transactionOps = scenario.operations.map(op => {
                     const [dimension, account] = op.account.split(':');
-                    return cellService.writeValue('TransactionCube', [dimension, account], op.amount);
+                    return cellService.writeValue(op.amount, 'TransactionCube', [dimension, account]);
                 });
                 
                 const results = await Promise.allSettled(transactionOps);

--- a/src/utils/Utils.ts
+++ b/src/utils/Utils.ts
@@ -116,6 +116,19 @@ export function lowerAndDropSpaces(str: string): string {
     return str.toLowerCase().replace(/\s+/g, '');
 }
 
+// Mirror tm1py Utils.frame_to_significant_digits (Utils.py:1766-1770).
+// Special floats follow Python's str() output: 'inf', '-inf', 'nan'. Zero stays '0'.
+export function frameToSignificantDigits(x: number, digits: number = 15): string {
+    if (Number.isNaN(x)) return 'nan';
+    if (x === Infinity) return 'inf';
+    if (x === -Infinity) return '-inf';
+    if (x === 0) return '0';
+    const adjusted = digits - Math.ceil(Math.log10(Math.abs(x)));
+    const factor = Math.pow(10, adjusted);
+    const rounded = Math.round(x * factor) / factor;
+    return String(rounded).replace('e+', 'E');
+}
+
 export function escapeODataValue(str: string): string {
     return str.replace(/'/g, "''");
 }

--- a/src/utils/Utils.ts
+++ b/src/utils/Utils.ts
@@ -116,6 +116,29 @@ export function lowerAndDropSpaces(str: string): string {
     return str.toLowerCase().replace(/\s+/g, '');
 }
 
+// Python's built-in `round(value, ndigits)` uses banker's rounding (round-half-to-even).
+// JS `Math.round` rounds half away from zero (or toward +Infinity, depending on viewpoint),
+// so a direct port would diverge on tie cases like round(2.5) → 2 (Python) vs 3 (JS).
+function pythonRound(value: number, ndigits: number): number {
+    if (!Number.isFinite(value)) return value;
+    const factor = Math.pow(10, ndigits);
+    const scaled = value * factor;
+    const truncated = Math.trunc(scaled);
+    const diff = scaled - truncated;
+    let rounded: number;
+    // Tie detection at the working precision. Use a small tolerance so binary-float artefacts
+    // near a half don't get mis-classified as ties.
+    if (Math.abs(Math.abs(diff) - 0.5) < 1e-9) {
+        // Round to even: pick the integer whose absolute value is even.
+        const lower = truncated;
+        const upper = truncated + Math.sign(scaled || 1);
+        rounded = (lower % 2 === 0) ? lower : upper;
+    } else {
+        rounded = Math.round(scaled);
+    }
+    return rounded / factor;
+}
+
 // Mirror tm1py Utils.frame_to_significant_digits (Utils.py:1766-1770).
 // Special floats follow Python's str() output: 'inf', '-inf', 'nan'. Zero stays '0'.
 export function frameToSignificantDigits(x: number, digits: number = 15): string {
@@ -124,8 +147,7 @@ export function frameToSignificantDigits(x: number, digits: number = 15): string
     if (x === -Infinity) return '-inf';
     if (x === 0) return '0';
     const adjusted = digits - Math.ceil(Math.log10(Math.abs(x)));
-    const factor = Math.pow(10, adjusted);
-    const rounded = Math.round(x * factor) / factor;
+    const rounded = pythonRound(x, adjusted);
     return String(rounded).replace('e+', 'E');
 }
 


### PR DESCRIPTION
## Summary

Closes #62. Aligns `CellService` write methods with tm1py byte-for-byte:

- **`writeValue`**: parameter order is now `(value, cubeName, elementTuple, dimensions?, sandboxName?)` — matches tm1py `write_value`. Body's `Value` lives at the top level (not nested in `Cells[0]`), and falsy values collapse to `''` per tm1py's `str(value) if value else ""` truthiness.
- **`write`**: adds `use_ti` → `writeThroughUnboundProcess`, `use_blob` → `writeThroughBlob` routing; `clear_view` requires `use_blob` (else throws). Backward-tolerant 4-arg shape preserves existing `(cube, cells, undefined, opts)` callers.
- **`writeThroughUnboundProcess`**: replaces the fabricated `CubeDataSet` calls with the proper `_buildCellUpdateStatements` pipeline (CellPutN/CellPutS based on measure element type) + `_buildAttributeUpdateStatements` for attribute cubes (auto-detected via `}ElementAttributes_*` prefix). Statements are chunked at every `2 * Process.maxStatements(version)` boundary, executed via `_executeWriteStatements`, with failure aggregation matching tm1py's `TM1pyWriteFailureException` / `TM1pyWritePartialFailureException` model.
- **`writeThroughBlob`**: replaces the invalid hand-rolled TI code with `_buildBlobToCubeProcess`, which mirrors tm1py's ASCII-data-source TI process character-for-character (CellPutN / CellIncrementN / CellPutProportionalSpread / CellPutS branches, CellIsUpdateable wrapping, `.blb` v11 suffix). CSV uses QUOTE_ALL with `\r\n` terminators (Python `csv.writer` default).
- **`writeDataframe`**: accepts `DataFrame` (`{columns, data}`) or 2D array; supports `static_dimension_elements`, `infer_column_order`, `sum_numeric_duplicates`; routes through `write()`.
- **`writeAsync`**: prefetches dimensions once before chunking; hoists transaction-log toggles around the whole job (mirrors `@manage_transaction_log`); aggregates per-chunk `TM1pyWriteFailureException` / `TM1pyWritePartialFailureException` into a merged partial failure with `itertools.chain`-equivalent semantics.

New helpers: `frameToSignificantDigits` (with Python banker's rounding), `TM1pyWriteFailureException` / `TM1pyWritePartialFailureException` (with snake-case alias for tm1py-port compatibility).

Breaking changes (mandated by the parity rule):
- `writeValue(value, cube, tuple)` replaces `(cube, coords, value)`
- `writeThroughUnboundProcess` drops the legacy `processName` arg
- `writeDataframe` shape narrowed; routes through `write()`
- `writeThroughBlob` / `writeThroughUnboundProcess` option types narrowed to method-specific keys

## Iterations

**8 internal review rounds + 8 external review rounds** before APPROVED. Highlights from review feedback:

- Round 3 (internal) caught an inverted `verifyVersion` arg order that would have broken the `.blb` suffix on v11 servers
- Round 6 (external) caught a `_fetchMeasureDimensionElementTypes` regression where flattening `CaseAndSpaceInsensitiveDict` to a plain `Record` produced normalized keys that missed every raw-coordinate lookup (would have silently emitted `CellPutN` for string measures)
- Round 8 (external) aligned exception message text byte-for-byte with tm1py's `__str__` output (Python list repr via `pyListRepr`)

Final review: 0 P0, 0 P1, 4 P2 cosmetic suggestions. Scores 9/9/9/8.

## Follow-ups

Two pre-existing parity bugs surfaced during review but are out of scope for #62 — filed separately:
- KimKaoPoo/tm1npm#110 — `writeThroughCellset` MDX refactor (currently bypasses `writeValuesThroughCellset`, so changeset id is never returned)
- KimKaoPoo/tm1npm#111 — `activate/deactivateTransactionlog` POST to fabricated `tm1.ActivateTransactionLog` endpoints; tm1py uses `writeValue('YES'/'NO', '}CubeProperties', [cubeName, 'Logging'])`

## Test plan

- [x] `node_modules/.bin/tsc --noEmit` — clean
- [x] `node_modules/.bin/jest` — 1611 passing
- [x] 7 pre-existing failures unchanged (4 × `cellServiceExtract` missing `stream-chain` dep, 1 × `security.advanced` broken mock, 2 × credentials-required suites)
- [ ] Smoke-test `writeThroughBlob` and `writeThroughUnboundProcess` against a real TM1 v11 server
- [ ] Smoke-test sandbox-name handling (tm1py-aligned `!sandbox=` query with single-quote doubling)