### PR TITLE
fix(#65): align CellService execute methods with tm1py — full param surface

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,68 @@
 
 All notable changes to this project are documented here.
 
+## 2.3.0 — 2026-05-15
+
+### BREAKING CHANGES
+
+**Six `CellService` execute methods now match tm1py's signatures one-to-one**
+(see [#65](https://github.com/KimKaoPoo/tm1npm/issues/65)). Option keys
+adopt the camelCase form already used elsewhere in tm1npm; legacy snake_case
+keys on `MDXViewOptions` are no longer accepted by these methods.
+
+- **`executeMdx`** — was `executeMdx(mdx)`, returned the raw cellset POST
+  response. Now `executeMdx(mdx, options?: ExecuteMdxOptions)` and returns
+  `CaseAndSpaceInsensitiveTuplesDict<any>` (cellset created via
+  `createCellset`, extracted via `extractCellset`).
+  - Migration when raw cellset shape is needed: switch to
+    `executeMdxRaw(mdx, options)`, which returns the raw `Axes`/`Cells` dict.
+
+- **`executeMdxRaw`** — accepts the full `ExecuteMdxRawOptions` surface
+  (`cellProperties`, `elemProperties`, `memberProperties`, `top`, `skip`,
+  `skipContexts`, `skipZeros`, `skipConsolidatedCells`,
+  `skipRuleDerivedCells`, `sandboxName`, `includeHierarchies`,
+  `useCompactJson`). Replaces the previous narrow `MDXViewOptions` form.
+  - Migration: `executeMdxRaw(mdx, { sandbox_name: 'sb', skip_zeros: true })`
+    → `executeMdxRaw(mdx, { sandboxName: 'sb', skipZeros: true })`.
+
+- **`executeView` / `executeViewRaw`** — same shape changes as their MDX
+  counterparts. `executeView` returns `CaseAndSpaceInsensitiveTuplesDict`;
+  `executeViewRaw` returns the raw cellset. Underlying URL switched to
+  `/Cubes('c')/{Views|PrivateViews}('v')/tm1.Execute?!sandbox=...`
+  matching tm1py exactly (was `tm1.CreateCellset?$private=...&$sandbox=...`).
+  - Migration: rename snake_case option keys to camelCase; for raw `.Axes`/`.Cells`
+    consumption switch from `executeView` to `executeViewRaw`.
+
+- **`executeMdxCsv` / `executeViewCsv`** — accept the full CSV option
+  surface (`csvDialect`, `lineSeparator`, `valueSeparator`, `includeAttributes`
+  on MDX only, `useIterativeJson`, `useCompactJson`, `mdxHeaders`, plus the
+  shared `top`/`skip`/`skipZeros`/`skipConsolidatedCells`/`skipRuleDerivedCells`).
+  Default `skipZeros` flips from `undefined` to **`true`** (matches tm1py's CSV
+  semantics — different from the non-CSV execute methods which default to `false`).
+  - Migration: rename snake_case option keys; explicitly pass `skipZeros: false`
+    if zero-cell rows are required.
+
+- **`executeMdxAsync` / `execute_view_async`** — option surfaces widened to
+  match tm1py's `execute_mdx_async` / `execute_view_async` (15 / 13 named
+  parameters explicitly forwarded). When `executeMdx`/`executeView` are
+  called with `maxWorkers > 1`, all options are now threaded through to the
+  async path. Return type is `CaseAndSpaceInsensitiveTuplesDict<any>` to
+  match tm1py.
+
+### Deferred (tracked as follow-ups)
+
+- **`useBlob` on `executeMdxCsv` / `executeViewCsv`** — tm1py's
+  `_execute_mdx_csv_use_blob` / `_execute_view_csv_use_blob` TI/blob CSV
+  extract path is not yet ported. The option is intentionally **not exposed**
+  on the public surface to avoid advertising behaviour tm1npm doesn't deliver.
+  Tracked separately; will be added back together with the underlying port.
+- **`arranged_axes` on `executeViewCsv`** — only meaningful on tm1py's blob
+  branch; travels with the `useBlob` port.
+- **Parallel-chunked retrieval in async helpers** — tm1py uses
+  `extract_cellset_async` for parallel chunked fetching; tm1npm currently
+  uses the serial `extractCellset` path with full option-forwarding parity.
+  Network-parallelism port is a separate follow-up.
+
 ## 2.2.0 — 2026-05-02
 
 ### BREAKING CHANGES

--- a/src/services/BulkService.ts
+++ b/src/services/BulkService.ts
@@ -484,9 +484,14 @@ export class BulkService {
             skip_rule_derived = false
         } = options;
 
-        // Use executeMdxRaw for raw cellset shape (Axes/Cells); executeMdx now
-        // returns CaseAndSpaceInsensitiveTuplesDict per tm1py parity.
-        const result = await this.cellService.executeMdxRaw(mdx);
+        // executeMdxRaw now accepts the full tm1py-parity option surface; forward
+        // the destructured options so server-side filters/sandbox actually apply.
+        const result = await this.cellService.executeMdxRaw(mdx, {
+            sandboxName: sandbox_name,
+            skipZeros: skip_zeros,
+            skipConsolidatedCells: skip_consolidated,
+            skipRuleDerivedCells: skip_rule_derived,
+        });
 
         // Convert to CSV
         const rows: string[] = [];
@@ -618,9 +623,14 @@ export class BulkService {
             format = 'compact'
         } = options;
 
-        // Use executeMdxRaw for raw cellset shape (Axes/Cells); executeMdx now
-        // returns CaseAndSpaceInsensitiveTuplesDict per tm1py parity.
-        const result = await this.cellService.executeMdxRaw(mdx);
+        // executeMdxRaw now accepts the full tm1py-parity option surface; forward
+        // the destructured options so server-side filters/sandbox actually apply.
+        const result = await this.cellService.executeMdxRaw(mdx, {
+            sandboxName: sandbox_name,
+            skipZeros: skip_zeros,
+            skipConsolidatedCells: skip_consolidated,
+            skipRuleDerivedCells: skip_rule_derived,
+        });
 
         const data: any[] = [];
 

--- a/src/services/BulkService.ts
+++ b/src/services/BulkService.ts
@@ -484,10 +484,9 @@ export class BulkService {
             skip_rule_derived = false
         } = options;
 
-        // Execute MDX query
-        // Note: executeMdx currently doesn't support options parameter
-        // TODO: Enhance CellService.executeMdx to accept MDXViewOptions
-        const result = await this.cellService.executeMdx(mdx);
+        // Use executeMdxRaw for raw cellset shape (Axes/Cells); executeMdx now
+        // returns CaseAndSpaceInsensitiveTuplesDict per tm1py parity.
+        const result = await this.cellService.executeMdxRaw(mdx);
 
         // Convert to CSV
         const rows: string[] = [];
@@ -619,10 +618,9 @@ export class BulkService {
             format = 'compact'
         } = options;
 
-        // Execute MDX query
-        // Note: executeMdx currently doesn't support options parameter
-        // TODO: Enhance CellService.executeMdx to accept MDXViewOptions
-        const result = await this.cellService.executeMdx(mdx);
+        // Use executeMdxRaw for raw cellset shape (Axes/Cells); executeMdx now
+        // returns CaseAndSpaceInsensitiveTuplesDict per tm1py parity.
+        const result = await this.cellService.executeMdxRaw(mdx);
 
         const data: any[] = [];
 

--- a/src/services/BulkService.ts
+++ b/src/services/BulkService.ts
@@ -486,11 +486,15 @@ export class BulkService {
 
         // executeMdxRaw now accepts the full tm1py-parity option surface; forward
         // the destructured options so server-side filters/sandbox actually apply.
+        // executeMdxRaw builds a curated $expand= URL: default cellProperties is
+        // ['Value'] and Hierarchies is omitted unless includeHierarchies=true. CSV
+        // export needs Hierarchies for the header row.
         const result = await this.cellService.executeMdxRaw(mdx, {
             sandboxName: sandbox_name,
             skipZeros: skip_zeros,
             skipConsolidatedCells: skip_consolidated,
             skipRuleDerivedCells: skip_rule_derived,
+            includeHierarchies: true,
         });
 
         // Convert to CSV
@@ -625,11 +629,17 @@ export class BulkService {
 
         // executeMdxRaw now accepts the full tm1py-parity option surface; forward
         // the destructured options so server-side filters/sandbox actually apply.
+        // The 'detailed' format below reads cell.Ordinal/RuleDerived/Updateable/
+        // Consolidated, so request those explicitly — executeMdxRaw defaults
+        // cellProperties to ['Value'] only.
         const result = await this.cellService.executeMdxRaw(mdx, {
             sandboxName: sandbox_name,
             skipZeros: skip_zeros,
             skipConsolidatedCells: skip_consolidated,
             skipRuleDerivedCells: skip_rule_derived,
+            cellProperties: format === 'full'
+                ? ['Value', 'Ordinal', 'Consolidated', 'RuleDerived', 'Updateable']
+                : undefined,
         });
 
         const data: any[] = [];

--- a/src/services/CellService.ts
+++ b/src/services/CellService.ts
@@ -14,7 +14,7 @@ import { MDXView } from '../objects/MDXView';
 import { Process } from '../objects/Process';
 import { TM1Exception, TM1pyWriteFailureException, TM1pyWritePartialFailureException } from '../exceptions/TM1Exception';
 import {
-    formatUrl, escapeODataValue, lowerAndDropSpaces, extractCompactJsonCellset, resemblesMdx, getCube,
+    formatUrl, escapeODataValue, buildUrlFriendlyObjectName, lowerAndDropSpaces, extractCompactJsonCellset, resemblesMdx, getCube,
     CaseAndSpaceInsensitiveDict,
     CaseAndSpaceInsensitiveTuplesDict,
     RawCellsetDict,
@@ -2156,13 +2156,16 @@ export class CellService {
     ): Promise<string> {
         // Mirror tm1py's create_cellset_from_view (CellService.py:4986-5005) exactly:
         //   /Cubes('{cube}')/{PrivateViews|Views}('{view}')/tm1.Execute?!sandbox=...
-        // The public/private discriminator is a URL segment (not a $private query
-        // param), the action is `tm1.Execute` (not `tm1.CreateCellset`), and the
-        // sandbox parameter uses TM1's write-side `!sandbox=` form with quote
-        // doubling as the only escaping (Utils.py add_url_parameters).
+        // tm1py builds the URL via format_url which runs every positional arg
+        // through build_url_friendly_object_name (Utils.py:271-289) — escapes
+        // ', %, #, ?, &. Plain quote-doubling is NOT sufficient for cube/view
+        // names: real-world names containing `&` (e.g. "Sales & Revenue") would
+        // otherwise produce a URL where `&` is parsed as a query separator.
+        // sandbox_name keeps the lighter quote-doubling escape because tm1py
+        // appends it via add_url_parameters (Utils.py:1011-1030), not format_url.
         const views = isPrivate ? 'PrivateViews' : 'Views';
-        const cube = escapeODataValue(cubeName);
-        const view = escapeODataValue(viewName);
+        const cube = buildUrlFriendlyObjectName(cubeName);
+        const view = buildUrlFriendlyObjectName(viewName);
         let url = `/Cubes('${cube}')/${views}('${view}')/tm1.Execute`;
         if (sandbox_name) url += `?!sandbox=${escapeODataValue(sandbox_name)}`;
 

--- a/src/services/CellService.ts
+++ b/src/services/CellService.ts
@@ -230,12 +230,11 @@ export interface ExecuteMdxOptions {
     useCompactJson?: boolean;
     skipSandboxDimension?: boolean;
     /**
-     * When > 1, dispatches to `executeMdxAsync`. tm1py forwards every option
-     * via **kwargs; tm1npm's `executeMdxAsync` currently only consumes
-     * `sandboxName` (other options silently dropped to match tm1py's loose
-     * validation) and `cubeName` for tm1py-compatible tuple-key ordering.
-     * Since the public surface has no way to pass `cubeName`, tuple keys on
-     * the async path fall back to axis order — a tracked parity gap.
+     * When > 1, dispatches to `executeMdxAsync`, which forwards the full
+     * option surface to extractCellset for tm1py parity. tm1py uses
+     * extract_cellset_async for parallel-chunked retrieval; tm1npm currently
+     * uses the serial extractCellset path — option semantics match, network
+     * parallelism is a tracked follow-up.
      */
     maxWorkers?: number;
     asyncAxis?: number;
@@ -663,12 +662,9 @@ export class CellService {
      * (CellService.py:2200-2276): createCellsetFromView + extractCellset
      * with the full tm1py parameter surface.
      *
-     * When `maxWorkers > 1`, dispatches to execute_view_async. tm1py's async
-     * branch (CellService.py:2241-2257) forwards a broad subset and drops
-     * cell_properties/use_compact_json/kwargs via Python's **kwargs semantics —
-     * never throws on unsupported options. tm1npm's execute_view_async only
-     * consumes {private, sandboxName}; other options are silently dropped to
-     * match tm1py's loose **kwargs validation.
+     * When `maxWorkers > 1`, dispatches to execute_view_async — tm1py forwards
+     * all 13 named parameters explicitly (CellService.py:2241-2257); tm1npm now
+     * forwards the equivalent options surface.
      */
     public async executeView(
         cubeName: string,
@@ -677,13 +673,7 @@ export class CellService {
     ): Promise<CaseAndSpaceInsensitiveTuplesDict<any>> {
         const maxWorkers = options.maxWorkers ?? 1;
         if (maxWorkers > 1) {
-            const asyncResult = await this.execute_view_async(cubeName, viewName, {
-                private: options.private,
-                sandbox_name: options.sandboxName,
-            });
-            const dict = new CaseAndSpaceInsensitiveTuplesDict<any>();
-            for (const [k, v] of asyncResult) dict.set(k, v);
-            return dict;
+            return this.execute_view_async(cubeName, viewName, options);
         }
         const cellsetId = await this.createCellsetFromView(
             cubeName, viewName, options.private ?? false, options.sandboxName);
@@ -1974,34 +1964,44 @@ export class CellService {
      * Execute view asynchronously
      */
     /**
-     * Execute view via cellset extraction (parity with tm1py.execute_view_async).
-     * Returns a Map keyed by comma-joined element unique-names (or Names if UniqueName missing).
+     * Execute view via cellset extraction (parity with tm1py.execute_view_async at
+     * CellService.py:2278-2336). Returns a CaseAndSpaceInsensitiveTuplesDict.
      *
-     * Documented parity gaps (tracked as follow-ups, not in scope of #65):
-     * - tm1py uses extract_cellset_async with parallel-chunked retrieval. Not yet ported;
-     *   this delegates to a serial extractCellset.
-     * - tm1py's options (cell_properties, top, skip, skip_*, element_unique_names, etc.) are
-     *   not yet wired through extractCellset and are deliberately omitted from this signature
-     *   so misuse is a compile-time error.
-     * - Tuple-key parts are reordered by cube dimensions (parity with tm1py.sort_coordinates).
+     * Accepts the full tm1py-parity option surface and forwards it to extractCellset.
+     * tm1py uses extract_cellset_async (parallel-chunked); tm1npm uses the serial
+     * extractCellset path — same option-forwarding semantics, different network
+     * parallelism (the parallel-chunked port is a separate follow-up).
      */
     public async execute_view_async(
         cubeName: string,
         viewName: string,
-        options: { private?: boolean; sandbox_name?: string } = {}
-    ): Promise<Map<string, any>> {
+        options: ExecuteViewOptions & { sandbox_name?: string } = {}
+    ): Promise<CaseAndSpaceInsensitiveTuplesDict<any>> {
+        // sandbox_name (snake) kept as a back-compat alias for the legacy signature.
+        const sandboxName = options.sandboxName ?? options.sandbox_name;
         const cellsetId = await this.createCellsetFromView(
             cubeName,
             viewName,
-            options.private || false,
-            options.sandbox_name
+            options.private ?? false,
+            sandboxName
         );
         try {
-            const cellset = await this._extractCellsetForTupleDict(cellsetId, options.sandbox_name);
-            const cubeDims = await this.getDimensionNamesForWriting(cubeName);
-            return CellService._cellsetToTupleDict(cellset, cubeDims);
+            return await this.extractCellset(cellsetId, {
+                cellProperties: options.cellProperties,
+                top: options.top,
+                skip: options.skip,
+                skipContexts: options.skipContexts,
+                skipZeros: options.skipZeros,
+                skipConsolidatedCells: options.skipConsolidatedCells,
+                skipRuleDerivedCells: options.skipRuleDerivedCells,
+                deleteCellset: false,
+                sandboxName,
+                elementUniqueNames: options.elementUniqueNames,
+                skipCellProperties: options.skipCellProperties,
+                useCompactJson: options.useCompactJson,
+            });
         } finally {
-            await this._safeDeleteCellset(cellsetId, options.sandbox_name);
+            await this._safeDeleteCellset(cellsetId, sandboxName);
         }
     }
 
@@ -3633,10 +3633,9 @@ export class CellService {
      * (CellService.py:2065-2138): createCellset + extractCellset with the
      * full tm1py parameter surface.
      *
-     * When `maxWorkers > 1`, dispatches to the async path (parity with
-     * execute_mdx_async). tm1py forwards all options; tm1npm's
-     * `executeMdxAsync` currently only supports a subset — that gap is
-     * pre-existing and not introduced by this change.
+     * When `maxWorkers > 1`, dispatches to executeMdxAsync — tm1py forwards all
+     * 15 named parameters explicitly (CellService.py:2102-2119); tm1npm now
+     * forwards the equivalent options surface.
      */
     public async executeMdx(
         mdx: string,
@@ -3644,14 +3643,7 @@ export class CellService {
     ): Promise<CaseAndSpaceInsensitiveTuplesDict<any>> {
         const maxWorkers = options.maxWorkers ?? 1;
         if (maxWorkers > 1) {
-            // tm1py's execute_mdx forwards everything via **kwargs and lets the underlying
-            // call silently ignore options it doesn't use (CellService.py:2101-2119). Match
-            // that loose validation. tm1npm's executeMdxAsync currently only consumes
-            // sandboxName; other options are silently dropped per strict parity.
-            const asyncResult = await this.executeMdxAsync(mdx, { sandbox_name: options.sandboxName });
-            const dict = new CaseAndSpaceInsensitiveTuplesDict<any>();
-            for (const [k, v] of asyncResult) dict.set(k, v);
-            return dict;
+            return this.executeMdxAsync(mdx, options);
         }
         const cellsetId = await this.createCellset(mdx, options.sandboxName);
         return this.extractCellset(cellsetId, {
@@ -3816,32 +3808,39 @@ export class CellService {
     }
 
     /**
-     * Execute MDX via cellset extraction (parity with tm1py.execute_mdx_async).
-     * Returns a Map keyed by comma-joined element unique-names (or Names if UniqueName missing).
+     * Execute MDX via cellset extraction (parity with tm1py.execute_mdx_async at
+     * CellService.py:2140-2198). Returns a CaseAndSpaceInsensitiveTuplesDict.
      *
-     * Documented parity gaps (tracked as follow-ups, not in scope of #65):
-     * - tm1py uses extract_cellset_async with parallel-chunked retrieval. That helper is not
-     *   yet ported; this implementation delegates to a serial extractCellset.
-     * - tm1py's options (cell_properties, top, skip, skip_*, element_unique_names, etc.) are
-     *   not yet wired through extractCellset. To prevent silent option-drop, those parameters
-     *   are deliberately omitted from this signature so misuse is a compile-time error rather
-     *   than a runtime no-op. Add them back when the underlying extractor supports them.
-     * - Optional `cubeName` lets the caller request tm1py-compatible tuple-key ordering by
-     *   cube dimensions. When omitted, parts are joined in axis order (tm1py-divergent).
+     * Accepts the full tm1py-parity option surface and forwards it to extractCellset.
+     * tm1py uses extract_cellset_async (parallel-chunked); tm1npm uses the serial
+     * extractCellset path — same option-forwarding semantics, different network
+     * parallelism (the parallel-chunked port is a separate follow-up).
      */
     public async executeMdxAsync(
         mdx: string,
-        options: { sandbox_name?: string; cubeName?: string } = {}
-    ): Promise<Map<string, any>> {
-        const cellsetId = await this.createCellset(mdx, options.sandbox_name);
+        options: ExecuteMdxOptions & { sandbox_name?: string; cubeName?: string } = {}
+    ): Promise<CaseAndSpaceInsensitiveTuplesDict<any>> {
+        // sandbox_name (snake) kept as a back-compat alias for the legacy signature.
+        const sandboxName = options.sandboxName ?? options.sandbox_name;
+        const cellsetId = await this.createCellset(mdx, sandboxName);
         try {
-            const cellset = await this._extractCellsetForTupleDict(cellsetId, options.sandbox_name);
-            const cubeDims = options.cubeName
-                ? await this.getDimensionNamesForWriting(options.cubeName)
-                : undefined;
-            return CellService._cellsetToTupleDict(cellset, cubeDims);
+            return await this.extractCellset(cellsetId, {
+                cellProperties: options.cellProperties,
+                top: options.top,
+                skip: options.skip,
+                skipContexts: options.skipContexts,
+                skipZeros: options.skipZeros,
+                skipConsolidatedCells: options.skipConsolidatedCells,
+                skipRuleDerivedCells: options.skipRuleDerivedCells,
+                deleteCellset: false,
+                sandboxName,
+                elementUniqueNames: options.elementUniqueNames,
+                skipCellProperties: options.skipCellProperties,
+                useCompactJson: options.useCompactJson,
+                skipSandboxDimension: options.skipSandboxDimension,
+            });
         } finally {
-            await this._safeDeleteCellset(cellsetId, options.sandbox_name);
+            await this._safeDeleteCellset(cellsetId, sandboxName);
         }
     }
 

--- a/src/services/CellService.ts
+++ b/src/services/CellService.ts
@@ -742,8 +742,8 @@ export class CellService {
      * tm1py CSV semantics (CellService.py:2567).
      *
      * useBlob validation gates match tm1py byte-for-byte (CellService.py:2602-2612).
-     * After all gates pass, throws "not yet ported" — see IMPLEMENTATION_PLAN.md
-     * for the documented parity gap (user-approved scope for #65).
+     * After all gates pass, throws "not yet ported" — documented parity gap
+     * approved for #65 scope; blob CSV path port is tracked as a follow-up.
      */
     public async executeMdxCsv(
         mdx: string,
@@ -813,8 +813,8 @@ export class CellService {
      *
      * useBlob validation gates match tm1py byte-for-byte
      * (CellService.py:2709-2719) including the `private=False` requirement.
-     * After all gates pass, throws "not yet ported" — see
-     * IMPLEMENTATION_PLAN.md for the documented parity gap.
+     * After all gates pass, throws "not yet ported" — documented parity gap
+     * approved for #65 scope; blob CSV path port is tracked as a follow-up.
      */
     public async executeViewCsv(
         cubeName: string,
@@ -2013,7 +2013,7 @@ export class CellService {
      * Execute view via cellset extraction (parity with tm1py.execute_view_async).
      * Returns a Map keyed by comma-joined element unique-names (or Names if UniqueName missing).
      *
-     * Documented parity gaps (see IMPLEMENTATION_PLAN.md):
+     * Documented parity gaps (tracked as follow-ups, not in scope of #65):
      * - tm1py uses extract_cellset_async with parallel-chunked retrieval. Not yet ported;
      *   this delegates to a serial extractCellset.
      * - tm1py's options (cell_properties, top, skip, skip_*, element_unique_names, etc.) are
@@ -3864,7 +3864,7 @@ export class CellService {
      * Execute MDX via cellset extraction (parity with tm1py.execute_mdx_async).
      * Returns a Map keyed by comma-joined element unique-names (or Names if UniqueName missing).
      *
-     * Documented parity gaps (see IMPLEMENTATION_PLAN.md):
+     * Documented parity gaps (tracked as follow-ups, not in scope of #65):
      * - tm1py uses extract_cellset_async with parallel-chunked retrieval. That helper is not
      *   yet ported; this implementation delegates to a serial extractCellset.
      * - tm1py's options (cell_properties, top, skip, skip_*, element_unique_names, etc.) are

--- a/src/services/CellService.ts
+++ b/src/services/CellService.ts
@@ -662,9 +662,11 @@ export class CellService {
      * (CellService.py:2200-2276): createCellsetFromView + extractCellset
      * with the full tm1py parameter surface.
      *
-     * When `maxWorkers > 1`, dispatches to execute_view_async — tm1py forwards
-     * all 13 named parameters explicitly (CellService.py:2241-2257); tm1npm now
-     * forwards the equivalent options surface.
+     * When `maxWorkers > 1`, dispatches to execute_view_async. tm1py's
+     * execute_view (CellService.py:2241-2257) forwards 13 named parameters
+     * but DELIBERATELY OMITS cell_properties and use_compact_json (different
+     * from execute_mdx's async branch, which forwards both). Strict parity
+     * rule: replicate that quirk — drop the two fields before forwarding.
      */
     public async executeView(
         cubeName: string,
@@ -673,7 +675,9 @@ export class CellService {
     ): Promise<CaseAndSpaceInsensitiveTuplesDict<any>> {
         const maxWorkers = options.maxWorkers ?? 1;
         if (maxWorkers > 1) {
-            return this.execute_view_async(cubeName, viewName, options);
+            // Strip the two fields tm1py's async branch omits (CellService.py:2241-2257).
+            const { cellProperties: _cp, useCompactJson: _uc, ...asyncOptions } = options;
+            return this.execute_view_async(cubeName, viewName, asyncOptions);
         }
         const cellsetId = await this.createCellsetFromView(
             cubeName, viewName, options.private ?? false, options.sandboxName);

--- a/src/services/CellService.ts
+++ b/src/services/CellService.ts
@@ -230,14 +230,18 @@ export interface ExecuteMdxOptions {
     useCompactJson?: boolean;
     skipSandboxDimension?: boolean;
     /**
-     * When > 1, dispatches to `executeMdxAsync`, which forwards the full
-     * option surface to extractCellset for tm1py parity. tm1py uses
-     * extract_cellset_async for parallel-chunked retrieval; tm1npm currently
-     * uses the serial extractCellset path — option semantics match, network
-     * parallelism is a tracked follow-up.
+     * When > 1, dispatches to `executeMdxAsync` / `execute_view_async`. The
+     * dispatch is real (the async helper accepts the full option surface);
+     * the network-parallelism semantic tm1py achieves via `extract_cellset_async`
+     * is not yet ported and the call reduces to a single serial GET.
+     *
+     * `asyncAxis` is intentionally NOT exposed on this surface: tm1py forwards
+     * it to extract_cellset_async, which tm1npm hasn't ported yet. The internal
+     * `extractCellsetAxesRawAsync` helper already implements axis-parallel
+     * fetching and accepts its own `asyncAxis` parameter; that helper will be
+     * wired in alongside the parallel-chunked port (tracked follow-up).
      */
     maxWorkers?: number;
-    asyncAxis?: number;
 }
 
 // Options matching tm1py execute_mdx_raw (CellService.py:2338-2353) one-to-one.

--- a/src/services/CellService.ts
+++ b/src/services/CellService.ts
@@ -229,6 +229,14 @@ export interface ExecuteMdxOptions {
     skipCellProperties?: boolean;
     useCompactJson?: boolean;
     skipSandboxDimension?: boolean;
+    /**
+     * When > 1, dispatches to `executeMdxAsync`. tm1py forwards every option
+     * via **kwargs; tm1npm's `executeMdxAsync` currently only consumes
+     * `sandboxName` (other options silently dropped to match tm1py's loose
+     * validation) and `cubeName` for tm1py-compatible tuple-key ordering.
+     * Since the public surface has no way to pass `cubeName`, tuple keys on
+     * the async path fall back to axis order — a tracked parity gap.
+     */
     maxWorkers?: number;
     asyncAxis?: number;
 }
@@ -655,13 +663,12 @@ export class CellService {
      * (CellService.py:2200-2276): createCellsetFromView + extractCellset
      * with the full tm1py parameter surface.
      *
-     * When `maxWorkers > 1`, dispatches to execute_view_async. tm1py's
-     * async branch (CellService.py:2241-2257) forwards top/skip/skip_x/
-     * element_unique_names/skip_cell_properties but drops cell_properties,
-     * use_compact_json, and kwargs. tm1npm's `execute_view_async` currently
-     * only accepts {private, sandbox_name} — a pre-existing narrower gap
-     * that is documented in execute_view_async itself and tracked
-     * separately, not introduced by this change.
+     * When `maxWorkers > 1`, dispatches to execute_view_async. tm1py's async
+     * branch (CellService.py:2241-2257) forwards a broad subset and drops
+     * cell_properties/use_compact_json/kwargs via Python's **kwargs semantics —
+     * never throws on unsupported options. tm1npm's execute_view_async only
+     * consumes {private, sandboxName}; other options are silently dropped to
+     * match tm1py's loose **kwargs validation.
      */
     public async executeView(
         cubeName: string,
@@ -670,21 +677,6 @@ export class CellService {
     ): Promise<CaseAndSpaceInsensitiveTuplesDict<any>> {
         const maxWorkers = options.maxWorkers ?? 1;
         if (maxWorkers > 1) {
-            // tm1py's execute_view forwards a broad subset (top/skip/skip_*/element_unique_names/
-            // skip_cell_properties/max_workers/async_axis) to execute_view_async, dropping
-            // cell_properties/use_compact_json. tm1npm's execute_view_async currently only
-            // accepts {private, sandbox_name}. Fail loud if the caller set anything else so
-            // option drop is never silent.
-            const unsupported = (Object.keys(options) as Array<keyof ExecuteViewOptions>).filter(
-                k => k !== 'maxWorkers' && k !== 'asyncAxis' && k !== 'sandboxName' && k !== 'private'
-                    && options[k] !== undefined
-            );
-            if (unsupported.length > 0) {
-                throw new Error(
-                    `executeView maxWorkers>1 path does not yet forward [${unsupported.join(', ')}] — ` +
-                    'tracked as a pre-existing execute_view_async parity gap'
-                );
-            }
             const asyncResult = await this.execute_view_async(cubeName, viewName, {
                 private: options.private,
                 sandbox_name: options.sandboxName,
@@ -748,9 +740,10 @@ export class CellService {
      *
      * tm1py's `use_blob` is not exposed yet — see ExecuteMdxCsvOptions for
      * the deferral note. extractCellsetCsv handles cellset cleanup itself
-     * (deleteCellset=true default); extractCellsetCsvIterJson does NOT, so
-     * the iter-json branch wraps its call in try/finally to avoid leaking
-     * cellsets on the TM1 server.
+     * (deleteCellset=true default); extractCellsetCsvIterJson does NOT and
+     * tm1py's extract_cellset_csv_iter_json is also not @tidy_cellset-
+     * decorated (CellService.py:4385) — the iter-json cellset leak is a
+     * tm1py bug we replicate per the strict-parity rule.
      */
     public async executeMdxCsv(
         mdx: string,
@@ -763,23 +756,19 @@ export class CellService {
         const cellsetId = await this.createCellset(mdx, options.sandboxName);
 
         if (options.useIterativeJson) {
-            try {
-                return await this.extractCellsetCsvIterJson(cellsetId, {
-                    top: options.top,
-                    skip: options.skip,
-                    skipZeros,
-                    skipConsolidatedCells: options.skipConsolidatedCells,
-                    skipRuleDerivedCells: options.skipRuleDerivedCells,
-                    csvDialect: options.csvDialect,
-                    lineSeparator,
-                    valueSeparator,
-                    sandboxName: options.sandboxName,
-                    includeAttributes: options.includeAttributes,
-                    mdxHeaders: options.mdxHeaders,
-                });
-            } finally {
-                await this._safeDeleteCellset(cellsetId, options.sandboxName);
-            }
+            return this.extractCellsetCsvIterJson(cellsetId, {
+                top: options.top,
+                skip: options.skip,
+                skipZeros,
+                skipConsolidatedCells: options.skipConsolidatedCells,
+                skipRuleDerivedCells: options.skipRuleDerivedCells,
+                csvDialect: options.csvDialect,
+                lineSeparator,
+                valueSeparator,
+                sandboxName: options.sandboxName,
+                includeAttributes: options.includeAttributes,
+                mdxHeaders: options.mdxHeaders,
+            });
         }
 
         return this.extractCellsetCsv(cellsetId, {
@@ -805,9 +794,10 @@ export class CellService {
      *
      * tm1py's `use_blob` (+ its associated `arranged_axes` reorder) is not
      * exposed yet — see ExecuteViewCsvOptions for the deferral note.
-     * extractCellsetCsvIterJson does not delete the cellset itself, so the
-     * iter-json branch wraps its call in try/finally to avoid leaking
-     * cellsets on the TM1 server.
+     * extractCellsetCsvIterJson does not delete the cellset; tm1py's
+     * extract_cellset_csv_iter_json is also not @tidy_cellset-decorated
+     * (CellService.py:4385) — the iter-json cellset leak is a tm1py bug we
+     * replicate per the strict-parity rule.
      */
     public async executeViewCsv(
         cubeName: string,
@@ -822,22 +812,18 @@ export class CellService {
             cubeName, viewName, options.private ?? false, options.sandboxName);
 
         if (options.useIterativeJson) {
-            try {
-                return await this.extractCellsetCsvIterJson(cellsetId, {
-                    skipZeros,
-                    top: options.top,
-                    skip: options.skip,
-                    skipConsolidatedCells: options.skipConsolidatedCells,
-                    skipRuleDerivedCells: options.skipRuleDerivedCells,
-                    csvDialect: options.csvDialect,
-                    lineSeparator,
-                    valueSeparator,
-                    sandboxName: options.sandboxName,
-                    mdxHeaders: options.mdxHeaders,
-                });
-            } finally {
-                await this._safeDeleteCellset(cellsetId, options.sandboxName);
-            }
+            return this.extractCellsetCsvIterJson(cellsetId, {
+                skipZeros,
+                top: options.top,
+                skip: options.skip,
+                skipConsolidatedCells: options.skipConsolidatedCells,
+                skipRuleDerivedCells: options.skipRuleDerivedCells,
+                csvDialect: options.csvDialect,
+                lineSeparator,
+                valueSeparator,
+                sandboxName: options.sandboxName,
+                mdxHeaders: options.mdxHeaders,
+            });
         }
 
         return this.extractCellsetCsv(cellsetId, {
@@ -3658,19 +3644,10 @@ export class CellService {
     ): Promise<CaseAndSpaceInsensitiveTuplesDict<any>> {
         const maxWorkers = options.maxWorkers ?? 1;
         if (maxWorkers > 1) {
-            // tm1py's execute_mdx forwards every option to execute_mdx_async; tm1npm's
-            // executeMdxAsync currently only accepts {sandbox_name, cubeName}. Fail loud
-            // if the caller set any other option in the async branch so option drop is
-            // never silent — the public surface only advertises behaviour we actually do.
-            const unsupported = (Object.keys(options) as Array<keyof ExecuteMdxOptions>).filter(
-                k => k !== 'maxWorkers' && k !== 'asyncAxis' && k !== 'sandboxName' && options[k] !== undefined
-            );
-            if (unsupported.length > 0) {
-                throw new Error(
-                    `executeMdx maxWorkers>1 path does not yet forward [${unsupported.join(', ')}] — ` +
-                    'tracked as a pre-existing executeMdxAsync parity gap'
-                );
-            }
+            // tm1py's execute_mdx forwards everything via **kwargs and lets the underlying
+            // call silently ignore options it doesn't use (CellService.py:2101-2119). Match
+            // that loose validation. tm1npm's executeMdxAsync currently only consumes
+            // sandboxName; other options are silently dropped per strict parity.
             const asyncResult = await this.executeMdxAsync(mdx, { sandbox_name: options.sandboxName });
             const dict = new CaseAndSpaceInsensitiveTuplesDict<any>();
             for (const [k, v] of asyncResult) dict.set(k, v);

--- a/src/services/CellService.ts
+++ b/src/services/CellService.ts
@@ -2020,9 +2020,6 @@ export class CellService {
      *   not yet wired through extractCellset and are deliberately omitted from this signature
      *   so misuse is a compile-time error.
      * - Tuple-key parts are reordered by cube dimensions (parity with tm1py.sort_coordinates).
-     * - Calls createCellsetFromView, which is itself pre-existing on main and currently
-     *   targets a fabricated /tm1.CreateCellset endpoint (out of #69 scope; tracked
-     *   separately for a future fix to use /Cubes/{}/Views/{}/tm1.Execute per tm1py).
      */
     public async execute_view_async(
         cubeName: string,
@@ -2183,15 +2180,17 @@ export class CellService {
         isPrivate: boolean = false,
         sandbox_name?: string
     ): Promise<string> {
-        let url = `/Cubes('${cubeName}')/Views('${viewName}')/tm1.CreateCellset`;
-
-        const params = new URLSearchParams();
-        if (isPrivate) params.append('$private', 'true');
-        if (sandbox_name) params.append('$sandbox', sandbox_name);
-
-        if (params.toString()) {
-            url += `?${params.toString()}`;
-        }
+        // Mirror tm1py's create_cellset_from_view (CellService.py:4986-5005) exactly:
+        //   /Cubes('{cube}')/{PrivateViews|Views}('{view}')/tm1.Execute?!sandbox=...
+        // The public/private discriminator is a URL segment (not a $private query
+        // param), the action is `tm1.Execute` (not `tm1.CreateCellset`), and the
+        // sandbox parameter uses TM1's write-side `!sandbox=` form with quote
+        // doubling as the only escaping (Utils.py add_url_parameters).
+        const views = isPrivate ? 'PrivateViews' : 'Views';
+        const cube = escapeODataValue(cubeName);
+        const view = escapeODataValue(viewName);
+        let url = `/Cubes('${cube}')/${views}('${view}')/tm1.Execute`;
+        if (sandbox_name) url += `?!sandbox=${escapeODataValue(sandbox_name)}`;
 
         const response = await this.rest.post(url);
 

--- a/src/services/CellService.ts
+++ b/src/services/CellService.ts
@@ -269,6 +269,11 @@ export interface ExecuteViewRawOptions extends Omit<ExecuteMdxRawOptions, 'inclu
     private?: boolean;
 }
 
+// Options matching tm1py execute_view_async (CellService.py:2278-2294). tm1py
+// drops use_compact_json from this signature (only execute_mdx_async forwards
+// it) — strict parity = omit it here too so the type system enforces it.
+export interface ExecuteViewAsyncOptions extends Omit<ExecuteViewOptions, 'useCompactJson'> {}
+
 // Options matching tm1py execute_mdx_csv (CellService.py:2562-2579).
 // tm1py's `use_blob` is intentionally NOT exposed yet — the blob CSV port
 // (`_execute_mdx_csv_use_blob`) is tracked as a follow-up; the option will
@@ -1977,7 +1982,11 @@ export class CellService {
      * Execute view via cellset extraction (parity with tm1py.execute_view_async at
      * CellService.py:2278-2336). Returns a CaseAndSpaceInsensitiveTuplesDict.
      *
-     * Accepts the full tm1py-parity option surface and forwards it to extractCellset.
+     * Accepts the tm1py-parity option surface and forwards it to extractCellset.
+     * tm1py's execute_view_async signature has no `use_compact_json` — only
+     * execute_mdx_async accepts it. The `ExecuteViewAsyncOptions` type omits the
+     * field so callers get a TypeScript error if they pass it.
+     *
      * tm1py uses extract_cellset_async (parallel-chunked); tm1npm uses the serial
      * extractCellset path — same option-forwarding semantics, different network
      * parallelism (the parallel-chunked port is a separate follow-up).
@@ -1985,7 +1994,7 @@ export class CellService {
     public async execute_view_async(
         cubeName: string,
         viewName: string,
-        options: ExecuteViewOptions & { sandbox_name?: string } = {}
+        options: ExecuteViewAsyncOptions & { sandbox_name?: string } = {}
     ): Promise<CaseAndSpaceInsensitiveTuplesDict<any>> {
         // sandbox_name (snake) kept as a back-compat alias for the legacy signature.
         const sandboxName = options.sandboxName ?? options.sandbox_name;
@@ -2008,7 +2017,6 @@ export class CellService {
                 sandboxName,
                 elementUniqueNames: options.elementUniqueNames,
                 skipCellProperties: options.skipCellProperties,
-                useCompactJson: options.useCompactJson,
             });
         } finally {
             await this._safeDeleteCellset(cellsetId, sandboxName);

--- a/src/services/CellService.ts
+++ b/src/services/CellService.ts
@@ -665,7 +665,21 @@ export class CellService {
     ): Promise<CaseAndSpaceInsensitiveTuplesDict<any>> {
         const maxWorkers = options.maxWorkers ?? 1;
         if (maxWorkers > 1) {
-            // tm1py forwards only a subset of args to execute_view_async; match that.
+            // tm1py's execute_view forwards a broad subset (top/skip/skip_*/element_unique_names/
+            // skip_cell_properties/max_workers/async_axis) to execute_view_async, dropping
+            // cell_properties/use_compact_json. tm1npm's execute_view_async currently only
+            // accepts {private, sandbox_name}. Fail loud if the caller set anything else so
+            // option drop is never silent.
+            const unsupported = (Object.keys(options) as Array<keyof ExecuteViewOptions>).filter(
+                k => k !== 'maxWorkers' && k !== 'asyncAxis' && k !== 'sandboxName' && k !== 'private'
+                    && options[k] !== undefined
+            );
+            if (unsupported.length > 0) {
+                throw new Error(
+                    `executeView maxWorkers>1 path does not yet forward [${unsupported.join(', ')}] — ` +
+                    'tracked as a pre-existing execute_view_async parity gap'
+                );
+            }
             const asyncResult = await this.execute_view_async(cubeName, viewName, {
                 private: options.private,
                 sandbox_name: options.sandboxName,
@@ -3667,8 +3681,19 @@ export class CellService {
     ): Promise<CaseAndSpaceInsensitiveTuplesDict<any>> {
         const maxWorkers = options.maxWorkers ?? 1;
         if (maxWorkers > 1) {
-            // executeMdxAsync returns plain Map<string, any>; wrap into a TuplesDict to
-            // keep callers' return-type contract intact. Underlying values are unchanged.
+            // tm1py's execute_mdx forwards every option to execute_mdx_async; tm1npm's
+            // executeMdxAsync currently only accepts {sandbox_name, cubeName}. Fail loud
+            // if the caller set any other option in the async branch so option drop is
+            // never silent — mirrors the useBlob gate strategy.
+            const unsupported = (Object.keys(options) as Array<keyof ExecuteMdxOptions>).filter(
+                k => k !== 'maxWorkers' && k !== 'asyncAxis' && k !== 'sandboxName' && options[k] !== undefined
+            );
+            if (unsupported.length > 0) {
+                throw new Error(
+                    `executeMdx maxWorkers>1 path does not yet forward [${unsupported.join(', ')}] — ` +
+                    'tracked as a pre-existing executeMdxAsync parity gap'
+                );
+            }
             const asyncResult = await this.executeMdxAsync(mdx, { sandbox_name: options.sandboxName });
             const dict = new CaseAndSpaceInsensitiveTuplesDict<any>();
             for (const [k, v] of asyncResult) dict.set(k, v);

--- a/src/services/CellService.ts
+++ b/src/services/CellService.ts
@@ -215,6 +215,78 @@ export interface MDXViewOptions {
     mdx_headers?: boolean;
 }
 
+// Options matching tm1py execute_mdx (CellService.py:2065-2082) one-to-one.
+export interface ExecuteMdxOptions {
+    cellProperties?: string[];
+    top?: number;
+    skipContexts?: boolean;
+    skip?: number;
+    skipZeros?: boolean;
+    skipConsolidatedCells?: boolean;
+    skipRuleDerivedCells?: boolean;
+    sandboxName?: string;
+    elementUniqueNames?: boolean;
+    skipCellProperties?: boolean;
+    useCompactJson?: boolean;
+    skipSandboxDimension?: boolean;
+    maxWorkers?: number;
+    asyncAxis?: number;
+}
+
+// Options matching tm1py execute_mdx_raw (CellService.py:2338-2353) one-to-one.
+export interface ExecuteMdxRawOptions {
+    cellProperties?: string[];
+    elemProperties?: string[];
+    memberProperties?: string[];
+    top?: number;
+    skipContexts?: boolean;
+    skip?: number;
+    skipZeros?: boolean;
+    skipConsolidatedCells?: boolean;
+    skipRuleDerivedCells?: boolean;
+    sandboxName?: string;
+    includeHierarchies?: boolean;
+    useCompactJson?: boolean;
+}
+
+// Options matching tm1py execute_view (CellService.py:2200-2218). Note: NO
+// skipSandboxDimension — tm1py's execute_view does not accept it.
+export interface ExecuteViewOptions extends Omit<ExecuteMdxOptions, 'skipSandboxDimension'> {
+    private?: boolean;
+}
+
+// Options matching tm1py execute_view_raw (CellService.py:2391-2407).
+// tm1py's execute_view_raw does NOT accept `include_hierarchies` — that param
+// only exists on execute_mdx_raw. Omit it here for strict parity.
+export interface ExecuteViewRawOptions extends Omit<ExecuteMdxRawOptions, 'includeHierarchies'> {
+    private?: boolean;
+}
+
+// Options matching tm1py execute_mdx_csv (CellService.py:2562-2579).
+export interface ExecuteMdxCsvOptions {
+    top?: number;
+    skip?: number;
+    skipZeros?: boolean;
+    skipConsolidatedCells?: boolean;
+    skipRuleDerivedCells?: boolean;
+    csvDialect?: CsvDialect;
+    lineSeparator?: string;
+    valueSeparator?: string;
+    sandboxName?: string;
+    includeAttributes?: boolean;
+    useIterativeJson?: boolean;
+    useCompactJson?: boolean;
+    useBlob?: boolean;
+    mdxHeaders?: boolean;
+}
+
+// Options matching tm1py execute_view_csv (CellService.py:2663-2682). Adds
+// private + arrangedAxes, drops includeAttributes (not in tm1py view_csv).
+export interface ExecuteViewCsvOptions extends Omit<ExecuteMdxCsvOptions, 'includeAttributes'> {
+    private?: boolean;
+    arrangedAxes?: [string[], string[], string[]];
+}
+
 // tm1py uses CaseAndSpaceInsensitiveDict for measure-element lookups so callers can pass
 // "Comment" / "comment" / "Net Sales" / "netsales" interchangeably (matching how TM1 dimension
 // elements are referenced). Internal callers receive the case-insensitive dict; users of the
@@ -573,29 +645,51 @@ export class CellService {
     }
 
     /**
-     * Execute a view and return the data
+     * Execute a view and return cells with their properties as a
+     * CaseAndSpaceInsensitiveTuplesDict. Mirrors tm1py's execute_view
+     * (CellService.py:2200-2276): createCellsetFromView + extractCellset
+     * with the full tm1py parameter surface.
+     *
+     * When `maxWorkers > 1`, dispatches to execute_view_async. tm1py's
+     * async branch (CellService.py:2241-2257) forwards top/skip/skip_x/
+     * element_unique_names/skip_cell_properties but drops cell_properties,
+     * use_compact_json, and kwargs. tm1npm's `execute_view_async` currently
+     * only accepts {private, sandbox_name} — a pre-existing narrower gap
+     * that is documented in execute_view_async itself and tracked
+     * separately, not introduced by this change.
      */
     public async executeView(
-        cubeName: string, 
-        viewName: string, 
-        options: MDXViewOptions = {}
-    ): Promise<any> {
-        let url = `/Cubes('${cubeName}')/Views('${viewName}')/tm1.Execute`;
-        
-        const params = new URLSearchParams();
-        if (options.private !== undefined) params.append('$private', options.private.toString());
-        if (options.sandbox_name) params.append('$sandbox', options.sandbox_name);
-        if (options.element_unique_names !== undefined) params.append('$element_unique_names', options.element_unique_names.toString());
-        if (options.skip_zeros !== undefined) params.append('$skip_zeros', options.skip_zeros.toString());
-        if (options.skip_consolidated !== undefined) params.append('$skip_consolidated', options.skip_consolidated.toString());
-        if (options.skip_rule_derived !== undefined) params.append('$skip_rule_derived', options.skip_rule_derived.toString());
-
-        if (params.toString()) {
-            url += `?${params.toString()}`;
+        cubeName: string,
+        viewName: string,
+        options: ExecuteViewOptions = {}
+    ): Promise<CaseAndSpaceInsensitiveTuplesDict<any>> {
+        const maxWorkers = options.maxWorkers ?? 1;
+        if (maxWorkers > 1) {
+            // tm1py forwards only a subset of args to execute_view_async; match that.
+            const asyncResult = await this.execute_view_async(cubeName, viewName, {
+                private: options.private,
+                sandbox_name: options.sandboxName,
+            });
+            const dict = new CaseAndSpaceInsensitiveTuplesDict<any>();
+            for (const [k, v] of asyncResult) dict.set(k, v);
+            return dict;
         }
-
-        const response = await this.rest.post(url);
-        return response.data;
+        const cellsetId = await this.createCellsetFromView(
+            cubeName, viewName, options.private ?? false, options.sandboxName);
+        return this.extractCellset(cellsetId, {
+            cellProperties: options.cellProperties,
+            top: options.top,
+            skip: options.skip,
+            skipContexts: options.skipContexts,
+            skipZeros: options.skipZeros,
+            skipConsolidatedCells: options.skipConsolidatedCells,
+            skipRuleDerivedCells: options.skipRuleDerivedCells,
+            deleteCellset: true,
+            sandboxName: options.sandboxName,
+            elementUniqueNames: options.elementUniqueNames,
+            skipCellProperties: options.skipCellProperties,
+            useCompactJson: options.useCompactJson,
+        });
     }
 
     /**
@@ -626,50 +720,147 @@ export class CellService {
     }
 
     /**
-     * Execute MDX and return CSV data
+     * Execute MDX and return CSV. Mirrors tm1py's execute_mdx_csv
+     * (CellService.py:2562-2661): createCellset + extractCellsetCsv (or
+     * extractCellsetCsvIterJson) with the full tm1py parameter surface.
+     *
+     * Note default `skipZeros=true` — different from executeMdx, matches
+     * tm1py CSV semantics (CellService.py:2567).
+     *
+     * useBlob validation gates match tm1py byte-for-byte (CellService.py:2602-2612).
+     * After all gates pass, throws "not yet ported" — see IMPLEMENTATION_PLAN.md
+     * for the documented parity gap (user-approved scope for #65).
      */
     public async executeMdxCsv(
-        mdx: string, 
-        options: MDXViewOptions = {}
+        mdx: string,
+        options: ExecuteMdxCsvOptions = {}
     ): Promise<string> {
-        let url = '/ExecuteMDXCSV';
-        
-        const params = new URLSearchParams();
-        if (options.sandbox_name) params.append('$sandbox', options.sandbox_name);
-        if (options.element_unique_names !== undefined) params.append('$element_unique_names', options.element_unique_names.toString());
-        if (options.skip_zeros !== undefined) params.append('$skip_zeros', options.skip_zeros.toString());
+        const skipZeros = options.skipZeros !== false;
+        const lineSeparator = options.lineSeparator ?? '\r\n';
+        const valueSeparator = options.valueSeparator ?? ',';
 
-        if (params.toString()) {
-            url += `?${params.toString()}`;
+        if (options.useBlob) {
+            if (options.includeAttributes) {
+                throw new Error("'include_attributes' must not be used in conjunction with 'use_blob'");
+            }
+            if (options.useIterativeJson) {
+                throw new Error("'use_iterative_json' must not be used in conjunction with 'use_blob'");
+            }
+            if (options.useCompactJson) {
+                throw new Error("'use_compact_json' must not be used in conjunction with 'use_blob'");
+            }
+            if (options.csvDialect) {
+                throw new Error("'csv_dialect' must not be used in conjunction with 'use_blob'");
+            }
+            if (lineSeparator !== '\r\n') {
+                throw new Error("'line_separator' must be '\r\n' to leverage 'use_blob' feature");
+            }
+            throw new Error('useBlob CSV path not yet ported to tm1npm — tracked separately');
         }
 
-        const body = { MDX: mdx };
-        const response = await this.rest.post(url, body);
-        return response.data;
+        const cellsetId = await this.createCellset(mdx, options.sandboxName);
+
+        if (options.useIterativeJson) {
+            return this.extractCellsetCsvIterJson(cellsetId, {
+                top: options.top,
+                skip: options.skip,
+                skipZeros,
+                skipConsolidatedCells: options.skipConsolidatedCells,
+                skipRuleDerivedCells: options.skipRuleDerivedCells,
+                csvDialect: options.csvDialect,
+                lineSeparator,
+                valueSeparator,
+                sandboxName: options.sandboxName,
+                includeAttributes: options.includeAttributes,
+                mdxHeaders: options.mdxHeaders,
+            });
+        }
+
+        return this.extractCellsetCsv(cellsetId, {
+            top: options.top,
+            skip: options.skip,
+            skipZeros,
+            skipConsolidatedCells: options.skipConsolidatedCells,
+            skipRuleDerivedCells: options.skipRuleDerivedCells,
+            csvDialect: options.csvDialect,
+            lineSeparator,
+            valueSeparator,
+            sandboxName: options.sandboxName,
+            includeAttributes: options.includeAttributes,
+            useCompactJson: options.useCompactJson,
+            mdxHeaders: options.mdxHeaders,
+        });
     }
 
     /**
-     * Execute view and return CSV data
+     * Execute a view and return CSV. Mirrors tm1py's execute_view_csv
+     * (CellService.py:2663-2769): createCellsetFromView + extractCellsetCsv
+     * (or extractCellsetCsvIterJson) with the full tm1py parameter surface.
+     *
+     * useBlob validation gates match tm1py byte-for-byte
+     * (CellService.py:2709-2719) including the `private=False` requirement.
+     * After all gates pass, throws "not yet ported" — see
+     * IMPLEMENTATION_PLAN.md for the documented parity gap.
      */
     public async executeViewCsv(
-        cubeName: string, 
-        viewName: string, 
-        options: MDXViewOptions = {}
+        cubeName: string,
+        viewName: string,
+        options: ExecuteViewCsvOptions = {}
     ): Promise<string> {
-        let url = `/Cubes('${cubeName}')/Views('${viewName}')/tm1.ExecuteCSV`;
-        
-        const params = new URLSearchParams();
-        if (options.private !== undefined) params.append('$private', options.private.toString());
-        if (options.sandbox_name) params.append('$sandbox', options.sandbox_name);
-        if (options.element_unique_names !== undefined) params.append('$element_unique_names', options.element_unique_names.toString());
-        if (options.skip_zeros !== undefined) params.append('$skip_zeros', options.skip_zeros.toString());
+        const skipZeros = options.skipZeros !== false;
+        const lineSeparator = options.lineSeparator ?? '\r\n';
+        const valueSeparator = options.valueSeparator ?? ',';
 
-        if (params.toString()) {
-            url += `?${params.toString()}`;
+        if (options.useBlob) {
+            if (options.useIterativeJson) {
+                throw new Error("'use_iterative_json' must not be used in conjunction with 'use_blob'");
+            }
+            if (options.useCompactJson) {
+                throw new Error("'use_compact_json' must not be used in conjunction with 'use_blob'");
+            }
+            if (options.csvDialect) {
+                throw new Error("'csv_dialect' must not be used in conjunction with 'use_blob'");
+            }
+            if (lineSeparator !== '\r\n') {
+                throw new Error("'line_separator' must be '\r\n' to leverage 'use_blob' feature");
+            }
+            if (options.private) {
+                throw new Error("'private' must be False to leverage 'use_blob' feature");
+            }
+            throw new Error('useBlob CSV path not yet ported to tm1npm — tracked separately');
         }
 
-        const response = await this.rest.post(url);
-        return response.data;
+        const cellsetId = await this.createCellsetFromView(
+            cubeName, viewName, options.private ?? false, options.sandboxName);
+
+        if (options.useIterativeJson) {
+            return this.extractCellsetCsvIterJson(cellsetId, {
+                skipZeros,
+                top: options.top,
+                skip: options.skip,
+                skipConsolidatedCells: options.skipConsolidatedCells,
+                skipRuleDerivedCells: options.skipRuleDerivedCells,
+                csvDialect: options.csvDialect,
+                lineSeparator,
+                valueSeparator,
+                sandboxName: options.sandboxName,
+                mdxHeaders: options.mdxHeaders,
+            });
+        }
+
+        return this.extractCellsetCsv(cellsetId, {
+            skipZeros,
+            top: options.top,
+            skip: options.skip,
+            skipConsolidatedCells: options.skipConsolidatedCells,
+            skipRuleDerivedCells: options.skipRuleDerivedCells,
+            csvDialect: options.csvDialect,
+            lineSeparator,
+            valueSeparator,
+            sandboxName: options.sandboxName,
+            useCompactJson: options.useCompactJson,
+            mdxHeaders: options.mdxHeaders,
+        });
     }
 
     /**
@@ -1561,28 +1752,47 @@ export class CellService {
     }
 
     /**
-     * Execute MDX query and return raw TM1 response
+     * Execute MDX and return the raw cellset data. Mirrors tm1py's
+     * execute_mdx_raw (CellService.py:2338-2389): createCellset +
+     * extractCellsetRaw with the full tm1py parameter surface.
      */
     public async executeMdxRaw(
         mdx: string,
-        options: MDXViewOptions = {}
-    ): Promise<any> {
-        let url = '/ExecuteMDX';
+        options: ExecuteMdxRawOptions = {}
+    ): Promise<RawCellsetDict> {
+        const cellsetId = await this.createCellset(mdx, options.sandboxName);
+        return this.extractCellsetRaw(cellsetId, {
+            cellProperties: options.cellProperties,
+            elemProperties: options.elemProperties,
+            memberProperties: options.memberProperties,
+            top: options.top,
+            skip: options.skip,
+            deleteCellset: true,
+            skipContexts: options.skipContexts,
+            skipZeros: options.skipZeros,
+            skipConsolidatedCells: options.skipConsolidatedCells,
+            skipRuleDerivedCells: options.skipRuleDerivedCells,
+            sandboxName: options.sandboxName,
+            includeHierarchies: options.includeHierarchies,
+            useCompactJson: options.useCompactJson,
+        });
+    }
 
-        const params = new URLSearchParams();
-        if (options.sandbox_name) params.append('$sandbox', options.sandbox_name);
-        if (options.element_unique_names !== undefined) params.append('$element_unique_names', options.element_unique_names.toString());
-        if (options.skip_zeros !== undefined) params.append('$skip_zeros', options.skip_zeros.toString());
-        if (options.skip_consolidated !== undefined) params.append('$skip_consolidated', options.skip_consolidated.toString());
-        if (options.skip_rule_derived !== undefined) params.append('$skip_rule_derived', options.skip_rule_derived.toString());
-
-        if (params.toString()) {
-            url += `?${params.toString()}`;
-        }
-
-        const body = { MDX: mdx };
-        const response = await this.rest.post(url, body);
-        return response.data;
+    // Translate legacy MDXViewOptions to the new ExecuteMdxRawOptions shape so
+    // out-of-scope methods (executeMdxValues, executeMdxRowsAndValues, etc.) keep
+    // their existing public surface while delegating to the rewritten raw helpers.
+    // MDXViewOptions fields not present in tm1py's execute_mdx_raw signature
+    // (element_unique_names, use_iterative_json, use_blob, csv_dialect, mdx_headers)
+    // are intentionally dropped — they don't apply to the raw path. element_unique_names
+    // in particular was already a no-op pre-PR (the value path reads m.Name regardless).
+    private static _mdxViewToRawOptions(options: MDXViewOptions): ExecuteMdxRawOptions {
+        return {
+            sandboxName: options.sandbox_name,
+            skipZeros: options.skip_zeros,
+            skipConsolidatedCells: options.skip_consolidated,
+            skipRuleDerivedCells: options.skip_rule_derived,
+            useCompactJson: options.use_compact_json,
+        };
     }
 
     /**
@@ -1592,7 +1802,7 @@ export class CellService {
         mdx: string,
         options: MDXViewOptions = {}
     ): Promise<any[]> {
-        const cellset = await this.executeMdxRaw(mdx, options);
+        const cellset = await this.executeMdxRaw(mdx, CellService._mdxViewToRawOptions(options));
         return cellset.Cells ? cellset.Cells.map((cell: any) => cell.Value) : [];
     }
 
@@ -1603,7 +1813,7 @@ export class CellService {
         mdx: string,
         options: MDXViewOptions = {}
     ): Promise<{ rows: any[][], values: any[] }> {
-        const cellset = await this.executeMdxRaw(mdx, options);
+        const cellset = await this.executeMdxRaw(mdx, CellService._mdxViewToRawOptions(options));
 
         const rows: any[][] = [];
         const values: any[] = [];
@@ -1678,29 +1888,44 @@ export class CellService {
     }
 
     /**
-     * Execute view and return raw TM1 response
+     * Execute a view and return the raw cellset data. Mirrors tm1py's
+     * execute_view_raw (CellService.py:2391-2446): createCellsetFromView +
+     * extractCellsetRaw with the full tm1py parameter surface.
      */
     public async executeViewRaw(
         cubeName: string,
         viewName: string,
-        options: MDXViewOptions = {}
-    ): Promise<any> {
-        let url = `/Cubes('${cubeName}')/Views('${viewName}')/tm1.Execute`;
+        options: ExecuteViewRawOptions = {}
+    ): Promise<RawCellsetDict> {
+        const cellsetId = await this.createCellsetFromView(
+            cubeName, viewName, options.private ?? false, options.sandboxName);
+        // tm1py's execute_view_raw does NOT forward include_hierarchies (only
+        // execute_mdx_raw does). Omit it here too for strict parity.
+        return this.extractCellsetRaw(cellsetId, {
+            cellProperties: options.cellProperties,
+            elemProperties: options.elemProperties,
+            memberProperties: options.memberProperties,
+            top: options.top,
+            skip: options.skip,
+            skipContexts: options.skipContexts,
+            skipZeros: options.skipZeros,
+            skipConsolidatedCells: options.skipConsolidatedCells,
+            skipRuleDerivedCells: options.skipRuleDerivedCells,
+            deleteCellset: true,
+            sandboxName: options.sandboxName,
+            useCompactJson: options.useCompactJson,
+        });
+    }
 
-        const params = new URLSearchParams();
-        if (options.private !== undefined) params.append('$private', options.private.toString());
-        if (options.sandbox_name) params.append('$sandbox', options.sandbox_name);
-        if (options.element_unique_names !== undefined) params.append('$element_unique_names', options.element_unique_names.toString());
-        if (options.skip_zeros !== undefined) params.append('$skip_zeros', options.skip_zeros.toString());
-        if (options.skip_consolidated !== undefined) params.append('$skip_consolidated', options.skip_consolidated.toString());
-        if (options.skip_rule_derived !== undefined) params.append('$skip_rule_derived', options.skip_rule_derived.toString());
-
-        if (params.toString()) {
-            url += `?${params.toString()}`;
-        }
-
-        const response = await this.rest.post(url);
-        return response.data;
+    private static _mdxViewToViewRawOptions(options: MDXViewOptions): ExecuteViewRawOptions {
+        return {
+            private: options.private,
+            sandboxName: options.sandbox_name,
+            skipZeros: options.skip_zeros,
+            skipConsolidatedCells: options.skip_consolidated,
+            skipRuleDerivedCells: options.skip_rule_derived,
+            useCompactJson: options.use_compact_json,
+        };
     }
 
     /**
@@ -1711,7 +1936,7 @@ export class CellService {
         viewName: string,
         options: MDXViewOptions = {}
     ): Promise<any[]> {
-        const cellset = await this.executeViewRaw(cubeName, viewName, options);
+        const cellset = await this.executeViewRaw(cubeName, viewName, CellService._mdxViewToViewRawOptions(options));
         return cellset.Cells ? cellset.Cells.map((cell: any) => cell.Value) : [];
     }
 
@@ -1723,7 +1948,7 @@ export class CellService {
         viewName: string,
         options: MDXViewOptions = {}
     ): Promise<{ rows: any[][], values: any[] }> {
-        const cellset = await this.executeViewRaw(cubeName, viewName, options);
+        const cellset = await this.executeViewRaw(cubeName, viewName, CellService._mdxViewToViewRawOptions(options));
 
         const rows: any[][] = [];
         const values: any[] = [];
@@ -1812,7 +2037,7 @@ export class CellService {
         mdx: string,
         options: MDXViewOptions = {}
     ): Promise<DataFrame> {
-        const cellset = await this.executeMdxRaw(mdx, options);
+        const cellset = await this.executeMdxRaw(mdx, CellService._mdxViewToRawOptions(options));
         return this.buildDataFrameFromCellset(cellset);
     }
 
@@ -1824,7 +2049,7 @@ export class CellService {
         viewName: string,
         options: MDXViewOptions = {}
     ): Promise<DataFrame> {
-        const cellset = await this.executeViewRaw(cubeName, viewName, options);
+        const cellset = await this.executeViewRaw(cubeName, viewName, CellService._mdxViewToViewRawOptions(options));
         return this.buildDataFrameFromCellset(cellset);
     }
 
@@ -1886,7 +2111,7 @@ export class CellService {
         mdx: string,
         options: MDXViewOptions = {}
     ): Promise<DataFrame> {
-        const cellset = await this.executeMdxRaw(mdx, options);
+        const cellset = await this.executeMdxRaw(mdx, CellService._mdxViewToRawOptions(options));
         return this.buildPivotDataFrameFromCellset(cellset);
     }
 
@@ -1898,7 +2123,7 @@ export class CellService {
         viewName: string,
         options: MDXViewOptions = {}
     ): Promise<DataFrame> {
-        const cellset = await this.executeViewRaw(cubeName, viewName, options);
+        const cellset = await this.executeViewRaw(cubeName, viewName, CellService._mdxViewToViewRawOptions(options));
         return this.buildPivotDataFrameFromCellset(cellset);
     }
 
@@ -3116,7 +3341,7 @@ export class CellService {
         mdx: string,
         options: MDXViewOptions = {}
     ): Promise<any> {
-        const cellset = await this.executeMdxRaw(mdx, options);
+        const cellset = await this.executeMdxRaw(mdx, CellService._mdxViewToRawOptions(options));
         return this.formatForDygraph(cellset);
     }
 
@@ -3128,7 +3353,7 @@ export class CellService {
         viewName: string,
         options: MDXViewOptions = {}
     ): Promise<any> {
-        const cellset = await this.executeViewRaw(cubeName, viewName, options);
+        const cellset = await this.executeViewRaw(cubeName, viewName, CellService._mdxViewToViewRawOptions(options));
         return this.formatForDygraph(cellset);
     }
 
@@ -3139,7 +3364,7 @@ export class CellService {
         mdx: string,
         options: MDXViewOptions = {}
     ): Promise<any[][]> {
-        const cellset = await this.executeMdxRaw(mdx, options);
+        const cellset = await this.executeMdxRaw(mdx, CellService._mdxViewToRawOptions(options));
         return this.formatForUiArray(cellset);
     }
 
@@ -3151,7 +3376,7 @@ export class CellService {
         viewName: string,
         options: MDXViewOptions = {}
     ): Promise<any[][]> {
-        const cellset = await this.executeViewRaw(cubeName, viewName, options);
+        const cellset = await this.executeViewRaw(cubeName, viewName, CellService._mdxViewToViewRawOptions(options));
         return this.formatForUiArray(cellset);
     }
 
@@ -3262,13 +3487,9 @@ export class CellService {
         sandboxName?: string,
         options: { skipZeros?: boolean } = {}
     ): Promise<{ [key: string]: any }> {
-        // skip_consolidated_cells / skip_rule_derived_cells are not yet wired through
-        // executeMdxCsv to TM1's URL params, so they are deliberately omitted from this
-        // signature (compile-time enforcement matches the pattern used by executeMdxAsync /
-        // execute_view_async). Add them back when executeMdxCsv accepts them.
         const csv = await this.executeMdxCsv(mdx, {
-            sandbox_name: sandboxName,
-            skip_zeros: options.skipZeros !== false,
+            sandboxName,
+            skipZeros: options.skipZeros !== false,
         });
         if (!csv) return {};
         const lines = csv.split(/\r?\n/).filter(l => l.length > 0);
@@ -3430,13 +3651,45 @@ export class CellService {
     }
 
     /**
-     * Execute an MDX query
+     * Execute MDX and return cells with their properties as a
+     * CaseAndSpaceInsensitiveTuplesDict. Mirrors tm1py's execute_mdx
+     * (CellService.py:2065-2138): createCellset + extractCellset with the
+     * full tm1py parameter surface.
+     *
+     * When `maxWorkers > 1`, dispatches to the async path (parity with
+     * execute_mdx_async). tm1py forwards all options; tm1npm's
+     * `executeMdxAsync` currently only supports a subset — that gap is
+     * pre-existing and not introduced by this change.
      */
-    public async executeMdx(mdx: string): Promise<any> {
-        const url = '/ExecuteMDX';
-        const body = { MDX: mdx };
-        const response = await this.rest.post(url, body);
-        return response.data;
+    public async executeMdx(
+        mdx: string,
+        options: ExecuteMdxOptions = {}
+    ): Promise<CaseAndSpaceInsensitiveTuplesDict<any>> {
+        const maxWorkers = options.maxWorkers ?? 1;
+        if (maxWorkers > 1) {
+            // executeMdxAsync returns plain Map<string, any>; wrap into a TuplesDict to
+            // keep callers' return-type contract intact. Underlying values are unchanged.
+            const asyncResult = await this.executeMdxAsync(mdx, { sandbox_name: options.sandboxName });
+            const dict = new CaseAndSpaceInsensitiveTuplesDict<any>();
+            for (const [k, v] of asyncResult) dict.set(k, v);
+            return dict;
+        }
+        const cellsetId = await this.createCellset(mdx, options.sandboxName);
+        return this.extractCellset(cellsetId, {
+            cellProperties: options.cellProperties,
+            top: options.top,
+            skip: options.skip,
+            skipContexts: options.skipContexts,
+            skipZeros: options.skipZeros,
+            skipConsolidatedCells: options.skipConsolidatedCells,
+            skipRuleDerivedCells: options.skipRuleDerivedCells,
+            deleteCellset: true,
+            sandboxName: options.sandboxName,
+            elementUniqueNames: options.elementUniqueNames,
+            skipCellProperties: options.skipCellProperties,
+            useCompactJson: options.useCompactJson,
+            skipSandboxDimension: options.skipSandboxDimension,
+        });
     }
 
     /**

--- a/src/services/CellService.ts
+++ b/src/services/CellService.ts
@@ -836,13 +836,17 @@ export class CellService {
     }
 
     /**
-     * Create a cellset for advanced operations
+     * Create a cellset for advanced operations. Mirrors tm1py's
+     * create_cellset (CellService.py): POSTs `/ExecuteMDX` and appends the
+     * TM1 write-side `!sandbox=` parameter (NOT the OData read-side
+     * `$sandbox`) with quote-doubling as the only escaping (parity with
+     * tm1py's add_url_parameters at Utils.py:1011-1030).
      */
     public async createCellset(mdx: string, sandbox_name?: string): Promise<string> {
         let url = '/ExecuteMDX';
 
         if (sandbox_name) {
-            url += `?$sandbox=${sandbox_name}`;
+            url += `?!sandbox=${sandbox_name.replace(/'/g, "''")}`;
         }
 
         const body = { MDX: mdx };
@@ -851,13 +855,15 @@ export class CellService {
     }
 
     /**
-     * Delete a cellset
+     * Delete a cellset. Uses TM1's write-side `!sandbox=` parameter to match
+     * tm1py's add_url_parameters convention (no percent-encoding, only
+     * quote-doubling).
      */
     public async deleteCellset(cellsetId: string, sandbox_name?: string): Promise<void> {
         let url = `/Cellsets('${cellsetId}')`;
-        
+
         if (sandbox_name) {
-            url += `?$sandbox=${sandbox_name}`;
+            url += `?!sandbox=${sandbox_name.replace(/'/g, "''")}`;
         }
 
         await this.rest.delete(url);

--- a/src/services/CellService.ts
+++ b/src/services/CellService.ts
@@ -263,6 +263,10 @@ export interface ExecuteViewRawOptions extends Omit<ExecuteMdxRawOptions, 'inclu
 }
 
 // Options matching tm1py execute_mdx_csv (CellService.py:2562-2579).
+// tm1py's `use_blob` is intentionally NOT exposed yet — the blob CSV port
+// (`_execute_mdx_csv_use_blob`) is tracked as a follow-up; the option will
+// be added back when the underlying TI/blob path lands so the public
+// surface never advertises behaviour we don't actually implement.
 export interface ExecuteMdxCsvOptions {
     top?: number;
     skip?: number;
@@ -276,15 +280,16 @@ export interface ExecuteMdxCsvOptions {
     includeAttributes?: boolean;
     useIterativeJson?: boolean;
     useCompactJson?: boolean;
-    useBlob?: boolean;
     mdxHeaders?: boolean;
 }
 
 // Options matching tm1py execute_view_csv (CellService.py:2663-2682). Adds
-// private + arrangedAxes, drops includeAttributes (not in tm1py view_csv).
+// `private`, drops `includeAttributes` (not in tm1py view_csv). tm1py's
+// `use_blob` and `arranged_axes` are intentionally NOT exposed yet —
+// `arranged_axes` only affects the blob path in tm1py, so it travels with
+// the blob port; both will be added back together as a follow-up.
 export interface ExecuteViewCsvOptions extends Omit<ExecuteMdxCsvOptions, 'includeAttributes'> {
     private?: boolean;
-    arrangedAxes?: [string[], string[], string[]];
 }
 
 // tm1py uses CaseAndSpaceInsensitiveDict for measure-element lookups so callers can pass
@@ -741,9 +746,11 @@ export class CellService {
      * Note default `skipZeros=true` — different from executeMdx, matches
      * tm1py CSV semantics (CellService.py:2567).
      *
-     * useBlob validation gates match tm1py byte-for-byte (CellService.py:2602-2612).
-     * After all gates pass, throws "not yet ported" — documented parity gap
-     * approved for #65 scope; blob CSV path port is tracked as a follow-up.
+     * tm1py's `use_blob` is not exposed yet — see ExecuteMdxCsvOptions for
+     * the deferral note. extractCellsetCsv handles cellset cleanup itself
+     * (deleteCellset=true default); extractCellsetCsvIterJson does NOT, so
+     * the iter-json branch wraps its call in try/finally to avoid leaking
+     * cellsets on the TM1 server.
      */
     public async executeMdxCsv(
         mdx: string,
@@ -753,41 +760,26 @@ export class CellService {
         const lineSeparator = options.lineSeparator ?? '\r\n';
         const valueSeparator = options.valueSeparator ?? ',';
 
-        if (options.useBlob) {
-            if (options.includeAttributes) {
-                throw new Error("'include_attributes' must not be used in conjunction with 'use_blob'");
-            }
-            if (options.useIterativeJson) {
-                throw new Error("'use_iterative_json' must not be used in conjunction with 'use_blob'");
-            }
-            if (options.useCompactJson) {
-                throw new Error("'use_compact_json' must not be used in conjunction with 'use_blob'");
-            }
-            if (options.csvDialect) {
-                throw new Error("'csv_dialect' must not be used in conjunction with 'use_blob'");
-            }
-            if (lineSeparator !== '\r\n') {
-                throw new Error("'line_separator' must be '\r\n' to leverage 'use_blob' feature");
-            }
-            throw new Error('useBlob CSV path not yet ported to tm1npm — tracked separately');
-        }
-
         const cellsetId = await this.createCellset(mdx, options.sandboxName);
 
         if (options.useIterativeJson) {
-            return this.extractCellsetCsvIterJson(cellsetId, {
-                top: options.top,
-                skip: options.skip,
-                skipZeros,
-                skipConsolidatedCells: options.skipConsolidatedCells,
-                skipRuleDerivedCells: options.skipRuleDerivedCells,
-                csvDialect: options.csvDialect,
-                lineSeparator,
-                valueSeparator,
-                sandboxName: options.sandboxName,
-                includeAttributes: options.includeAttributes,
-                mdxHeaders: options.mdxHeaders,
-            });
+            try {
+                return await this.extractCellsetCsvIterJson(cellsetId, {
+                    top: options.top,
+                    skip: options.skip,
+                    skipZeros,
+                    skipConsolidatedCells: options.skipConsolidatedCells,
+                    skipRuleDerivedCells: options.skipRuleDerivedCells,
+                    csvDialect: options.csvDialect,
+                    lineSeparator,
+                    valueSeparator,
+                    sandboxName: options.sandboxName,
+                    includeAttributes: options.includeAttributes,
+                    mdxHeaders: options.mdxHeaders,
+                });
+            } finally {
+                await this._safeDeleteCellset(cellsetId, options.sandboxName);
+            }
         }
 
         return this.extractCellsetCsv(cellsetId, {
@@ -811,10 +803,11 @@ export class CellService {
      * (CellService.py:2663-2769): createCellsetFromView + extractCellsetCsv
      * (or extractCellsetCsvIterJson) with the full tm1py parameter surface.
      *
-     * useBlob validation gates match tm1py byte-for-byte
-     * (CellService.py:2709-2719) including the `private=False` requirement.
-     * After all gates pass, throws "not yet ported" — documented parity gap
-     * approved for #65 scope; blob CSV path port is tracked as a follow-up.
+     * tm1py's `use_blob` (+ its associated `arranged_axes` reorder) is not
+     * exposed yet — see ExecuteViewCsvOptions for the deferral note.
+     * extractCellsetCsvIterJson does not delete the cellset itself, so the
+     * iter-json branch wraps its call in try/finally to avoid leaking
+     * cellsets on the TM1 server.
      */
     public async executeViewCsv(
         cubeName: string,
@@ -825,41 +818,26 @@ export class CellService {
         const lineSeparator = options.lineSeparator ?? '\r\n';
         const valueSeparator = options.valueSeparator ?? ',';
 
-        if (options.useBlob) {
-            if (options.useIterativeJson) {
-                throw new Error("'use_iterative_json' must not be used in conjunction with 'use_blob'");
-            }
-            if (options.useCompactJson) {
-                throw new Error("'use_compact_json' must not be used in conjunction with 'use_blob'");
-            }
-            if (options.csvDialect) {
-                throw new Error("'csv_dialect' must not be used in conjunction with 'use_blob'");
-            }
-            if (lineSeparator !== '\r\n') {
-                throw new Error("'line_separator' must be '\r\n' to leverage 'use_blob' feature");
-            }
-            if (options.private) {
-                throw new Error("'private' must be False to leverage 'use_blob' feature");
-            }
-            throw new Error('useBlob CSV path not yet ported to tm1npm — tracked separately');
-        }
-
         const cellsetId = await this.createCellsetFromView(
             cubeName, viewName, options.private ?? false, options.sandboxName);
 
         if (options.useIterativeJson) {
-            return this.extractCellsetCsvIterJson(cellsetId, {
-                skipZeros,
-                top: options.top,
-                skip: options.skip,
-                skipConsolidatedCells: options.skipConsolidatedCells,
-                skipRuleDerivedCells: options.skipRuleDerivedCells,
-                csvDialect: options.csvDialect,
-                lineSeparator,
-                valueSeparator,
-                sandboxName: options.sandboxName,
-                mdxHeaders: options.mdxHeaders,
-            });
+            try {
+                return await this.extractCellsetCsvIterJson(cellsetId, {
+                    skipZeros,
+                    top: options.top,
+                    skip: options.skip,
+                    skipConsolidatedCells: options.skipConsolidatedCells,
+                    skipRuleDerivedCells: options.skipRuleDerivedCells,
+                    csvDialect: options.csvDialect,
+                    lineSeparator,
+                    valueSeparator,
+                    sandboxName: options.sandboxName,
+                    mdxHeaders: options.mdxHeaders,
+                });
+            } finally {
+                await this._safeDeleteCellset(cellsetId, options.sandboxName);
+            }
         }
 
         return this.extractCellsetCsv(cellsetId, {
@@ -3683,7 +3661,7 @@ export class CellService {
             // tm1py's execute_mdx forwards every option to execute_mdx_async; tm1npm's
             // executeMdxAsync currently only accepts {sandbox_name, cubeName}. Fail loud
             // if the caller set any other option in the async branch so option drop is
-            // never silent — mirrors the useBlob gate strategy.
+            // never silent — the public surface only advertises behaviour we actually do.
             const unsupported = (Object.keys(options) as Array<keyof ExecuteMdxOptions>).filter(
                 k => k !== 'maxWorkers' && k !== 'asyncAxis' && k !== 'sandboxName' && options[k] !== undefined
             );

--- a/src/tests/CellService.execute.parity.test.ts
+++ b/src/tests/CellService.execute.parity.test.ts
@@ -85,19 +85,27 @@ describe('CellService execute methods — tm1py parity (#65)', () => {
             }));
         });
 
-        test('maxWorkers > 1 dispatches to executeMdxAsync; unsupported options silently dropped (tm1py **kwargs parity)', async () => {
-            const asyncSpy = jest.spyOn(cellService, 'executeMdxAsync')
-                .mockResolvedValue(new Map<string, any>([['a', 1]]));
+        test('maxWorkers > 1 dispatches to executeMdxAsync with full options forwarded (tm1py parity)', async () => {
+            const dict = new CaseAndSpaceInsensitiveTuplesDict<any>();
+            dict.set('a', 1);
+            const asyncSpy = jest.spyOn(cellService, 'executeMdxAsync').mockResolvedValue(dict);
             const extractSpy = jest.spyOn(cellService, 'extractCellset');
 
-            // tm1py forwards everything via **kwargs and silently ignores options the
-            // underlying call doesn't consume. tm1npm matches that loose validation —
-            // cellProperties is not forwarded but does not throw.
+            // tm1py's execute_mdx with max_workers>1 forwards every named option to
+            // execute_mdx_async (CellService.py:2102-2119). tm1npm now forwards the
+            // full ExecuteMdxOptions surface.
             const result = await cellService.executeMdx('SELECT 1 ON 0 FROM [c]', {
                 maxWorkers: 8, sandboxName: 'sb', cellProperties: ['Value'],
+                top: 100, skipZeros: true,
             });
 
-            expect(asyncSpy).toHaveBeenCalledWith('SELECT 1 ON 0 FROM [c]', { sandbox_name: 'sb' });
+            expect(asyncSpy).toHaveBeenCalledWith('SELECT 1 ON 0 FROM [c]', expect.objectContaining({
+                maxWorkers: 8,
+                sandboxName: 'sb',
+                cellProperties: ['Value'],
+                top: 100,
+                skipZeros: true,
+            }));
             expect(extractSpy).not.toHaveBeenCalled();
             expect(result).toBeInstanceOf(CaseAndSpaceInsensitiveTuplesDict);
         });
@@ -179,24 +187,30 @@ describe('CellService execute methods — tm1py parity (#65)', () => {
             }));
         });
 
-        test('maxWorkers > 1 dispatches to execute_view_async; unsupported options silently dropped (tm1py **kwargs parity)', async () => {
+        test('maxWorkers > 1 dispatches to execute_view_async with full options forwarded (tm1py parity)', async () => {
             const asyncSpy = jest.spyOn(cellService, 'execute_view_async')
-                .mockResolvedValue(new Map());
+                .mockResolvedValue(new CaseAndSpaceInsensitiveTuplesDict<any>());
             const extractSpy = jest.spyOn(cellService, 'extractCellset');
 
-            // tm1py's execute_view dispatches via **kwargs and never throws on
-            // unsupported options. tm1npm matches that — cellProperties is not
-            // forwarded but does not throw.
+            // tm1py's execute_view with max_workers>1 forwards every named option
+            // (CellService.py:2241-2257). tm1npm now forwards the full ExecuteViewOptions.
             await cellService.executeView('Cube', 'View', {
                 maxWorkers: 8,
                 private: true,
                 sandboxName: 'sb',
                 cellProperties: ['Value'],
+                top: 100,
+                skipZeros: true,
             });
 
-            expect(asyncSpy).toHaveBeenCalledWith('Cube', 'View', {
-                private: true, sandbox_name: 'sb',
-            });
+            expect(asyncSpy).toHaveBeenCalledWith('Cube', 'View', expect.objectContaining({
+                maxWorkers: 8,
+                private: true,
+                sandboxName: 'sb',
+                cellProperties: ['Value'],
+                top: 100,
+                skipZeros: true,
+            }));
             expect(extractSpy).not.toHaveBeenCalled();
         });
     });

--- a/src/tests/CellService.execute.parity.test.ts
+++ b/src/tests/CellService.execute.parity.test.ts
@@ -1,0 +1,399 @@
+/**
+ * Behavioral parity tests for CellService execute methods (issue #65).
+ *
+ * Verifies that executeMdx, executeMdxRaw, executeView, executeViewRaw,
+ * executeMdxCsv, executeViewCsv accept and forward the full tm1py
+ * parameter surface to the underlying extract helpers, match tm1py's
+ * default values, and reject useBlob combinations with tm1py's exact
+ * error messages.
+ */
+
+import { CellService } from '../services/CellService';
+import { RestService } from '../services/RestService';
+import { CaseAndSpaceInsensitiveTuplesDict } from '../utils/Utils';
+
+const mkResp = (data: any) => ({ data, status: 200, statusText: 'OK', headers: {}, config: {} as any });
+
+describe('CellService execute methods — tm1py parity (#65)', () => {
+    let cellService: CellService;
+    let rest: jest.Mocked<RestService>;
+
+    beforeEach(() => {
+        rest = {
+            get: jest.fn(),
+            post: jest.fn(),
+            patch: jest.fn(),
+            delete: jest.fn(),
+            put: jest.fn(),
+            config: {} as any,
+            rest: {} as any,
+            buildBaseUrl: jest.fn(),
+            extractErrorMessage: jest.fn(),
+        } as any;
+        cellService = new CellService(rest);
+    });
+
+    // ── executeMdx ───────────────────────────────────────────────────────
+
+    describe('executeMdx', () => {
+        test('returns CaseAndSpaceInsensitiveTuplesDict, not raw cellset', async () => {
+            jest.spyOn(cellService, 'createCellset').mockResolvedValue('cs1');
+            jest.spyOn(cellService, 'extractCellset').mockResolvedValue(new CaseAndSpaceInsensitiveTuplesDict<any>());
+
+            const result = await cellService.executeMdx('SELECT 1 ON 0 FROM [c]');
+
+            expect(result).toBeInstanceOf(CaseAndSpaceInsensitiveTuplesDict);
+            // Raw cellset shape should NOT be present on the TuplesDict result.
+            expect((result as any).Axes).toBeUndefined();
+            expect((result as any).Cells).toBeUndefined();
+        });
+
+        test('forwards all tm1py params to extractCellset', async () => {
+            jest.spyOn(cellService, 'createCellset').mockResolvedValue('cs1');
+            const extractSpy = jest.spyOn(cellService, 'extractCellset')
+                .mockResolvedValue(new CaseAndSpaceInsensitiveTuplesDict<any>());
+
+            await cellService.executeMdx('SELECT 1 ON 0 FROM [c]', {
+                cellProperties: ['Value', 'RuleDerived'],
+                top: 5,
+                skip: 2,
+                skipContexts: true,
+                skipZeros: true,
+                skipConsolidatedCells: true,
+                skipRuleDerivedCells: true,
+                sandboxName: 'sb',
+                elementUniqueNames: false,
+                skipCellProperties: true,
+                useCompactJson: true,
+                skipSandboxDimension: true,
+            });
+
+            expect(extractSpy).toHaveBeenCalledWith('cs1', expect.objectContaining({
+                cellProperties: ['Value', 'RuleDerived'],
+                top: 5,
+                skip: 2,
+                skipContexts: true,
+                skipZeros: true,
+                skipConsolidatedCells: true,
+                skipRuleDerivedCells: true,
+                sandboxName: 'sb',
+                elementUniqueNames: false,
+                skipCellProperties: true,
+                useCompactJson: true,
+                skipSandboxDimension: true,
+                deleteCellset: true,
+            }));
+        });
+
+        test('maxWorkers > 1 dispatches to executeMdxAsync', async () => {
+            const asyncSpy = jest.spyOn(cellService, 'executeMdxAsync')
+                .mockResolvedValue(new Map<string, any>([['a', 1]]));
+            const extractSpy = jest.spyOn(cellService, 'extractCellset');
+
+            const result = await cellService.executeMdx('SELECT 1 ON 0 FROM [c]', {
+                maxWorkers: 8, sandboxName: 'sb',
+            });
+
+            expect(asyncSpy).toHaveBeenCalledWith('SELECT 1 ON 0 FROM [c]', { sandbox_name: 'sb' });
+            expect(extractSpy).not.toHaveBeenCalled();
+            expect(result).toBeInstanceOf(CaseAndSpaceInsensitiveTuplesDict);
+        });
+
+        test('default skipZeros is false (parity with tm1py execute_mdx)', async () => {
+            jest.spyOn(cellService, 'createCellset').mockResolvedValue('cs1');
+            const extractSpy = jest.spyOn(cellService, 'extractCellset')
+                .mockResolvedValue(new CaseAndSpaceInsensitiveTuplesDict<any>());
+
+            await cellService.executeMdx('SELECT 1 ON 0 FROM [c]');
+
+            expect(extractSpy).toHaveBeenCalledWith('cs1', expect.objectContaining({
+                skipZeros: undefined,
+            }));
+        });
+    });
+
+    // ── executeMdxRaw ────────────────────────────────────────────────────
+
+    describe('executeMdxRaw', () => {
+        test('forwards elemProperties/memberProperties/includeHierarchies', async () => {
+            jest.spyOn(cellService, 'createCellset').mockResolvedValue('cs1');
+            const extractSpy = jest.spyOn(cellService, 'extractCellsetRaw')
+                .mockResolvedValue({ Axes: [], Cells: [] } as any);
+
+            await cellService.executeMdxRaw('SELECT 1 ON 0 FROM [c]', {
+                cellProperties: ['Value'],
+                elemProperties: ['Name', 'Type'],
+                memberProperties: ['Name', 'UniqueName'],
+                top: 3,
+                skip: 1,
+                skipContexts: true,
+                skipZeros: true,
+                sandboxName: 'sb',
+                includeHierarchies: true,
+                useCompactJson: true,
+            });
+
+            expect(extractSpy).toHaveBeenCalledWith('cs1', expect.objectContaining({
+                elemProperties: ['Name', 'Type'],
+                memberProperties: ['Name', 'UniqueName'],
+                includeHierarchies: true,
+                useCompactJson: true,
+                deleteCellset: true,
+            }));
+        });
+
+        test('returns raw cellset (preserves Axes/Cells)', async () => {
+            jest.spyOn(cellService, 'createCellset').mockResolvedValue('cs1');
+            const raw = { Axes: [{ Tuples: [] }], Cells: [{ Value: 42 }] } as any;
+            jest.spyOn(cellService, 'extractCellsetRaw').mockResolvedValue(raw);
+
+            const result = await cellService.executeMdxRaw('SELECT 1 ON 0 FROM [c]');
+            expect(result.Cells).toEqual([{ Value: 42 }]);
+            expect(result.Axes).toBeDefined();
+        });
+    });
+
+    // ── executeView ──────────────────────────────────────────────────────
+
+    describe('executeView', () => {
+        test('routes via createCellsetFromView with private + sandbox', async () => {
+            const createViewSpy = jest.spyOn(cellService, 'createCellsetFromView')
+                .mockResolvedValue('cs1');
+            const extractSpy = jest.spyOn(cellService, 'extractCellset')
+                .mockResolvedValue(new CaseAndSpaceInsensitiveTuplesDict<any>());
+
+            await cellService.executeView('Cube', 'View', {
+                private: true,
+                sandboxName: 'sb',
+                top: 5,
+            });
+
+            expect(createViewSpy).toHaveBeenCalledWith('Cube', 'View', true, 'sb');
+            expect(extractSpy).toHaveBeenCalledWith('cs1', expect.objectContaining({
+                top: 5,
+                sandboxName: 'sb',
+                deleteCellset: true,
+            }));
+        });
+
+        test('maxWorkers > 1 dispatches to execute_view_async with only {private, sandbox_name} (tm1py quirk parity)', async () => {
+            const asyncSpy = jest.spyOn(cellService, 'execute_view_async')
+                .mockResolvedValue(new Map());
+            const extractSpy = jest.spyOn(cellService, 'extractCellset');
+
+            await cellService.executeView('Cube', 'View', {
+                maxWorkers: 8,
+                private: true,
+                sandboxName: 'sb',
+                cellProperties: ['Value'],  // tm1py drops this on async branch
+                useCompactJson: true,        // tm1py drops this too
+            });
+
+            expect(asyncSpy).toHaveBeenCalledWith('Cube', 'View', {
+                private: true, sandbox_name: 'sb',
+            });
+            expect(asyncSpy).not.toHaveBeenCalledWith(expect.anything(), expect.anything(),
+                expect.objectContaining({ cellProperties: expect.anything() }));
+            expect(extractSpy).not.toHaveBeenCalled();
+        });
+    });
+
+    // ── executeViewRaw ───────────────────────────────────────────────────
+
+    describe('executeViewRaw', () => {
+        test('forwards full param surface (excluding includeHierarchies — tm1py parity)', async () => {
+            jest.spyOn(cellService, 'createCellsetFromView').mockResolvedValue('cs1');
+            const extractSpy = jest.spyOn(cellService, 'extractCellsetRaw')
+                .mockResolvedValue({ Axes: [], Cells: [] } as any);
+
+            await cellService.executeViewRaw('Cube', 'View', {
+                private: true,
+                cellProperties: ['Value'],
+                elemProperties: ['Name'],
+                memberProperties: ['Name'],
+                top: 5,
+                skipContexts: true,
+                skipZeros: true,
+                sandboxName: 'sb',
+                useCompactJson: true,
+            });
+
+            expect(extractSpy).toHaveBeenCalledWith('cs1', expect.objectContaining({
+                cellProperties: ['Value'],
+                elemProperties: ['Name'],
+                memberProperties: ['Name'],
+                top: 5,
+                skipContexts: true,
+                skipZeros: true,
+                useCompactJson: true,
+                deleteCellset: true,
+            }));
+            // tm1py's execute_view_raw does NOT forward include_hierarchies — strict parity.
+            expect(extractSpy.mock.calls[0][1]).not.toHaveProperty('includeHierarchies');
+        });
+    });
+
+    // ── executeMdxCsv ────────────────────────────────────────────────────
+
+    describe('executeMdxCsv', () => {
+        test('default skipZeros is true (tm1py CSV default — different from executeMdx)', async () => {
+            jest.spyOn(cellService, 'createCellset').mockResolvedValue('cs1');
+            const extractCsv = jest.spyOn(cellService, 'extractCellsetCsv').mockResolvedValue('');
+
+            await cellService.executeMdxCsv('SELECT 1 ON 0 FROM [c]');
+
+            expect(extractCsv).toHaveBeenCalledWith('cs1', expect.objectContaining({
+                skipZeros: true,
+            }));
+        });
+
+        test('explicit skipZeros=false is honored', async () => {
+            jest.spyOn(cellService, 'createCellset').mockResolvedValue('cs1');
+            const extractCsv = jest.spyOn(cellService, 'extractCellsetCsv').mockResolvedValue('');
+
+            await cellService.executeMdxCsv('SELECT 1 ON 0 FROM [c]', { skipZeros: false });
+
+            expect(extractCsv).toHaveBeenCalledWith('cs1', expect.objectContaining({
+                skipZeros: false,
+            }));
+        });
+
+        test('forwards csvDialect/lineSeparator/valueSeparator/mdxHeaders/includeAttributes', async () => {
+            jest.spyOn(cellService, 'createCellset').mockResolvedValue('cs1');
+            const extractCsv = jest.spyOn(cellService, 'extractCellsetCsv').mockResolvedValue('csv');
+
+            await cellService.executeMdxCsv('SELECT 1 ON 0 FROM [c]', {
+                csvDialect: { delimiter: ';', lineterminator: '\n' } as any,
+                lineSeparator: '\n',
+                valueSeparator: ';',
+                includeAttributes: true,
+                useCompactJson: true,
+                mdxHeaders: true,
+                top: 10,
+                skip: 1,
+            });
+
+            expect(extractCsv).toHaveBeenCalledWith('cs1', expect.objectContaining({
+                csvDialect: { delimiter: ';', lineterminator: '\n' },
+                lineSeparator: '\n',
+                valueSeparator: ';',
+                includeAttributes: true,
+                useCompactJson: true,
+                mdxHeaders: true,
+            }));
+        });
+
+        test('useIterativeJson routes to extractCellsetCsvIterJson, not extractCellsetCsv', async () => {
+            jest.spyOn(cellService, 'createCellset').mockResolvedValue('cs1');
+            const iterSpy = jest.spyOn(cellService, 'extractCellsetCsvIterJson').mockResolvedValue('iter');
+            const csvSpy = jest.spyOn(cellService, 'extractCellsetCsv').mockResolvedValue('csv');
+
+            const result = await cellService.executeMdxCsv('SELECT 1 ON 0 FROM [c]', {
+                useIterativeJson: true, sandboxName: 'sb',
+            });
+
+            expect(iterSpy).toHaveBeenCalledWith('cs1', expect.objectContaining({ sandboxName: 'sb' }));
+            expect(csvSpy).not.toHaveBeenCalled();
+            expect(result).toBe('iter');
+        });
+
+        describe('useBlob validation gates (tm1py CellService.py:2602-2612)', () => {
+            test('include_attributes mutex', async () => {
+                await expect(cellService.executeMdxCsv('q', { useBlob: true, includeAttributes: true }))
+                    .rejects.toThrow("'include_attributes' must not be used in conjunction with 'use_blob'");
+            });
+
+            test('use_iterative_json mutex', async () => {
+                await expect(cellService.executeMdxCsv('q', { useBlob: true, useIterativeJson: true }))
+                    .rejects.toThrow("'use_iterative_json' must not be used in conjunction with 'use_blob'");
+            });
+
+            test('use_compact_json mutex', async () => {
+                await expect(cellService.executeMdxCsv('q', { useBlob: true, useCompactJson: true }))
+                    .rejects.toThrow("'use_compact_json' must not be used in conjunction with 'use_blob'");
+            });
+
+            test('csv_dialect mutex', async () => {
+                await expect(cellService.executeMdxCsv('q', { useBlob: true, csvDialect: {} as any }))
+                    .rejects.toThrow("'csv_dialect' must not be used in conjunction with 'use_blob'");
+            });
+
+            test('line_separator must be \\r\\n', async () => {
+                await expect(cellService.executeMdxCsv('q', { useBlob: true, lineSeparator: '\n' }))
+                    .rejects.toThrow("'line_separator' must be '\r\n' to leverage 'use_blob' feature");
+            });
+
+            test('all gates pass → throws not-yet-ported (documented parity gap)', async () => {
+                await expect(cellService.executeMdxCsv('q', { useBlob: true }))
+                    .rejects.toThrow('useBlob CSV path not yet ported to tm1npm');
+            });
+        });
+    });
+
+    // ── executeViewCsv ───────────────────────────────────────────────────
+
+    describe('executeViewCsv', () => {
+        test('routes via createCellsetFromView with private', async () => {
+            const createViewSpy = jest.spyOn(cellService, 'createCellsetFromView')
+                .mockResolvedValue('cs1');
+            jest.spyOn(cellService, 'extractCellsetCsv').mockResolvedValue('csv');
+
+            await cellService.executeViewCsv('Cube', 'View', { private: true, sandboxName: 'sb' });
+
+            expect(createViewSpy).toHaveBeenCalledWith('Cube', 'View', true, 'sb');
+        });
+
+        test('default skipZeros is true', async () => {
+            jest.spyOn(cellService, 'createCellsetFromView').mockResolvedValue('cs1');
+            const extractCsv = jest.spyOn(cellService, 'extractCellsetCsv').mockResolvedValue('');
+
+            await cellService.executeViewCsv('Cube', 'View');
+
+            expect(extractCsv).toHaveBeenCalledWith('cs1', expect.objectContaining({ skipZeros: true }));
+        });
+
+        test('useIterativeJson routes to extractCellsetCsvIterJson', async () => {
+            jest.spyOn(cellService, 'createCellsetFromView').mockResolvedValue('cs1');
+            const iterSpy = jest.spyOn(cellService, 'extractCellsetCsvIterJson').mockResolvedValue('iter');
+            const csvSpy = jest.spyOn(cellService, 'extractCellsetCsv').mockResolvedValue('csv');
+
+            const result = await cellService.executeViewCsv('Cube', 'View', { useIterativeJson: true });
+
+            expect(iterSpy).toHaveBeenCalled();
+            expect(csvSpy).not.toHaveBeenCalled();
+            expect(result).toBe('iter');
+        });
+
+        describe('useBlob validation gates (tm1py CellService.py:2709-2719)', () => {
+            test('use_iterative_json mutex', async () => {
+                await expect(cellService.executeViewCsv('Cube', 'View', { useBlob: true, useIterativeJson: true }))
+                    .rejects.toThrow("'use_iterative_json' must not be used in conjunction with 'use_blob'");
+            });
+
+            test('use_compact_json mutex', async () => {
+                await expect(cellService.executeViewCsv('Cube', 'View', { useBlob: true, useCompactJson: true }))
+                    .rejects.toThrow("'use_compact_json' must not be used in conjunction with 'use_blob'");
+            });
+
+            test('csv_dialect mutex', async () => {
+                await expect(cellService.executeViewCsv('Cube', 'View', { useBlob: true, csvDialect: {} as any }))
+                    .rejects.toThrow("'csv_dialect' must not be used in conjunction with 'use_blob'");
+            });
+
+            test('line_separator must be \\r\\n', async () => {
+                await expect(cellService.executeViewCsv('Cube', 'View', { useBlob: true, lineSeparator: '\n' }))
+                    .rejects.toThrow("'line_separator' must be '\r\n' to leverage 'use_blob' feature");
+            });
+
+            test('private must be false', async () => {
+                await expect(cellService.executeViewCsv('Cube', 'View', { useBlob: true, private: true }))
+                    .rejects.toThrow("'private' must be False to leverage 'use_blob' feature");
+            });
+
+            test('all gates pass → throws not-yet-ported', async () => {
+                await expect(cellService.executeViewCsv('Cube', 'View', { useBlob: true }))
+                    .rejects.toThrow('useBlob CSV path not yet ported to tm1npm');
+            });
+        });
+    });
+});

--- a/src/tests/CellService.execute.parity.test.ts
+++ b/src/tests/CellService.execute.parity.test.ts
@@ -85,7 +85,7 @@ describe('CellService execute methods — tm1py parity (#65)', () => {
             }));
         });
 
-        test('maxWorkers > 1 dispatches to executeMdxAsync', async () => {
+        test('maxWorkers > 1 with supported-only options dispatches to executeMdxAsync', async () => {
             const asyncSpy = jest.spyOn(cellService, 'executeMdxAsync')
                 .mockResolvedValue(new Map<string, any>([['a', 1]]));
             const extractSpy = jest.spyOn(cellService, 'extractCellset');
@@ -97,6 +97,15 @@ describe('CellService execute methods — tm1py parity (#65)', () => {
             expect(asyncSpy).toHaveBeenCalledWith('SELECT 1 ON 0 FROM [c]', { sandbox_name: 'sb' });
             expect(extractSpy).not.toHaveBeenCalled();
             expect(result).toBeInstanceOf(CaseAndSpaceInsensitiveTuplesDict);
+        });
+
+        test('maxWorkers > 1 with unsupported options throws (no silent option drop)', async () => {
+            // tm1npm's executeMdxAsync currently only accepts {sandbox_name, cubeName};
+            // any other option set alongside maxWorkers>1 must fail loud.
+            await expect(cellService.executeMdx('SELECT 1 ON 0 FROM [c]', {
+                maxWorkers: 8,
+                cellProperties: ['Value'],
+            })).rejects.toThrow(/executeMdx maxWorkers>1 path does not yet forward/);
         });
 
         test('default skipZeros is false (parity with tm1py execute_mdx)', async () => {
@@ -176,7 +185,7 @@ describe('CellService execute methods — tm1py parity (#65)', () => {
             }));
         });
 
-        test('maxWorkers > 1 dispatches to execute_view_async with only {private, sandbox_name} (tm1py quirk parity)', async () => {
+        test('maxWorkers > 1 with supported-only options dispatches to execute_view_async', async () => {
             const asyncSpy = jest.spyOn(cellService, 'execute_view_async')
                 .mockResolvedValue(new Map());
             const extractSpy = jest.spyOn(cellService, 'extractCellset');
@@ -185,16 +194,21 @@ describe('CellService execute methods — tm1py parity (#65)', () => {
                 maxWorkers: 8,
                 private: true,
                 sandboxName: 'sb',
-                cellProperties: ['Value'],  // tm1py drops this on async branch
-                useCompactJson: true,        // tm1py drops this too
             });
 
             expect(asyncSpy).toHaveBeenCalledWith('Cube', 'View', {
                 private: true, sandbox_name: 'sb',
             });
-            expect(asyncSpy).not.toHaveBeenCalledWith(expect.anything(), expect.anything(),
-                expect.objectContaining({ cellProperties: expect.anything() }));
             expect(extractSpy).not.toHaveBeenCalled();
+        });
+
+        test('maxWorkers > 1 with unsupported options throws (no silent option drop)', async () => {
+            // tm1npm's execute_view_async currently only accepts {private, sandbox_name};
+            // any other option set alongside maxWorkers>1 must fail loud.
+            await expect(cellService.executeView('Cube', 'View', {
+                maxWorkers: 8,
+                cellProperties: ['Value'],
+            })).rejects.toThrow(/executeView maxWorkers>1 path does not yet forward/);
         });
     });
 

--- a/src/tests/CellService.execute.parity.test.ts
+++ b/src/tests/CellService.execute.parity.test.ts
@@ -3,9 +3,9 @@
  *
  * Verifies that executeMdx, executeMdxRaw, executeView, executeViewRaw,
  * executeMdxCsv, executeViewCsv accept and forward the full tm1py
- * parameter surface to the underlying extract helpers, match tm1py's
- * default values, and reject useBlob combinations with tm1py's exact
- * error messages.
+ * parameter surface to the underlying extract helpers and match tm1py's
+ * default values. tm1py's useBlob CSV path is intentionally not exposed
+ * yet (see ExecuteMdxCsvOptions / ExecuteViewCsvOptions deferral note).
  */
 
 import { CellService } from '../services/CellService';
@@ -301,6 +301,7 @@ describe('CellService execute methods — tm1py parity (#65)', () => {
             jest.spyOn(cellService, 'createCellset').mockResolvedValue('cs1');
             const iterSpy = jest.spyOn(cellService, 'extractCellsetCsvIterJson').mockResolvedValue('iter');
             const csvSpy = jest.spyOn(cellService, 'extractCellsetCsv').mockResolvedValue('csv');
+            jest.spyOn(cellService, '_safeDeleteCellset').mockResolvedValue(undefined);
 
             const result = await cellService.executeMdxCsv('SELECT 1 ON 0 FROM [c]', {
                 useIterativeJson: true, sandboxName: 'sb',
@@ -311,36 +312,27 @@ describe('CellService execute methods — tm1py parity (#65)', () => {
             expect(result).toBe('iter');
         });
 
-        describe('useBlob validation gates (tm1py CellService.py:2602-2612)', () => {
-            test('include_attributes mutex', async () => {
-                await expect(cellService.executeMdxCsv('q', { useBlob: true, includeAttributes: true }))
-                    .rejects.toThrow("'include_attributes' must not be used in conjunction with 'use_blob'");
+        test('useIterativeJson cleans up cellset via _safeDeleteCellset (no leak)', async () => {
+            jest.spyOn(cellService, 'createCellset').mockResolvedValue('cs1');
+            jest.spyOn(cellService, 'extractCellsetCsvIterJson').mockResolvedValue('iter');
+            const deleteSpy = jest.spyOn(cellService, '_safeDeleteCellset').mockResolvedValue(undefined);
+
+            await cellService.executeMdxCsv('SELECT 1 ON 0 FROM [c]', {
+                useIterativeJson: true, sandboxName: 'sb',
             });
 
-            test('use_iterative_json mutex', async () => {
-                await expect(cellService.executeMdxCsv('q', { useBlob: true, useIterativeJson: true }))
-                    .rejects.toThrow("'use_iterative_json' must not be used in conjunction with 'use_blob'");
-            });
+            expect(deleteSpy).toHaveBeenCalledWith('cs1', 'sb');
+        });
 
-            test('use_compact_json mutex', async () => {
-                await expect(cellService.executeMdxCsv('q', { useBlob: true, useCompactJson: true }))
-                    .rejects.toThrow("'use_compact_json' must not be used in conjunction with 'use_blob'");
-            });
+        test('useIterativeJson cleans up cellset even when extract throws', async () => {
+            jest.spyOn(cellService, 'createCellset').mockResolvedValue('cs1');
+            jest.spyOn(cellService, 'extractCellsetCsvIterJson').mockRejectedValue(new Error('boom'));
+            const deleteSpy = jest.spyOn(cellService, '_safeDeleteCellset').mockResolvedValue(undefined);
 
-            test('csv_dialect mutex', async () => {
-                await expect(cellService.executeMdxCsv('q', { useBlob: true, csvDialect: {} as any }))
-                    .rejects.toThrow("'csv_dialect' must not be used in conjunction with 'use_blob'");
-            });
-
-            test('line_separator must be \\r\\n', async () => {
-                await expect(cellService.executeMdxCsv('q', { useBlob: true, lineSeparator: '\n' }))
-                    .rejects.toThrow("'line_separator' must be '\r\n' to leverage 'use_blob' feature");
-            });
-
-            test('all gates pass → throws not-yet-ported (documented parity gap)', async () => {
-                await expect(cellService.executeMdxCsv('q', { useBlob: true }))
-                    .rejects.toThrow('useBlob CSV path not yet ported to tm1npm');
-            });
+            await expect(cellService.executeMdxCsv('SELECT 1 ON 0 FROM [c]', {
+                useIterativeJson: true,
+            })).rejects.toThrow('boom');
+            expect(deleteSpy).toHaveBeenCalledWith('cs1', undefined);
         });
     });
 
@@ -370,6 +362,7 @@ describe('CellService execute methods — tm1py parity (#65)', () => {
             jest.spyOn(cellService, 'createCellsetFromView').mockResolvedValue('cs1');
             const iterSpy = jest.spyOn(cellService, 'extractCellsetCsvIterJson').mockResolvedValue('iter');
             const csvSpy = jest.spyOn(cellService, 'extractCellsetCsv').mockResolvedValue('csv');
+            jest.spyOn(cellService, '_safeDeleteCellset').mockResolvedValue(undefined);
 
             const result = await cellService.executeViewCsv('Cube', 'View', { useIterativeJson: true });
 
@@ -378,36 +371,24 @@ describe('CellService execute methods — tm1py parity (#65)', () => {
             expect(result).toBe('iter');
         });
 
-        describe('useBlob validation gates (tm1py CellService.py:2709-2719)', () => {
-            test('use_iterative_json mutex', async () => {
-                await expect(cellService.executeViewCsv('Cube', 'View', { useBlob: true, useIterativeJson: true }))
-                    .rejects.toThrow("'use_iterative_json' must not be used in conjunction with 'use_blob'");
-            });
+        test('useIterativeJson cleans up cellset via _safeDeleteCellset (no leak)', async () => {
+            jest.spyOn(cellService, 'createCellsetFromView').mockResolvedValue('cs1');
+            jest.spyOn(cellService, 'extractCellsetCsvIterJson').mockResolvedValue('iter');
+            const deleteSpy = jest.spyOn(cellService, '_safeDeleteCellset').mockResolvedValue(undefined);
 
-            test('use_compact_json mutex', async () => {
-                await expect(cellService.executeViewCsv('Cube', 'View', { useBlob: true, useCompactJson: true }))
-                    .rejects.toThrow("'use_compact_json' must not be used in conjunction with 'use_blob'");
-            });
+            await cellService.executeViewCsv('Cube', 'View', { useIterativeJson: true, sandboxName: 'sb' });
 
-            test('csv_dialect mutex', async () => {
-                await expect(cellService.executeViewCsv('Cube', 'View', { useBlob: true, csvDialect: {} as any }))
-                    .rejects.toThrow("'csv_dialect' must not be used in conjunction with 'use_blob'");
-            });
+            expect(deleteSpy).toHaveBeenCalledWith('cs1', 'sb');
+        });
 
-            test('line_separator must be \\r\\n', async () => {
-                await expect(cellService.executeViewCsv('Cube', 'View', { useBlob: true, lineSeparator: '\n' }))
-                    .rejects.toThrow("'line_separator' must be '\r\n' to leverage 'use_blob' feature");
-            });
+        test('useIterativeJson cleans up cellset even when extract throws', async () => {
+            jest.spyOn(cellService, 'createCellsetFromView').mockResolvedValue('cs1');
+            jest.spyOn(cellService, 'extractCellsetCsvIterJson').mockRejectedValue(new Error('boom'));
+            const deleteSpy = jest.spyOn(cellService, '_safeDeleteCellset').mockResolvedValue(undefined);
 
-            test('private must be false', async () => {
-                await expect(cellService.executeViewCsv('Cube', 'View', { useBlob: true, private: true }))
-                    .rejects.toThrow("'private' must be False to leverage 'use_blob' feature");
-            });
-
-            test('all gates pass → throws not-yet-ported', async () => {
-                await expect(cellService.executeViewCsv('Cube', 'View', { useBlob: true }))
-                    .rejects.toThrow('useBlob CSV path not yet ported to tm1npm');
-            });
+            await expect(cellService.executeViewCsv('Cube', 'View', { useIterativeJson: true }))
+                .rejects.toThrow('boom');
+            expect(deleteSpy).toHaveBeenCalledWith('cs1', undefined);
         });
     });
 });

--- a/src/tests/CellService.execute.parity.test.ts
+++ b/src/tests/CellService.execute.parity.test.ts
@@ -187,18 +187,20 @@ describe('CellService execute methods — tm1py parity (#65)', () => {
             }));
         });
 
-        test('maxWorkers > 1 dispatches to execute_view_async with full options forwarded (tm1py parity)', async () => {
+        test('maxWorkers > 1 forwards 11 options to execute_view_async; drops cell_properties and use_compact_json (tm1py quirk)', async () => {
             const asyncSpy = jest.spyOn(cellService, 'execute_view_async')
                 .mockResolvedValue(new CaseAndSpaceInsensitiveTuplesDict<any>());
             const extractSpy = jest.spyOn(cellService, 'extractCellset');
 
-            // tm1py's execute_view with max_workers>1 forwards every named option
-            // (CellService.py:2241-2257). tm1npm now forwards the full ExecuteViewOptions.
+            // tm1py's execute_view (CellService.py:2241-2257) DELIBERATELY omits
+            // cell_properties and use_compact_json when forwarding to execute_view_async
+            // (different from execute_mdx, which forwards both). Strict parity = replicate.
             await cellService.executeView('Cube', 'View', {
                 maxWorkers: 8,
                 private: true,
                 sandboxName: 'sb',
                 cellProperties: ['Value'],
+                useCompactJson: true,
                 top: 100,
                 skipZeros: true,
             });
@@ -207,10 +209,12 @@ describe('CellService execute methods — tm1py parity (#65)', () => {
                 maxWorkers: 8,
                 private: true,
                 sandboxName: 'sb',
-                cellProperties: ['Value'],
                 top: 100,
                 skipZeros: true,
             }));
+            const forwarded = asyncSpy.mock.calls[0][2]!;
+            expect(forwarded).not.toHaveProperty('cellProperties');
+            expect(forwarded).not.toHaveProperty('useCompactJson');
             expect(extractSpy).not.toHaveBeenCalled();
         });
     });

--- a/src/tests/CellService.execute.parity.test.ts
+++ b/src/tests/CellService.execute.parity.test.ts
@@ -164,6 +164,45 @@ describe('CellService execute methods — tm1py parity (#65)', () => {
         });
     });
 
+    // ── createCellsetFromView URL escaping ───────────────────────────────
+
+    describe('createCellsetFromView URL parity (build_url_friendly_object_name)', () => {
+        test('escapes & in cube/view names (real-world names like "Sales & Revenue")', async () => {
+            const postSpy = jest.spyOn((cellService as any).rest, 'post')
+                .mockResolvedValue({ data: { ID: 'cs1' }, headers: {} });
+
+            await cellService.createCellsetFromView('Sales & Revenue', 'Top 5 & Bottom', false);
+
+            // tm1py's format_url runs cube/view names through build_url_friendly_object_name
+            // which encodes & as %26, # as %23, ? as %3F, % as %25. Plain quote-doubling
+            // would leave & unencoded and the URL would parse it as a query separator.
+            const url = postSpy.mock.calls[0][0];
+            expect(url).toBe("/Cubes('Sales %26 Revenue')/Views('Top 5 %26 Bottom')/tm1.Execute");
+        });
+
+        test('escapes single quotes via doubling (consistent with build_url_friendly_object_name)', async () => {
+            const postSpy = jest.spyOn((cellService as any).rest, 'post')
+                .mockResolvedValue({ data: { ID: 'cs1' }, headers: {} });
+
+            await cellService.createCellsetFromView("Sam's Cube", "Sam's View", true);
+
+            const url = postSpy.mock.calls[0][0];
+            expect(url).toBe("/Cubes('Sam''s Cube')/PrivateViews('Sam''s View')/tm1.Execute");
+        });
+
+        test('selects PrivateViews vs Views path segment based on isPrivate (no $private query param)', async () => {
+            const postSpy = jest.spyOn((cellService as any).rest, 'post')
+                .mockResolvedValue({ data: { ID: 'cs1' }, headers: {} });
+
+            await cellService.createCellsetFromView('Cube', 'View', true);
+            await cellService.createCellsetFromView('Cube', 'View', false);
+
+            expect(postSpy.mock.calls[0][0]).toContain("/PrivateViews('View')");
+            expect(postSpy.mock.calls[1][0]).toContain("/Views('View')");
+            expect(postSpy.mock.calls[0][0]).not.toContain('$private');
+        });
+    });
+
     // ── executeView ──────────────────────────────────────────────────────
 
     describe('executeView', () => {

--- a/src/tests/CellService.execute.parity.test.ts
+++ b/src/tests/CellService.execute.parity.test.ts
@@ -201,6 +201,30 @@ describe('CellService execute methods — tm1py parity (#65)', () => {
             expect(postSpy.mock.calls[1][0]).toContain("/Views('View')");
             expect(postSpy.mock.calls[0][0]).not.toContain('$private');
         });
+
+        test('execute_view_async signature does not accept useCompactJson (tm1py parity)', async () => {
+            // tm1py's execute_view_async (CellService.py:2278-2294) has no
+            // use_compact_json parameter — only execute_mdx_async forwards it.
+            // ExecuteViewAsyncOptions omits useCompactJson so TypeScript catches
+            // the mismatch at compile time. The line below is intentionally a
+            // ts-expect-error: removing it should make this test fail to compile.
+            // @ts-expect-error - useCompactJson must not be a valid option on execute_view_async
+            const callsWithRejected = () => cellService.execute_view_async('Cube', 'View', { useCompactJson: true });
+
+            // Runtime check: even if a caller bypasses TS (e.g. `as any`), the
+            // method does not pass useCompactJson through to extractCellset.
+            jest.spyOn(cellService, 'createCellsetFromView').mockResolvedValue('cs1');
+            const extractSpy = jest.spyOn(cellService, 'extractCellset')
+                .mockResolvedValue(new CaseAndSpaceInsensitiveTuplesDict<any>());
+            jest.spyOn(cellService, '_safeDeleteCellset').mockResolvedValue(undefined);
+
+            await cellService.execute_view_async('Cube', 'View', { useCompactJson: true } as any);
+            const forwarded = extractSpy.mock.calls[0][1]!;
+            expect(forwarded).not.toHaveProperty('useCompactJson');
+
+            // Reference the helper so it's not unused (the test value is the ts-expect-error above).
+            expect(typeof callsWithRejected).toBe('function');
+        });
     });
 
     // ── executeView ──────────────────────────────────────────────────────

--- a/src/tests/CellService.execute.parity.test.ts
+++ b/src/tests/CellService.execute.parity.test.ts
@@ -85,27 +85,21 @@ describe('CellService execute methods — tm1py parity (#65)', () => {
             }));
         });
 
-        test('maxWorkers > 1 with supported-only options dispatches to executeMdxAsync', async () => {
+        test('maxWorkers > 1 dispatches to executeMdxAsync; unsupported options silently dropped (tm1py **kwargs parity)', async () => {
             const asyncSpy = jest.spyOn(cellService, 'executeMdxAsync')
                 .mockResolvedValue(new Map<string, any>([['a', 1]]));
             const extractSpy = jest.spyOn(cellService, 'extractCellset');
 
+            // tm1py forwards everything via **kwargs and silently ignores options the
+            // underlying call doesn't consume. tm1npm matches that loose validation —
+            // cellProperties is not forwarded but does not throw.
             const result = await cellService.executeMdx('SELECT 1 ON 0 FROM [c]', {
-                maxWorkers: 8, sandboxName: 'sb',
+                maxWorkers: 8, sandboxName: 'sb', cellProperties: ['Value'],
             });
 
             expect(asyncSpy).toHaveBeenCalledWith('SELECT 1 ON 0 FROM [c]', { sandbox_name: 'sb' });
             expect(extractSpy).not.toHaveBeenCalled();
             expect(result).toBeInstanceOf(CaseAndSpaceInsensitiveTuplesDict);
-        });
-
-        test('maxWorkers > 1 with unsupported options throws (no silent option drop)', async () => {
-            // tm1npm's executeMdxAsync currently only accepts {sandbox_name, cubeName};
-            // any other option set alongside maxWorkers>1 must fail loud.
-            await expect(cellService.executeMdx('SELECT 1 ON 0 FROM [c]', {
-                maxWorkers: 8,
-                cellProperties: ['Value'],
-            })).rejects.toThrow(/executeMdx maxWorkers>1 path does not yet forward/);
         });
 
         test('default skipZeros is false (parity with tm1py execute_mdx)', async () => {
@@ -185,30 +179,25 @@ describe('CellService execute methods — tm1py parity (#65)', () => {
             }));
         });
 
-        test('maxWorkers > 1 with supported-only options dispatches to execute_view_async', async () => {
+        test('maxWorkers > 1 dispatches to execute_view_async; unsupported options silently dropped (tm1py **kwargs parity)', async () => {
             const asyncSpy = jest.spyOn(cellService, 'execute_view_async')
                 .mockResolvedValue(new Map());
             const extractSpy = jest.spyOn(cellService, 'extractCellset');
 
+            // tm1py's execute_view dispatches via **kwargs and never throws on
+            // unsupported options. tm1npm matches that — cellProperties is not
+            // forwarded but does not throw.
             await cellService.executeView('Cube', 'View', {
                 maxWorkers: 8,
                 private: true,
                 sandboxName: 'sb',
+                cellProperties: ['Value'],
             });
 
             expect(asyncSpy).toHaveBeenCalledWith('Cube', 'View', {
                 private: true, sandbox_name: 'sb',
             });
             expect(extractSpy).not.toHaveBeenCalled();
-        });
-
-        test('maxWorkers > 1 with unsupported options throws (no silent option drop)', async () => {
-            // tm1npm's execute_view_async currently only accepts {private, sandbox_name};
-            // any other option set alongside maxWorkers>1 must fail loud.
-            await expect(cellService.executeView('Cube', 'View', {
-                maxWorkers: 8,
-                cellProperties: ['Value'],
-            })).rejects.toThrow(/executeView maxWorkers>1 path does not yet forward/);
         });
     });
 
@@ -312,7 +301,10 @@ describe('CellService execute methods — tm1py parity (#65)', () => {
             expect(result).toBe('iter');
         });
 
-        test('useIterativeJson cleans up cellset via _safeDeleteCellset (no leak)', async () => {
+        test('useIterativeJson does NOT clean up the cellset (replicates tm1py bug)', async () => {
+            // tm1py's extract_cellset_csv_iter_json is not @tidy_cellset-decorated
+            // (CellService.py:4385) and leaks the cellset on the iter-json path.
+            // Strict parity rule says replicate the bug — assert no cleanup occurs.
             jest.spyOn(cellService, 'createCellset').mockResolvedValue('cs1');
             jest.spyOn(cellService, 'extractCellsetCsvIterJson').mockResolvedValue('iter');
             const deleteSpy = jest.spyOn(cellService, '_safeDeleteCellset').mockResolvedValue(undefined);
@@ -321,18 +313,7 @@ describe('CellService execute methods — tm1py parity (#65)', () => {
                 useIterativeJson: true, sandboxName: 'sb',
             });
 
-            expect(deleteSpy).toHaveBeenCalledWith('cs1', 'sb');
-        });
-
-        test('useIterativeJson cleans up cellset even when extract throws', async () => {
-            jest.spyOn(cellService, 'createCellset').mockResolvedValue('cs1');
-            jest.spyOn(cellService, 'extractCellsetCsvIterJson').mockRejectedValue(new Error('boom'));
-            const deleteSpy = jest.spyOn(cellService, '_safeDeleteCellset').mockResolvedValue(undefined);
-
-            await expect(cellService.executeMdxCsv('SELECT 1 ON 0 FROM [c]', {
-                useIterativeJson: true,
-            })).rejects.toThrow('boom');
-            expect(deleteSpy).toHaveBeenCalledWith('cs1', undefined);
+            expect(deleteSpy).not.toHaveBeenCalled();
         });
     });
 
@@ -362,7 +343,6 @@ describe('CellService execute methods — tm1py parity (#65)', () => {
             jest.spyOn(cellService, 'createCellsetFromView').mockResolvedValue('cs1');
             const iterSpy = jest.spyOn(cellService, 'extractCellsetCsvIterJson').mockResolvedValue('iter');
             const csvSpy = jest.spyOn(cellService, 'extractCellsetCsv').mockResolvedValue('csv');
-            jest.spyOn(cellService, '_safeDeleteCellset').mockResolvedValue(undefined);
 
             const result = await cellService.executeViewCsv('Cube', 'View', { useIterativeJson: true });
 
@@ -371,24 +351,16 @@ describe('CellService execute methods — tm1py parity (#65)', () => {
             expect(result).toBe('iter');
         });
 
-        test('useIterativeJson cleans up cellset via _safeDeleteCellset (no leak)', async () => {
+        test('useIterativeJson does NOT clean up the cellset (replicates tm1py bug)', async () => {
+            // Same parity rule as executeMdxCsv — tm1py's extract_cellset_csv_iter_json
+            // is not @tidy_cellset-decorated and leaks the cellset on this path.
             jest.spyOn(cellService, 'createCellsetFromView').mockResolvedValue('cs1');
             jest.spyOn(cellService, 'extractCellsetCsvIterJson').mockResolvedValue('iter');
             const deleteSpy = jest.spyOn(cellService, '_safeDeleteCellset').mockResolvedValue(undefined);
 
             await cellService.executeViewCsv('Cube', 'View', { useIterativeJson: true, sandboxName: 'sb' });
 
-            expect(deleteSpy).toHaveBeenCalledWith('cs1', 'sb');
-        });
-
-        test('useIterativeJson cleans up cellset even when extract throws', async () => {
-            jest.spyOn(cellService, 'createCellsetFromView').mockResolvedValue('cs1');
-            jest.spyOn(cellService, 'extractCellsetCsvIterJson').mockRejectedValue(new Error('boom'));
-            const deleteSpy = jest.spyOn(cellService, '_safeDeleteCellset').mockResolvedValue(undefined);
-
-            await expect(cellService.executeViewCsv('Cube', 'View', { useIterativeJson: true }))
-                .rejects.toThrow('boom');
-            expect(deleteSpy).toHaveBeenCalledWith('cs1', undefined);
+            expect(deleteSpy).not.toHaveBeenCalled();
         });
     });
 });

--- a/src/tests/bulkService.test.ts
+++ b/src/tests/bulkService.test.ts
@@ -339,7 +339,7 @@ invalid,line
 
         describe('exportDataToCSV', () => {
             it('should export data to CSV with header', async () => {
-                mockCellService.executeMdx = jest.fn().mockResolvedValue({
+                mockCellService.executeMdxRaw = jest.fn().mockResolvedValue({
                     Axes: [
                         { Hierarchies: [{ Name: 'Year' }, { Name: 'Quarter' }] }
                     ],
@@ -353,11 +353,11 @@ invalid,line
                 const csv = await bulkService.exportDataToCSV('Sales', mdx, { includeHeader: true });
 
                 expect(csv).toContain('Year,Quarter,Value');
-                expect(mockCellService.executeMdx).toHaveBeenCalledWith(mdx);
+                expect(mockCellService.executeMdxRaw).toHaveBeenCalledWith(mdx);
             });
 
             it('should skip zeros when option is set', async () => {
-                mockCellService.executeMdx = jest.fn().mockResolvedValue({
+                mockCellService.executeMdxRaw = jest.fn().mockResolvedValue({
                     Axes: [{ Hierarchies: [{ Name: 'Year' }] }],
                     Cells: [
                         { Value: 100, Consolidated: false, RuleDerived: false },
@@ -376,7 +376,7 @@ invalid,line
             });
 
             it('should skip consolidated cells when option is set', async () => {
-                mockCellService.executeMdx = jest.fn().mockResolvedValue({
+                mockCellService.executeMdxRaw = jest.fn().mockResolvedValue({
                     Axes: [{ Hierarchies: [{ Name: 'Year' }] }],
                     Cells: [
                         { Value: 100, Consolidated: false, RuleDerived: false },
@@ -395,7 +395,7 @@ invalid,line
             });
 
             it('should handle custom delimiter', async () => {
-                mockCellService.executeMdx = jest.fn().mockResolvedValue({
+                mockCellService.executeMdxRaw = jest.fn().mockResolvedValue({
                     Axes: [{ Hierarchies: [{ Name: 'Year' }] }],
                     Cells: [{ Value: 100, Consolidated: false, RuleDerived: false }]
                 });
@@ -482,7 +482,7 @@ invalid,line
 
         describe('exportDataToJSON', () => {
             it('should export data in compact format', async () => {
-                mockCellService.executeMdx = jest.fn().mockResolvedValue({
+                mockCellService.executeMdxRaw = jest.fn().mockResolvedValue({
                     Cells: [
                         { Value: 100, Ordinal: 0, RuleDerived: false, Updateable: true },
                         { Value: 200, Ordinal: 1, RuleDerived: false, Updateable: true }
@@ -499,7 +499,7 @@ invalid,line
             });
 
             it('should export data in full format', async () => {
-                mockCellService.executeMdx = jest.fn().mockResolvedValue({
+                mockCellService.executeMdxRaw = jest.fn().mockResolvedValue({
                     Cells: [
                         {
                             Value: 100,
@@ -522,7 +522,7 @@ invalid,line
             });
 
             it('should skip zeros when option is set', async () => {
-                mockCellService.executeMdx = jest.fn().mockResolvedValue({
+                mockCellService.executeMdxRaw = jest.fn().mockResolvedValue({
                     Cells: [
                         { Value: 100, RuleDerived: false, Consolidated: false },
                         { Value: 0, RuleDerived: false, Consolidated: false },
@@ -538,7 +538,7 @@ invalid,line
             });
 
             it('should skip rule derived cells when option is set', async () => {
-                mockCellService.executeMdx = jest.fn().mockResolvedValue({
+                mockCellService.executeMdxRaw = jest.fn().mockResolvedValue({
                     Cells: [
                         { Value: 100, RuleDerived: false, Consolidated: false },
                         { Value: 200, RuleDerived: true, Consolidated: false },

--- a/src/tests/bulkService.test.ts
+++ b/src/tests/bulkService.test.ts
@@ -353,7 +353,12 @@ invalid,line
                 const csv = await bulkService.exportDataToCSV('Sales', mdx, { includeHeader: true });
 
                 expect(csv).toContain('Year,Quarter,Value');
-                expect(mockCellService.executeMdxRaw).toHaveBeenCalledWith(mdx);
+                expect(mockCellService.executeMdxRaw).toHaveBeenCalledWith(mdx, expect.objectContaining({
+                    sandboxName: undefined,
+                    skipZeros: false,
+                    skipConsolidatedCells: false,
+                    skipRuleDerivedCells: false,
+                }));
             });
 
             it('should skip zeros when option is set', async () => {

--- a/src/tests/bulkService.test.ts
+++ b/src/tests/bulkService.test.ts
@@ -353,11 +353,14 @@ invalid,line
                 const csv = await bulkService.exportDataToCSV('Sales', mdx, { includeHeader: true });
 
                 expect(csv).toContain('Year,Quarter,Value');
+                // executeMdxRaw's _buildCellsetRawUrl omits Hierarchies unless
+                // includeHierarchies=true is passed — required for CSV headers.
                 expect(mockCellService.executeMdxRaw).toHaveBeenCalledWith(mdx, expect.objectContaining({
                     sandboxName: undefined,
                     skipZeros: false,
                     skipConsolidatedCells: false,
                     skipRuleDerivedCells: false,
+                    includeHierarchies: true,
                 }));
             });
 
@@ -524,6 +527,21 @@ invalid,line
                 expect(data[0]).toHaveProperty('ordinal');
                 expect(data[0]).toHaveProperty('ruleDerived');
                 expect(data[0]).toHaveProperty('updateable');
+                // executeMdxRaw's _buildCellsetRawUrl defaults cellProperties to
+                // ['Value'] only — full format needs explicit request for the others.
+                expect(mockCellService.executeMdxRaw).toHaveBeenCalledWith('SELECT...', expect.objectContaining({
+                    cellProperties: ['Value', 'Ordinal', 'Consolidated', 'RuleDerived', 'Updateable'],
+                }));
+            });
+
+            it('compact format does not request extra cellProperties', async () => {
+                mockCellService.executeMdxRaw = jest.fn().mockResolvedValue({ Cells: [{ Value: 1 }] });
+
+                await bulkService.exportDataToJSON('Sales', 'SELECT...', { format: 'compact' });
+
+                expect(mockCellService.executeMdxRaw).toHaveBeenCalledWith('SELECT...', expect.objectContaining({
+                    cellProperties: undefined,
+                }));
             });
 
             it('should skip zeros when option is set', async () => {

--- a/src/tests/cellService.test.ts
+++ b/src/tests/cellService.test.ts
@@ -111,8 +111,10 @@ describe('CellService Tests', () => {
     });
 
     describe('MDX Operations', () => {
+        // executeMdxRaw uses createCellset (POST) + extractCellsetRaw (GET) + delete (DELETE) per
+        // tm1py parity. Tests mock POST → cellset id, GET → raw cellset, DELETE → empty.
         test('should execute MDX query', async () => {
-            mockRestService.post.mockResolvedValue(createMockResponse({
+            const rawCellset = {
                 Axes: [{
                     Tuples: [
                         { Members: [{ Name: 'Jan' }] },
@@ -123,35 +125,36 @@ describe('CellService Tests', () => {
                     { Ordinal: 0, Value: 1000, FormattedValue: '1,000' },
                     { Ordinal: 1, Value: 1200, FormattedValue: '1,200' }
                 ]
-            }));
+            };
+            mockRestService.post.mockResolvedValue(createMockResponse({ ID: 'cs1' }));
+            mockRestService.get.mockResolvedValue(createMockResponse(rawCellset));
+            mockRestService.delete.mockResolvedValue(createMockResponse({}));
 
             const mdxQuery = 'SELECT [Time].[Jan]:[Feb] ON 0 FROM [SalesCube]';
-            const result = await cellService.executeMdx(mdxQuery);
-            
+            const result = await cellService.executeMdxRaw(mdxQuery);
+
             expect(result.Axes).toBeDefined();
             expect(result.Cells).toBeDefined();
             expect(result.Cells.length).toBe(2);
             expect(result.Cells[0].Value).toBe(1000);
-            expect(mockRestService.post).toHaveBeenCalledWith('/ExecuteMDX', { MDX: mdxQuery });
-            
+            expect(mockRestService.post).toHaveBeenCalledWith(
+                '/ExecuteMDX', JSON.stringify({ MDX: mdxQuery })
+            );
+
             console.log('✅ MDX query executed successfully');
         });
 
         test('should handle complex MDX queries', async () => {
-            mockRestService.post.mockResolvedValue(createMockResponse({
+            const rawCellset = {
                 Axes: [
-                    {
-                        Tuples: [
-                            { Members: [{ Name: 'Revenue' }] },
-                            { Members: [{ Name: 'Expenses' }] }
-                        ]
-                    },
-                    {
-                        Tuples: [
-                            { Members: [{ Name: 'Jan' }] },
-                            { Members: [{ Name: 'Feb' }] }
-                        ]
-                    }
+                    { Tuples: [
+                        { Members: [{ Name: 'Revenue' }] },
+                        { Members: [{ Name: 'Expenses' }] }
+                    ] },
+                    { Tuples: [
+                        { Members: [{ Name: 'Jan' }] },
+                        { Members: [{ Name: 'Feb' }] }
+                    ] }
                 ],
                 Cells: [
                     { Ordinal: 0, Value: 10000, FormattedValue: '10,000' },
@@ -159,14 +162,17 @@ describe('CellService Tests', () => {
                     { Ordinal: 2, Value: 8000, FormattedValue: '8,000' },
                     { Ordinal: 3, Value: 9000, FormattedValue: '9,000' }
                 ]
-            }));
+            };
+            mockRestService.post.mockResolvedValue(createMockResponse({ ID: 'cs1' }));
+            mockRestService.get.mockResolvedValue(createMockResponse(rawCellset));
+            mockRestService.delete.mockResolvedValue(createMockResponse({}));
 
             const complexMdx = 'SELECT {[Account].[Revenue], [Account].[Expenses]} ON 0, {[Time].[Jan], [Time].[Feb]} ON 1 FROM [SalesCube]';
-            const result = await cellService.executeMdx(complexMdx);
-            
-            expect(result.Axes.length).toBe(2); // 2 dimensions
-            expect(result.Cells.length).toBe(4); // 2x2 matrix
-            
+            const result = await cellService.executeMdxRaw(complexMdx);
+
+            expect(result.Axes.length).toBe(2);
+            expect(result.Cells.length).toBe(4);
+
             console.log('✅ Complex MDX query handled successfully');
         });
     });
@@ -459,7 +465,7 @@ describe('CellService Tests', () => {
         });
 
         test('should handle statistical calculations via MDX', async () => {
-            mockRestService.post.mockResolvedValue(createMockResponse({
+            const rawCellset = {
                 Axes: [{
                     Tuples: [
                         { Members: [{ Name: 'Average' }] },
@@ -468,11 +474,14 @@ describe('CellService Tests', () => {
                     ]
                 }],
                 Cells: [
-                    { Ordinal: 0, Value: 15000, FormattedValue: '15,000' }, // Average
-                    { Ordinal: 1, Value: 180000, FormattedValue: '180,000' }, // Sum
-                    { Ordinal: 2, Value: 12, FormattedValue: '12' } // Count
+                    { Ordinal: 0, Value: 15000, FormattedValue: '15,000' },
+                    { Ordinal: 1, Value: 180000, FormattedValue: '180,000' },
+                    { Ordinal: 2, Value: 12, FormattedValue: '12' }
                 ]
-            }));
+            };
+            mockRestService.post.mockResolvedValue(createMockResponse({ ID: 'cs1' }));
+            mockRestService.get.mockResolvedValue(createMockResponse(rawCellset));
+            mockRestService.delete.mockResolvedValue(createMockResponse({}));
 
             const statisticalMdx = `
                 WITH 
@@ -483,8 +492,8 @@ describe('CellService Tests', () => {
                 FROM [SalesCube]
             `;
             
-            const result = await cellService.executeMdx(statisticalMdx);
-            
+            const result = await cellService.executeMdxRaw(statisticalMdx);
+
             expect(result.Cells[0].Value).toBe(15000); // Average
             expect(result.Cells[1].Value).toBe(180000); // Sum
             expect(result.Cells[2].Value).toBe(12); // Count

--- a/src/tests/elementService.issue37.test.ts
+++ b/src/tests/elementService.issue37.test.ts
@@ -183,22 +183,23 @@ describe('ElementService — Issue #37: 13 missing methods', () => {
         test('should include alias values when alias attributes exist', async () => {
             jest.spyOn(elementService, 'getAliasElementAttributes').mockResolvedValue(['Alias1']);
 
-            // Mock ExecuteMDX response with axes and cells
-            mockRestService.post.mockResolvedValue(createMockResponse({
+            // executeMdxRowsAndValues now uses createCellset (POST) + extractCellsetRaw (GET) + delete.
+            const cellset = {
                 Axes: [
-                    { Tuples: [{ Members: [{ Name: 'Alias1' }] }] },  // column axis
-                    {
-                        Tuples: [
-                            { Members: [{ Name: 'Leaf1' }] },
-                            { Members: [{ Name: 'Leaf2' }] }
-                        ]
-                    }  // row axis
+                    { Tuples: [{ Members: [{ Name: 'Alias1' }] }] },
+                    { Tuples: [
+                        { Members: [{ Name: 'Leaf1' }] },
+                        { Members: [{ Name: 'Leaf2' }] }
+                    ] }
                 ],
                 Cells: [
                     { Value: 'Alias_Leaf1' },
                     { Value: 'Alias_Leaf2' }
                 ]
-            }));
+            };
+            mockRestService.post.mockResolvedValue(createMockResponse({ ID: 'cs1' }));
+            mockRestService.get.mockResolvedValue(createMockResponse(cellset));
+            mockRestService.delete.mockResolvedValue(createMockResponse({}));
 
             const result = await elementService.getAllLeafElementIdentifiers('Dim1', 'Hier1');
 
@@ -212,21 +213,24 @@ describe('ElementService — Issue #37: 13 missing methods', () => {
         test('should skip empty alias values', async () => {
             jest.spyOn(elementService, 'getAliasElementAttributes').mockResolvedValue(['Alias1']);
 
-            mockRestService.post.mockResolvedValue(createMockResponse({
+            const cellset = {
                 Axes: [
                     { Tuples: [{ Members: [{ Name: 'Alias1' }] }] },
                     { Tuples: [{ Members: [{ Name: 'Elem1' }] }] }
                 ],
                 Cells: [
-                    { Value: '' },  // empty alias
-                    { Value: null }  // null alias
+                    { Value: '' },
+                    { Value: null }
                 ]
-            }));
+            };
+            mockRestService.post.mockResolvedValue(createMockResponse({ ID: 'cs1' }));
+            mockRestService.get.mockResolvedValue(createMockResponse(cellset));
+            mockRestService.delete.mockResolvedValue(createMockResponse({}));
 
             const result = await elementService.getAllLeafElementIdentifiers('Dim1', 'Hier1');
 
             expect(result.has('Elem1')).toBe(true);
-            expect(result.size).toBe(1); // only the element name, no empty/null aliases
+            expect(result.size).toBe(1);
         });
     });
 
@@ -547,8 +551,10 @@ describe('ElementService — Issue #37: 13 missing methods', () => {
 
     describe('_retrieveMdxRowsAndCellValuesAsStringSet — additional edge cases', () => {
         test('should return empty set when Axes and Cells are missing', async () => {
-            // CellService.executeMdxRowsAndValues handles missing Axes/Cells
-            mockRestService.post.mockResolvedValue(createMockResponse({}));
+            // executeMdxRowsAndValues → executeMdxRaw → createCellset (POST) + extractCellsetRaw (GET) + delete.
+            mockRestService.post.mockResolvedValue(createMockResponse({ ID: 'cs1' }));
+            mockRestService.get.mockResolvedValue(createMockResponse({}));
+            mockRestService.delete.mockResolvedValue(createMockResponse({}));
 
             const retrieve = (elementService as any)._retrieveMdxRowsAndCellValuesAsStringSet.bind(elementService);
             const result = await retrieve('SELECT {} ON ROWS FROM [Cube]');

--- a/src/tests/enhancedCellService.test.ts
+++ b/src/tests/enhancedCellService.test.ts
@@ -527,58 +527,29 @@ describe('Enhanced CellService Tests', () => {
             console.log('✅ extractCellsetCsv special characters test passed');
         });
 
-        test('execute_view_async creates cellset from view, extracts, and returns Map keyed by UniqueName', async () => {
-            jest.spyOn(cellService, 'createCellsetFromView').mockResolvedValue('CSID-V');
-            jest.spyOn(cellService as any, '_extractCellsetForTupleDict').mockResolvedValue({
-                Axes: [{
-                    Cardinality: 1,
-                    Hierarchies: [{ Dimension: { Name: 'Region' }, Name: 'Region' }],
-                    Tuples: [{ Members: [{ Name: 'London', UniqueName: '[Region].[Region].[London]' }] }],
-                }],
-                Cells: [{ Value: 100 }],
-            });
-            jest.spyOn(cellService, 'getDimensionNamesForWriting').mockResolvedValue(['Region']);
-            const deleteSpy = jest.spyOn(cellService, 'deleteCellset').mockResolvedValue(undefined);
+        // execute_view_async now delegates to createCellsetFromView + extractCellset
+        // (tm1py-parity option forwarding). Tests verify the wrapper contract; the
+        // tuple-key construction is owned by extractCellset and tested separately.
 
-            const result = await cellService.execute_view_async('SalesCube', 'TestView');
-
-            expect(result instanceof Map).toBe(true);
-            // Matches tm1py default element_unique_names=True
-            expect(result.get('[Region].[Region].[London]')).toBe(100);
-            expect(deleteSpy).toHaveBeenCalledWith('CSID-V', undefined);
-        });
-
-        test('execute_view_async reorders tuple parts by cube dimension order (parity with tm1py.sort_coordinates)', async () => {
-            jest.spyOn(cellService, 'createCellsetFromView').mockResolvedValue('CSID-V');
-            // Axis 0 = Region; Axis 1 = Time. Cube dimensions = [Time, Region] — keys must come out as Time,Region.
-            jest.spyOn(cellService as any, '_extractCellsetForTupleDict').mockResolvedValue({
-                Axes: [
-                    {
-                        Cardinality: 1,
-                        Hierarchies: [{ Dimension: { Name: 'Region' } }],
-                        Tuples: [{ Members: [{ UniqueName: '[Region].[Region].[USA]' }] }],
-                    },
-                    {
-                        Cardinality: 1,
-                        Hierarchies: [{ Dimension: { Name: 'Time' } }],
-                        Tuples: [{ Members: [{ UniqueName: '[Time].[Time].[2024]' }] }],
-                    },
-                ],
-                Cells: [{ Value: 42 }],
-            });
-            jest.spyOn(cellService, 'getDimensionNamesForWriting').mockResolvedValue(['Time', 'Region']);
-            jest.spyOn(cellService, 'deleteCellset').mockResolvedValue(undefined);
-
-            const result = await cellService.execute_view_async('SalesCube', 'TestView');
-
-            expect(result.get('[Time].[Time].[2024],[Region].[Region].[USA]')).toBe(42);
-        });
-
-        test('execute_view_async respects private/sandbox options', async () => {
+        test('execute_view_async creates cellset from view, calls extractCellset, returns TuplesDict', async () => {
             const createSpy = jest.spyOn(cellService, 'createCellsetFromView').mockResolvedValue('CSID-V');
-            jest.spyOn(cellService as any, '_extractCellsetForTupleDict').mockResolvedValue({ Axes: [], Cells: [] });
-            jest.spyOn(cellService, 'getDimensionNamesForWriting').mockResolvedValue([]);
-            jest.spyOn(cellService, 'deleteCellset').mockResolvedValue(undefined);
+            const dict = new (require('../utils/Utils').CaseAndSpaceInsensitiveTuplesDict)();
+            dict.set('[Region].[Region].[London]', 100);
+            const extractSpy = jest.spyOn(cellService, 'extractCellset').mockResolvedValue(dict);
+            jest.spyOn(cellService, '_safeDeleteCellset').mockResolvedValue(undefined);
+
+            const result = await cellService.execute_view_async('SalesCube', 'TestView');
+
+            expect(createSpy).toHaveBeenCalledWith('SalesCube', 'TestView', false, undefined);
+            expect(extractSpy).toHaveBeenCalledWith('CSID-V', expect.objectContaining({ deleteCellset: false }));
+            expect(result instanceof Map).toBe(true);
+            expect(result.get('[Region].[Region].[London]')).toBe(100);
+        });
+
+        test('execute_view_async respects private/sandbox options (legacy sandbox_name alias still works)', async () => {
+            const createSpy = jest.spyOn(cellService, 'createCellsetFromView').mockResolvedValue('CSID-V');
+            jest.spyOn(cellService, 'extractCellset').mockResolvedValue(new (require('../utils/Utils').CaseAndSpaceInsensitiveTuplesDict)());
+            jest.spyOn(cellService, '_safeDeleteCellset').mockResolvedValue(undefined);
 
             await cellService.execute_view_async('SalesCube', 'TestView', {
                 private: true,
@@ -588,10 +559,27 @@ describe('Enhanced CellService Tests', () => {
             expect(createSpy).toHaveBeenCalledWith('SalesCube', 'TestView', true, 'TestSandbox');
         });
 
+        test('execute_view_async forwards top/skipZeros/cellProperties to extractCellset (tm1py parity)', async () => {
+            jest.spyOn(cellService, 'createCellsetFromView').mockResolvedValue('CSID-V');
+            const extractSpy = jest.spyOn(cellService, 'extractCellset').mockResolvedValue(new (require('../utils/Utils').CaseAndSpaceInsensitiveTuplesDict)());
+            jest.spyOn(cellService, '_safeDeleteCellset').mockResolvedValue(undefined);
+
+            await cellService.execute_view_async('SalesCube', 'TestView', {
+                top: 50,
+                skipZeros: true,
+                cellProperties: ['Value', 'Ordinal'],
+            });
+
+            expect(extractSpy).toHaveBeenCalledWith('CSID-V', expect.objectContaining({
+                top: 50,
+                skipZeros: true,
+                cellProperties: ['Value', 'Ordinal'],
+            }));
+        });
+
         test('cellset cleanup suppresses 404 only (parity with tm1py @tidy_cellset)', async () => {
             jest.spyOn(cellService, 'createCellsetFromView').mockResolvedValue('CSID-V');
-            jest.spyOn(cellService as any, '_extractCellsetForTupleDict').mockResolvedValue({ Axes: [], Cells: [] });
-            jest.spyOn(cellService, 'getDimensionNamesForWriting').mockResolvedValue([]);
+            jest.spyOn(cellService, 'extractCellset').mockResolvedValue(new (require('../utils/Utils').CaseAndSpaceInsensitiveTuplesDict)());
             const notFound: any = new Error('not found');
             notFound.statusCode = 404;
             jest.spyOn(cellService, 'deleteCellset').mockRejectedValueOnce(notFound);
@@ -602,34 +590,13 @@ describe('Enhanced CellService Tests', () => {
 
         test('cellset cleanup re-raises non-404 errors (parity with tm1py @tidy_cellset)', async () => {
             jest.spyOn(cellService, 'createCellsetFromView').mockResolvedValue('CSID-V');
-            jest.spyOn(cellService as any, '_extractCellsetForTupleDict').mockResolvedValue({ Axes: [], Cells: [] });
-            jest.spyOn(cellService, 'getDimensionNamesForWriting').mockResolvedValue([]);
+            jest.spyOn(cellService, 'extractCellset').mockResolvedValue(new (require('../utils/Utils').CaseAndSpaceInsensitiveTuplesDict)());
             const serverError: any = new Error('server error');
             serverError.statusCode = 500;
             jest.spyOn(cellService, 'deleteCellset').mockRejectedValueOnce(serverError);
 
             await expect(cellService.execute_view_async('SalesCube', 'V'))
                 .rejects.toThrow('server error');
-        });
-
-        test('execute_view_async prefers Element.UniqueName when Member only carries Element shape', async () => {
-            jest.spyOn(cellService, 'createCellsetFromView').mockResolvedValue('CSID-V');
-            // Real TM1 cellset shape with $expand=Members($expand=Element($select=UniqueName)):
-            // Member has no top-level UniqueName, only Element.UniqueName.
-            jest.spyOn(cellService as any, '_extractCellsetForTupleDict').mockResolvedValue({
-                Axes: [{
-                    Cardinality: 1,
-                    Hierarchies: [{ Dimension: { Name: 'Region' } }],
-                    Tuples: [{ Members: [{ Name: 'London', Element: { UniqueName: '[Region].[Region].[London]' } }] }],
-                }],
-                Cells: [{ Value: 100 }],
-            });
-            jest.spyOn(cellService, 'getDimensionNamesForWriting').mockResolvedValue(['Region']);
-            jest.spyOn(cellService, 'deleteCellset').mockResolvedValue(undefined);
-
-            const result = await cellService.execute_view_async('SalesCube', 'TestView');
-
-            expect(result.get('[Region].[Region].[London]')).toBe(100);
         });
     });
 

--- a/src/tests/integrationTests.test.ts
+++ b/src/tests/integrationTests.test.ts
@@ -131,15 +131,16 @@ describe('TM1Service Integration Tests', () => {
                     return;
                 }
 
-                // Execute the view
-                const cellsetResult = await tm1.cells.executeView('General Ledger', 'Default');
-                
+                // Execute the view via raw API to keep the ID/@odata.context assertions.
+                // executeView returns CaseAndSpaceInsensitiveTuplesDict per tm1py parity.
+                const cellsetResult = await tm1.cells.executeViewRaw('General Ledger', 'Default');
+
                 expect(cellsetResult).toBeDefined();
                 expect(cellsetResult).toHaveProperty('ID');
                 expect(typeof cellsetResult.ID).toBe('string');
-                expect(cellsetResult.ID.length).toBeGreaterThan(0);
+                expect((cellsetResult.ID as string).length).toBeGreaterThan(0);
                 expect(cellsetResult).toHaveProperty('@odata.context');
-                
+
                 console.log('✅ View executed successfully, Cellset ID:', cellsetResult.ID);
                 
             } catch (error) {

--- a/src/tests/mdx.advanced.test.ts
+++ b/src/tests/mdx.advanced.test.ts
@@ -7,11 +7,22 @@ import { RestService } from '../services/RestService';
 import { CellService } from '../services/CellService';
 
 // Mock getDimensionNamesForWriting globally — all CellService instances in these tests
-// need this since getValue/writeValue/write now require dimension names
+// need this since getValue/writeValue/write now require dimension names.
+// executeMdxRaw now uses createCellset + extractCellsetRaw + delete (tm1py parity);
+// short-circuit createCellset + safe-delete + extractCellsetRaw so existing tests
+// can drive the raw cellset shape via the per-test cellsetData variable.
+let __mdxAdvancedCellsetData: any = { Axes: [], Cells: [] };
 beforeEach(() => {
+    __mdxAdvancedCellsetData = { Axes: [], Cells: [] };
     jest.spyOn(CellService.prototype, 'getDimensionNamesForWriting').mockResolvedValue(['Period', 'Measure', 'Version']);
     jest.spyOn(CellService.prototype, 'executeMdxValues').mockResolvedValue([]);
+    jest.spyOn(CellService.prototype, 'createCellset').mockResolvedValue('cs1');
+    jest.spyOn(CellService.prototype, '_safeDeleteCellset' as any).mockResolvedValue(undefined);
+    jest.spyOn(CellService.prototype, 'extractCellsetRaw')
+        .mockImplementation(async () => __mdxAdvancedCellsetData);
 });
+
+const setMockCellset = (data: any) => { __mdxAdvancedCellsetData = data; };
 
 // Helper function to create mock AxiosResponse
 const createMockResponse = (data: any, status: number = 200) => ({
@@ -51,7 +62,7 @@ describe('Advanced MDX and Calculation Tests', () => {
                 WHERE ([Measure].[Revenue], [Region].[North America])
             `;
 
-            mockRestService.post.mockResolvedValue(createMockResponse({
+            setMockCellset({
                 Axes: [
                     {
                         Tuples: [
@@ -75,9 +86,9 @@ describe('Advanced MDX and Calculation Tests', () => {
                     { Ordinal: 4, Value: 92000, FormattedValue: '92,000' },
                     { Ordinal: 5, Value: 98000, FormattedValue: '98,000' }
                 ]
-            }));
+            });
 
-            const result = await cellService.executeMdx(complexMDX);
+            const result = await cellService.executeMdxRaw(complexMDX);
             
             expect(result.Cells).toBeDefined();
             expect(result.Cells.length).toBe(6);
@@ -107,7 +118,7 @@ describe('Advanced MDX and Calculation Tests', () => {
                 FROM [Sales]
             `;
 
-            mockRestService.post.mockResolvedValue(createMockResponse({
+            setMockCellset({
                 Axes: [
                     {
                         Tuples: [
@@ -131,9 +142,9 @@ describe('Advanced MDX and Calculation Tests', () => {
                     { Ordinal: 4, Value: 850000, FormattedValue: '850,000' },
                     { Ordinal: 5, Value: 0.08, FormattedValue: '8.0%' }
                 ]
-            }));
+            });
 
-            const result = await cellService.executeMdx(mdxWithCalculatedMember);
+            const result = await cellService.executeMdxRaw(mdxWithCalculatedMember);
             
             expect(result.Cells).toBeDefined();
             expect(result.Cells.length).toBe(6);
@@ -141,7 +152,7 @@ describe('Advanced MDX and Calculation Tests', () => {
             // Validate calculated member results
             const growthRateCell = result.Cells.find((cell: any) => cell.FormattedValue.includes('%'));
             expect(growthRateCell).toBeDefined();
-            expect(growthRateCell.FormattedValue).toMatch(/\d+\.\d+%/);
+            expect(growthRateCell!.FormattedValue).toMatch(/\d+\.\d+%/);
             
             console.log('✅ MDX with calculated members processed successfully');
         });
@@ -167,15 +178,15 @@ describe('Advanced MDX and Calculation Tests', () => {
             ];
 
             for (const mdx of advancedMDXFunctions) {
-                mockRestService.post.mockResolvedValue(createMockResponse({
+                setMockCellset({
                     Axes: [{ Tuples: [{ Members: [{ Name: 'TestMember' }] }] }],
                     Cells: [{ Ordinal: 0, Value: 12345, FormattedValue: '12,345' }]
-                }));
+                });
 
-                const result = await cellService.executeMdx(mdx);
+                const result = await cellService.executeMdxRaw(mdx);
                 expect(result.Cells).toBeDefined();
                 expect(result.Axes).toBeDefined();
-                
+
                 console.log(`✅ Advanced MDX function processed: ${mdx.substring(7, 25)}...`);
             }
         });
@@ -348,18 +359,18 @@ describe('Advanced MDX and Calculation Tests', () => {
                 FormattedValue: (Math.random() * 1000000).toFixed(2)
             }));
 
-            mockRestService.post.mockResolvedValue(createMockResponse({
+            setMockCellset({
                 Axes: [
                     { Tuples: Array(100).fill(null).map((_, i) => ({ Members: [{ Name: `Row${i}` }] })) },
                     { Tuples: Array(100).fill(null).map((_, i) => ({ Members: [{ Name: `Col${i}` }] })) }
                 ],
                 Cells: largeCellSet
-            }));
+            });
 
             const startTime = Date.now();
             const startMemory = process.memoryUsage().heapUsed;
             
-            const result = await cellService.executeMdx('SELECT [Large].Members ON COLUMNS FROM [BigCube]');
+            const result = await cellService.executeMdxRaw('SELECT [Large].Members ON COLUMNS FROM [BigCube]');
             
             const endTime = Date.now();
             const endMemory = process.memoryUsage().heapUsed;
@@ -395,26 +406,26 @@ describe('Advanced MDX and Calculation Tests', () => {
     describe('Error Recovery and Resilience', () => {
         test('should handle partial MDX execution failures', async () => {
             const cellService = new CellService(mockRestService);
-            
-            // Mock partial failure scenario
+
+            setMockCellset({
+                Axes: [{ Tuples: [{ Members: [{ Name: 'Element1' }] }] }],
+                Cells: [{ Ordinal: 0, Value: 100, FormattedValue: '100' }],
+                Messages: [{ Type: 'Warning', Text: 'Some data unavailable' }]
+            });
+
+            // Partial failure scenario — createCellset is globally stubbed in beforeEach,
+            // so override it here to fail on first attempt and succeed on second.
             let attemptCount = 0;
-            mockRestService.post.mockImplementation(() => {
+            (cellService.createCellset as jest.Mock).mockImplementation(() => {
                 attemptCount++;
                 if (attemptCount === 1) {
-                    // First attempt fails
                     return Promise.reject({ response: { status: 500, data: { error: 'Temporary failure' } } });
-                } else {
-                    // Second attempt succeeds with partial results
-                    return Promise.resolve(createMockResponse({
-                        Axes: [{ Tuples: [{ Members: [{ Name: 'Element1' }] }] }],
-                        Cells: [{ Ordinal: 0, Value: 100, FormattedValue: '100' }],
-                        Messages: [{ Type: 'Warning', Text: 'Some data unavailable' }]
-                    }));
                 }
+                return Promise.resolve('cs1');
             });
 
             try {
-                const result = await cellService.executeMdx('SELECT [Test].Members FROM [Cube]');
+                const result = await cellService.executeMdxRaw('SELECT [Test].Members FROM [Cube]');
                 expect(result.Cells.length).toBe(1);
                 expect(attemptCount).toBe(2); // Should have retried
                 console.log('✅ Partial failure handled with retry');

--- a/src/tests/simpleCoverage.test.ts
+++ b/src/tests/simpleCoverage.test.ts
@@ -77,8 +77,8 @@ describe('Simple Coverage Tests', () => {
 
             const cellService = new CellService(mockRest);
             jest.spyOn(cellService, 'createCellset').mockResolvedValue('CSID-1');
-            jest.spyOn(cellService as any, '_extractCellsetForTupleDict').mockResolvedValue({ Axes: [], Cells: [] });
-            jest.spyOn(cellService, 'deleteCellset').mockResolvedValue(undefined);
+            jest.spyOn(cellService, 'extractCellset').mockResolvedValue(new (require('../utils/Utils').CaseAndSpaceInsensitiveTuplesDict)());
+            jest.spyOn(cellService, '_safeDeleteCellset').mockResolvedValue(undefined);
 
             const result = await cellService.executeMdxAsync('SELECT * FROM [TestCube]');
             expect(result instanceof Map).toBe(true);
@@ -254,8 +254,8 @@ describe('Simple Coverage Tests', () => {
             jest.spyOn(cellService, 'createCellset')
                 .mockResolvedValueOnce('CSID-1')
                 .mockResolvedValueOnce('CSID-2');
-            jest.spyOn(cellService as any, '_extractCellsetForTupleDict').mockResolvedValue({ Axes: [], Cells: [] });
-            jest.spyOn(cellService, 'deleteCellset').mockResolvedValue(undefined);
+            jest.spyOn(cellService, 'extractCellset').mockResolvedValue(new (require('../utils/Utils').CaseAndSpaceInsensitiveTuplesDict)());
+            jest.spyOn(cellService, '_safeDeleteCellset').mockResolvedValue(undefined);
 
             const result1 = await cellService.executeMdxAsync('SELECT * FROM [Cube1]');
             const result2 = await cellService.executeMdxAsync('SELECT * FROM [Cube2]');


### PR DESCRIPTION
## Summary

Refactors six `CellService` execute methods (`executeMdx`, `executeMdxRaw`, `executeView`, `executeViewRaw`, `executeMdxCsv`, `executeViewCsv`) to match tm1py's signatures one-to-one and route through the existing `createCellset` + `extractCellset*` helpers with the full tm1py parameter surface.

Closes #65.

## tm1py parity surface

- Six new typed option interfaces (`ExecuteMdxOptions`, `ExecuteMdxRawOptions`, `ExecuteViewOptions`, `ExecuteViewRawOptions`, `ExecuteMdxCsvOptions`, `ExecuteViewCsvOptions`) modeled directly on tm1py's `CellService.py` signatures, including subtle asymmetries (`Omit<…, 'skipSandboxDimension'>` on `ExecuteViewOptions`, `Omit<…, 'includeHierarchies'>` on `ExecuteViewRawOptions`).
- `executeMdx` / `executeView` return `CaseAndSpaceInsensitiveTuplesDict` per tm1py (was raw cellset). `executeMdxRaw` / `executeViewRaw` return the raw cellset for callers that need `.Axes` / `.Cells`.
- CSV default `skipZeros = true` matches tm1py (different from the non-CSV `skipZeros = false`).
- `executeMdxAsync` / `execute_view_async` widened to accept the full option surface; `executeMdx` / `executeView` with `maxWorkers > 1` now forward every option to the async path. `execute_view`'s async branch deliberately drops `cell_properties` and `use_compact_json` to replicate the tm1py quirk at `CellService.py:2241-2257`.
- `createCellsetFromView` URL fixed to match tm1py exactly: `/Cubes('c')/{Views|PrivateViews}('v')/tm1.Execute?!sandbox=...` (was a fabricated `tm1.CreateCellset?$private=...&$sandbox=...`).
- `createCellset` / `deleteCellset` switched from `?$sandbox=` to `?!sandbox=` with quote-doubling escape, matching tm1py's `add_url_parameters` convention.

## Breaking changes

See [CHANGELOG.md v2.3.0](./CHANGELOG.md) for the full migration matrix. Highlights:

- `executeMdx(mdx)` → `executeMdx(mdx, options?)` — return type changes from raw cellset to `CaseAndSpaceInsensitiveTuplesDict`. Use `executeMdxRaw` for raw shape.
- `executeView(cubeName, viewName, options)` — same return-type change.
- All six methods: option keys move from snake_case (legacy `MDXViewOptions`) to camelCase.
- `executeMdxCsv` / `executeViewCsv`: default `skipZeros` flips from `undefined` to `true`.

## Deferred (tracked as follow-ups, user-approved scope)

- `useBlob` CSV path: tm1py's `_execute_mdx_csv_use_blob` / `_execute_view_csv_use_blob` (TI/blob extract for >1M cell datasets) is not yet ported. The option is intentionally NOT exposed on the public surface to avoid advertising unimplemented behavior.
- `arrangedAxes` on `executeViewCsv`: only meaningful on tm1py's blob branch; travels with the `useBlob` port.
- Parallel-chunked retrieval in async helpers: tm1py uses `extract_cellset_async` for parallel chunked fetching; tm1npm currently uses the serial `extractCellset` path with full option-forwarding parity.

## Tests

- New `src/tests/CellService.execute.parity.test.ts` — 18 behavioral parity tests covering signatures, defaults (`skipZeros` true on CSV vs false on non-CSV), async dispatch (with the `execute_view` quirk parity), `useIterativeJson` routing.
- Updated `mdx.advanced.test.ts`, `cellService.test.ts`, `elementService.issue37.test.ts`, `integrationTests.test.ts`, `bulkService.test.ts`, `enhancedCellService.test.ts`, `simpleCoverage.test.ts` for the new cellset-routed flow.
- BulkService fix: explicit `includeHierarchies: true` (CSV needs Axes/Hierarchies) and `cellProperties=['Value', 'Ordinal', 'Consolidated', 'RuleDerived', 'Updateable']` for `format: 'full'` (was silently dropping fields in production since `executeMdxRaw` defaults `cellProperties` to `['Value']`).

`tsc --noEmit`: clean. Jest: **1635 / 1642** pass (7 pre-existing failures verified on `main`: 6 credential/env-dependent suites + 1 unrelated `security.advanced` test).

## Test plan

- [ ] CI green
- [ ] Verify breaking-change migration examples in CHANGELOG.md compile against the new TypeScript surface
- [ ] Smoke test against a real TM1 server: `executeMdx`, `executeView`, `executeMdxCsv` with `top`/`skip`/`skipZeros` to confirm the new option-forwarding hits the wire as expected