### PR TITLE
fix(#87): align ViewService getAll/getAllNames with tm1py — include private views

### DIFF
--- a/src/services/ViewService.ts
+++ b/src/services/ViewService.ts
@@ -142,6 +142,8 @@ export class ViewService extends ObjectService {
          * :param include_elements: false to return view details without elements, faster
          * :return: 2 Lists of View instances: private views, public views
          */
+        // Inline elementFilter into the template literally so formatUrl's encodeURIComponent
+        // does not percent-encode ";$top=0" into "%3B%24top%3D0" — tm1py's format_url keeps it literal.
         const elementFilter = includeElements ? "" : ";$top=0";
         const privateViews: View[] = [];
         const publicViews: View[] = [];
@@ -150,16 +152,16 @@ export class ViewService extends ObjectService {
             const url = formatUrl(
                 "/Cubes('{}')/{}?$expand=" +
                 "tm1.NativeView/Rows/Subset($expand=Hierarchy($select=Name;" +
-                "$expand=Dimension($select=Name)),Elements($select=Name{});" +
+                "$expand=Dimension($select=Name)),Elements($select=Name" + elementFilter + ");" +
                 "$select=Expression,UniqueName,Name, Alias),  " +
                 "tm1.NativeView/Columns/Subset($expand=Hierarchy($select=Name;" +
-                "$expand=Dimension($select=Name)),Elements($select=Name{});" +
+                "$expand=Dimension($select=Name)),Elements($select=Name" + elementFilter + ");" +
                 "$select=Expression,UniqueName,Name,Alias), " +
                 "tm1.NativeView/Titles/Subset($expand=Hierarchy($select=Name;" +
-                "$expand=Dimension($select=Name)),Elements($select=Name{});" +
+                "$expand=Dimension($select=Name)),Elements($select=Name" + elementFilter + ");" +
                 "$select=Expression,UniqueName,Name,Alias), " +
                 "tm1.NativeView/Titles/Selected($select=Name)",
-                cubeName, viewType, elementFilter, elementFilter, elementFilter);
+                cubeName, viewType);
             const response = await this.rest.get(url);
             for (const viewAsDict of response.data.value) {
                 const view: View =

--- a/src/services/ViewService.ts
+++ b/src/services/ViewService.ts
@@ -164,6 +164,11 @@ export class ViewService extends ObjectService {
                 cubeName, viewType);
             const response = await this.rest.get(url);
             for (const viewAsDict of response.data.value) {
+                // tm1py does view_as_dict["@odata.type"] — Python raises KeyError on missing key.
+                // Mirror that loud failure instead of silently treating undefined as NativeView.
+                if (!('@odata.type' in viewAsDict)) {
+                    throw new Error("'@odata.type'");
+                }
                 const view: View =
                     viewAsDict['@odata.type'] === '#ibm.tm1.api.v1.MDXView'
                         ? MDXView.fromDict(viewAsDict, cubeName)

--- a/src/services/ViewService.ts
+++ b/src/services/ViewService.ts
@@ -132,63 +132,71 @@ export class ViewService extends ObjectService {
         return await this.rest.delete(url);
     }
 
-    public async getAll(cubeName: string): Promise<[NativeView[], MDXView[]]> {
-        /** Get all views from a cube
+    public async getAll(
+        cubeName: string,
+        includeElements: boolean = true
+    ): Promise<[View[], View[]]> {
+        /** Get all public and private views from cube.
          *
-         * :param cube_name: String, name of the cube
-         * :return: Tuple of List of instances of .NativeView and .MDXView
+         * :param cube_name: String, name of the cube.
+         * :param include_elements: false to return view details without elements, faster
+         * :return: 2 Lists of View instances: private views, public views
          */
-        const url = formatUrl("/Cubes('{}')/Views?$expand=*", cubeName);
-        const response = await this.rest.get(url);
-        
-        const nativeViews: NativeView[] = [];
-        const mdxViews: MDXView[] = [];
-        
-        for (const viewDict of response.data.value) {
-            if ("MDX" in viewDict) {
-                mdxViews.push(MDXView.fromDict(viewDict, cubeName));
-            } else {
-                const nativeView = await this.getNativeView(cubeName, viewDict.Name, false);
-                nativeViews.push(nativeView);
+        const elementFilter = includeElements ? "" : ";$top=0";
+        const privateViews: View[] = [];
+        const publicViews: View[] = [];
+
+        for (const viewType of ['PrivateViews', 'Views'] as const) {
+            const url = formatUrl(
+                "/Cubes('{}')/{}?$expand=" +
+                "tm1.NativeView/Rows/Subset($expand=Hierarchy($select=Name;" +
+                "$expand=Dimension($select=Name)),Elements($select=Name{});" +
+                "$select=Expression,UniqueName,Name, Alias),  " +
+                "tm1.NativeView/Columns/Subset($expand=Hierarchy($select=Name;" +
+                "$expand=Dimension($select=Name)),Elements($select=Name{});" +
+                "$select=Expression,UniqueName,Name,Alias), " +
+                "tm1.NativeView/Titles/Subset($expand=Hierarchy($select=Name;" +
+                "$expand=Dimension($select=Name)),Elements($select=Name{});" +
+                "$select=Expression,UniqueName,Name,Alias), " +
+                "tm1.NativeView/Titles/Selected($select=Name)",
+                cubeName, viewType, elementFilter, elementFilter, elementFilter);
+            const response = await this.rest.get(url);
+            for (const viewAsDict of response.data.value) {
+                const view: View =
+                    viewAsDict['@odata.type'] === '#ibm.tm1.api.v1.MDXView'
+                        ? MDXView.fromDict(viewAsDict, cubeName)
+                        : NativeView.fromDict(viewAsDict, cubeName);
+                if (viewType === 'PrivateViews') {
+                    privateViews.push(view);
+                } else {
+                    publicViews.push(view);
+                }
             }
         }
-        
-        return [nativeViews, mdxViews];
+        return [privateViews, publicViews];
     }
 
-    public async getAllNames(cubeName: string, isPrivate?: boolean): Promise<string[]> {
-        /** Get all view names from a cube
+    public async getAllNames(cubeName: string): Promise<[string[], string[]]> {
+        /** Get all view names from a cube.
          *
-         * :param cube_name: String, name of the cube  
-         * :param private: Boolean, private views only
-         * :return: List of view names
+         * :param cube_name: String, name of the cube
+         * :return: 2 Lists of view names: private views, public views
          */
-        let viewType = "Views";
-        if (isPrivate === true) {
-            viewType = "PrivateViews";
-        } else if (isPrivate === false) {
-            viewType = "Views";
+        const privateNames: string[] = [];
+        const publicNames: string[] = [];
+
+        for (const viewType of ['PrivateViews', 'Views'] as const) {
+            const url = formatUrl("/Cubes('{}')/{}?$select=Name", cubeName, viewType);
+            const response = await this.rest.get(url);
+            for (const view of response.data.value) {
+                if (viewType === 'PrivateViews') {
+                    privateNames.push(view.Name);
+                } else {
+                    publicNames.push(view.Name);
+                }
+            }
         }
-        
-        if (isPrivate === undefined) {
-            // Get both private and public view names
-            const privateUrl = formatUrl("/Cubes('{}')/PrivateViews?$select=Name", cubeName);
-            const publicUrl = formatUrl("/Cubes('{}')/Views?$select=Name", cubeName);
-            
-            const [privateResponse, publicResponse] = await Promise.all([
-                this.rest.get(privateUrl),
-                this.rest.get(publicUrl)
-            ]);
-            
-            const privateNames = privateResponse.data.value.map((v: any) => v.Name);
-            const publicNames = publicResponse.data.value.map((v: any) => v.Name);
-            
-            return [...privateNames, ...publicNames];
-        }
-        
-        const url = formatUrl("/Cubes('{}')/{}?$select=Name", cubeName, viewType);
-        const response = await this.rest.get(url);
-        return response.data.value.map((view: any) => view.Name);
+        return [privateNames, publicNames];
     }
 
     public async getMdxView(

--- a/src/tests/comprehensive.service.test.ts
+++ b/src/tests/comprehensive.service.test.ts
@@ -190,7 +190,7 @@ describe('Comprehensive Service Tests with Mocking', () => {
         });
 
         test('should handle all view operations successfully', async () => {
-            // Test getAllNames - ViewService makes two calls for private and public views
+            // getAllNames returns [private, public] tuple — two GETs.
             mockRestService.get
                 .mockResolvedValueOnce(createMockResponse({
                     value: [{ Name: 'PrivateView1' }]
@@ -198,35 +198,39 @@ describe('Comprehensive Service Tests with Mocking', () => {
                 .mockResolvedValueOnce(createMockResponse({
                     value: [{ Name: 'PublicView1' }, { Name: 'PublicView2' }]
                 }));
-            
+
             const viewNames = await viewService.getAllNames('TestCube');
-            expect(viewNames).toEqual(['PrivateView1', 'PublicView1', 'PublicView2']);
-            
-            // Test getAll - simplified to avoid complex nested calls
-            mockRestService.get.mockResolvedValueOnce(createMockResponse({
-                value: [
-                    { Name: 'MDXView1', MDX: 'SELECT FROM [TestCube]' }, // Has MDX property
-                    { Name: 'NativeView1' } // Doesn't have MDX property
-                ]
-            }));
-            
-            // Mock the getNativeView call that will be made for the native view
-            mockRestService.get.mockResolvedValueOnce(createMockResponse({
-                Name: 'NativeView1',
-                Columns: [],
-                Rows: [],
-                Titles: []
-            }));
-            
-            const views = await viewService.getAll('TestCube');
-            expect(Array.isArray(views)).toBe(true);
-            expect(views.length).toBe(2); // Array of [nativeViews, mdxViews]
-            
+            expect(viewNames).toEqual([['PrivateView1'], ['PublicView1', 'PublicView2']]);
+
+            // getAll returns [private, public]; private empty, public has mixed MDX/Native.
+            mockRestService.get
+                .mockResolvedValueOnce(createMockResponse({ value: [] }))
+                .mockResolvedValueOnce(createMockResponse({
+                    value: [
+                        {
+                            '@odata.type': '#ibm.tm1.api.v1.MDXView',
+                            Name: 'MDXView1',
+                            MDX: 'SELECT FROM [TestCube]'
+                        },
+                        {
+                            '@odata.type': '#ibm.tm1.api.v1.NativeView',
+                            Name: 'NativeView1',
+                            Columns: [],
+                            Rows: [],
+                            Titles: []
+                        }
+                    ]
+                }));
+
+            const [privateViews, publicViews] = await viewService.getAll('TestCube');
+            expect(privateViews).toEqual([]);
+            expect(publicViews).toHaveLength(2);
+
             // Test exists
             mockRestService.get.mockResolvedValueOnce(createMockResponse({ Name: 'View1' }));
             const exists = await viewService.exists('TestCube', 'View1', false);
             expect(exists).toBe(true);
-            
+
             console.log('✅ All ViewService operations working');
         });
     });
@@ -391,12 +395,13 @@ describe('Comprehensive Service Tests with Mocking', () => {
             
             const dimensions = await dimensionService.getAllNames();
             const cubes = await cubeService.getAll();
-            const views = await viewService.getAllNames('SalesCube');
-            
+            const [privateViewNames, publicViewNames] = await viewService.getAllNames('SalesCube');
+
             expect(dimensions.length).toBe(2);
             expect(cubes.length).toBe(1);
-            expect(views.length).toBe(3); // PrivateView + DefaultView + BudgetView
-            
+            expect(privateViewNames).toEqual(['PrivateView']);
+            expect(publicViewNames).toEqual(['DefaultView', 'BudgetView']);
+
             console.log('✅ Cross-service integration working');
         });
 

--- a/src/tests/integrationTests.test.ts
+++ b/src/tests/integrationTests.test.ts
@@ -168,11 +168,11 @@ describe('TM1Service Integration Tests', () => {
                 ) || cubeNames[0];
 
                 if (testCube) {
-                    const [privateViews, publicViews] = await tm1.cubes.views.getAllNames(testCube);
-                    const allViews = [...privateViews, ...publicViews];
+                    const [privateViewNames, publicViewNames] = await tm1.cubes.views.getAllNames(testCube);
+                    const allViewNames = [...privateViewNames, ...publicViewNames];
 
-                    if (allViews.length > 0) {
-                        const testView = allViews[0];
+                    if (allViewNames.length > 0) {
+                        const testView = allViewNames[0];
                         const viewResult = await tm1.cells.executeView(testCube, testView);
 
                         expect(viewResult).toBeDefined();

--- a/src/tests/integrationTests.test.ts
+++ b/src/tests/integrationTests.test.ts
@@ -97,11 +97,10 @@ describe('TM1Service Integration Tests', () => {
             }
 
             try {
-                const viewNames = await tm1.cubes.views.getAllNames('General Ledger');
-                expect(viewNames).toBeDefined();
-                expect(Array.isArray(viewNames)).toBe(true);
-                expect(viewNames.length).toBeGreaterThan(0);
-                expect(viewNames).toContain('Default');
+                const [privateViewNames, publicViewNames] = await tm1.cubes.views.getAllNames('General Ledger');
+                const allViewNames = [...privateViewNames, ...publicViewNames];
+                expect(allViewNames.length).toBeGreaterThan(0);
+                expect(allViewNames).toContain('Default');
             } catch (error) {
                 // If General Ledger doesn't exist, test should still pass
                 console.log('General Ledger cube may not exist in this TM1 instance');
@@ -125,8 +124,9 @@ describe('TM1Service Integration Tests', () => {
                     return;
                 }
 
-                const viewNames = await tm1.cubes.views.getAllNames('General Ledger');
-                if (!viewNames.includes('Default')) {
+                const [privateViewNames, publicViewNames] = await tm1.cubes.views.getAllNames('General Ledger');
+                const allViewNames = [...privateViewNames, ...publicViewNames];
+                if (!allViewNames.includes('Default')) {
                     console.log('Default view not available, skipping view execution test');
                     return;
                 }
@@ -168,14 +168,13 @@ describe('TM1Service Integration Tests', () => {
                 ) || cubeNames[0];
 
                 if (testCube) {
-                    const views = await tm1.cubes.views.getAllNames(testCube);
-                    expect(views).toBeDefined();
-                    expect(Array.isArray(views)).toBe(true);
-                    
-                    if (views.length > 0) {
-                        const testView = views[0];
+                    const [privateViews, publicViews] = await tm1.cubes.views.getAllNames(testCube);
+                    const allViews = [...privateViews, ...publicViews];
+
+                    if (allViews.length > 0) {
+                        const testView = allViews[0];
                         const viewResult = await tm1.cells.executeView(testCube, testView);
-                        
+
                         expect(viewResult).toBeDefined();
                         expect(viewResult).toHaveProperty('ID');
                         console.log(`✅ Alternative cube test: ${testCube} -> ${testView}`);

--- a/src/tests/viewService.test.ts
+++ b/src/tests/viewService.test.ts
@@ -40,8 +40,7 @@ describe('ViewService Tests', () => {
     });
 
     describe('View Retrieval Operations', () => {
-        test('should get all view names for cube', async () => {
-            // Mock both private and public view calls
+        test('should get all view names for cube as [private, public] tuple', async () => {
             mockRestService.get
                 .mockResolvedValueOnce(createMockResponse({
                     value: [{ Name: 'PrivateView1' }]
@@ -50,40 +49,125 @@ describe('ViewService Tests', () => {
                     value: [{ Name: 'PublicView1' }, { Name: 'PublicView2' }]
                 }));
 
-            const viewNames = await viewService.getAllNames('TestCube');
-            
-            expect(Array.isArray(viewNames)).toBe(true);
-            expect(viewNames.length).toBe(3);
-            expect(viewNames).toEqual(['PrivateView1', 'PublicView1', 'PublicView2']);
-            
-            console.log('✅ View names retrieved successfully');
+            const [privateNames, publicNames] = await viewService.getAllNames('TestCube');
+
+            expect(privateNames).toEqual(['PrivateView1']);
+            expect(publicNames).toEqual(['PublicView1', 'PublicView2']);
+
+            const calls = mockRestService.get.mock.calls;
+            expect(calls).toHaveLength(2);
+            expect(calls[0][0]).toBe("/Cubes('TestCube')/PrivateViews?$select=Name");
+            expect(calls[1][0]).toBe("/Cubes('TestCube')/Views?$select=Name");
+
+            console.log('✅ View names retrieved as [private, public] tuple');
         });
 
-        test('should get all views for cube', async () => {
-            // Mock the main views call - first call for getAll
-            mockRestService.get.mockResolvedValueOnce(createMockResponse({
-                value: [
-                    { Name: 'MDXView1', MDX: 'SELECT FROM [TestCube]' }, // Has MDX property
-                    { Name: 'NativeView1' } // Doesn't have MDX property  
-                ]
-            }));
+        test('should get all views for cube as [private, public] tuple with @odata.type discriminator', async () => {
+            mockRestService.get
+                .mockResolvedValueOnce(createMockResponse({ value: [] }))
+                .mockResolvedValueOnce(createMockResponse({
+                    value: [
+                        {
+                            '@odata.type': '#ibm.tm1.api.v1.MDXView',
+                            Name: 'MDXView1',
+                            MDX: 'SELECT FROM [TestCube]'
+                        },
+                        {
+                            '@odata.type': '#ibm.tm1.api.v1.NativeView',
+                            Name: 'NativeView1',
+                            Columns: [],
+                            Rows: [],
+                            Titles: []
+                        }
+                    ]
+                }));
 
-            // Mock the getNativeView call that will be made for the native view
-            mockRestService.get.mockResolvedValueOnce(createMockResponse({
-                Name: 'NativeView1',
-                Columns: [],
-                Rows: [],
-                Titles: []
-            }));
+            const [privateViews, publicViews] = await viewService.getAll('TestCube');
 
-            const views = await viewService.getAll('TestCube');
-            
-            expect(Array.isArray(views)).toBe(true);
-            expect(views.length).toBe(2); // Returns [nativeViews, mdxViews]
-            expect(views[0]).toEqual(expect.any(Array)); // nativeViews array
-            expect(views[1]).toEqual(expect.any(Array)); // mdxViews array
-            
-            console.log('✅ All views retrieved successfully');
+            expect(privateViews).toEqual([]);
+            expect(publicViews).toHaveLength(2);
+            expect(publicViews[0]).toBeInstanceOf(MDXView);
+            expect(publicViews[1]).toBeInstanceOf(NativeView);
+
+            const calls = mockRestService.get.mock.calls;
+            expect(calls).toHaveLength(2);
+            expect(calls[0][0]).toContain("/Cubes('TestCube')/PrivateViews?$expand=");
+            expect(calls[0][0]).toContain('tm1.NativeView/Rows/Subset($expand=');
+            expect(calls[0][0]).not.toContain('?$expand=*');
+            expect(calls[1][0]).toContain("/Cubes('TestCube')/Views?$expand=");
+
+            console.log('✅ All views retrieved as [private, public] tuple');
+        });
+
+        test('getAll honors includeElements=false by injecting $top=0', async () => {
+            mockRestService.get
+                .mockResolvedValueOnce(createMockResponse({ value: [] }))
+                .mockResolvedValueOnce(createMockResponse({ value: [] }));
+
+            await viewService.getAll('TestCube', false);
+
+            // formatUrl percent-encodes substituted values, so ";$top=0" becomes "%3B%24top%3D0".
+            const calls = mockRestService.get.mock.calls;
+            expect(calls[0][0]).toContain('Elements($select=Name%3B%24top%3D0)');
+            expect(calls[1][0]).toContain('Elements($select=Name%3B%24top%3D0)');
+        });
+
+        test('getAll with includeElements=true does NOT inject $top=0', async () => {
+            mockRestService.get
+                .mockResolvedValueOnce(createMockResponse({ value: [] }))
+                .mockResolvedValueOnce(createMockResponse({ value: [] }));
+
+            await viewService.getAll('TestCube');
+
+            const calls = mockRestService.get.mock.calls;
+            expect(calls[0][0]).not.toContain('top%3D0');
+            expect(calls[0][0]).toContain('Elements($select=Name)');
+        });
+
+        test('getAll handles mixed MDX/Native in both buckets and preserves order', async () => {
+            mockRestService.get
+                .mockResolvedValueOnce(createMockResponse({
+                    value: [
+                        {
+                            '@odata.type': '#ibm.tm1.api.v1.MDXView',
+                            Name: 'PrivMDX',
+                            MDX: 'SELECT FROM [TestCube]'
+                        },
+                        {
+                            '@odata.type': '#ibm.tm1.api.v1.NativeView',
+                            Name: 'PrivNative',
+                            Columns: [], Rows: [], Titles: []
+                        }
+                    ]
+                }))
+                .mockResolvedValueOnce(createMockResponse({
+                    value: [
+                        {
+                            '@odata.type': '#ibm.tm1.api.v1.NativeView',
+                            Name: 'PubNative',
+                            Columns: [], Rows: [], Titles: []
+                        },
+                        {
+                            '@odata.type': '#ibm.tm1.api.v1.MDXView',
+                            Name: 'PubMDX',
+                            MDX: 'SELECT FROM [TestCube]'
+                        }
+                    ]
+                }));
+
+            const [privateViews, publicViews] = await viewService.getAll('TestCube');
+
+            expect(privateViews).toHaveLength(2);
+            expect(privateViews[0]).toBeInstanceOf(MDXView);
+            expect(privateViews[0].name).toBe('PrivMDX');
+            expect(privateViews[1]).toBeInstanceOf(NativeView);
+            expect(privateViews[1].name).toBe('PrivNative');
+
+            expect(publicViews).toHaveLength(2);
+            expect(publicViews[0]).toBeInstanceOf(NativeView);
+            expect(publicViews[0].name).toBe('PubNative');
+            expect(publicViews[1]).toBeInstanceOf(MDXView);
+            expect(publicViews[1].name).toBe('PubMDX');
         });
 
         test('should check if view exists', async () => {
@@ -214,11 +298,34 @@ describe('ViewService Tests', () => {
                 .mockResolvedValueOnce(createMockResponse({ value: [] }));
 
             const views = await viewService.getAllNames('EmptyCube');
-            
-            expect(Array.isArray(views)).toBe(true);
-            expect(views.length).toBe(0);
-            
+
+            expect(views).toEqual([[], []]);
+
             console.log('✅ Empty view list handling working');
+        });
+
+        test('should handle asymmetric empty (only public has views)', async () => {
+            mockRestService.get
+                .mockResolvedValueOnce(createMockResponse({ value: [] }))
+                .mockResolvedValueOnce(createMockResponse({
+                    value: [{ Name: 'V1' }, { Name: 'V2' }]
+                }));
+
+            const [privateNames, publicNames] = await viewService.getAllNames('Cube');
+            expect(privateNames).toEqual([]);
+            expect(publicNames).toEqual(['V1', 'V2']);
+        });
+
+        test('should handle asymmetric empty (only private has views)', async () => {
+            mockRestService.get
+                .mockResolvedValueOnce(createMockResponse({
+                    value: [{ Name: 'V1' }]
+                }))
+                .mockResolvedValueOnce(createMockResponse({ value: [] }));
+
+            const [privateNames, publicNames] = await viewService.getAllNames('Cube');
+            expect(privateNames).toEqual(['V1']);
+            expect(publicNames).toEqual([]);
         });
 
         test('should handle concurrent operations', async () => {
@@ -254,12 +361,12 @@ describe('ViewService Tests', () => {
                 .mockResolvedValueOnce(createMockResponse({ value: largeViewList.slice(500) }));
 
             const startTime = Date.now();
-            const result = await viewService.getAllNames('LargeCube');
+            const [privateNames, publicNames] = await viewService.getAllNames('LargeCube');
             const endTime = Date.now();
 
-            expect(result.length).toBe(1000);
+            expect(privateNames.length + publicNames.length).toBe(1000);
             expect(endTime - startTime).toBeLessThan(1000); // Should be fast with mocking
-            
+
             console.log('✅ Large dataset handling efficient');
         });
     });
@@ -281,10 +388,11 @@ describe('ViewService Tests', () => {
             const names1 = await viewService.getAllNames('TestCube');
             const names2 = await viewService.getAllNames('TestCube');
 
-            // Note: getAllNames returns combined private+public, so results will be ['View1', 'View2', 'View1', 'View2']
-            expect(names1.length).toBeGreaterThan(0);
-            expect(names2.length).toBeGreaterThan(0);
-            
+            // getAllNames returns [private, public]; same mock for both calls,
+            // so each bucket should contain ['View1','View2'] for both invocations.
+            expect(names1).toEqual([['View1', 'View2'], ['View1', 'View2']]);
+            expect(names2).toEqual([['View1', 'View2'], ['View1', 'View2']]);
+
             console.log('✅ Data consistency maintained');
         });
 

--- a/src/tests/viewService.test.ts
+++ b/src/tests/viewService.test.ts
@@ -124,6 +124,18 @@ describe('ViewService Tests', () => {
             expect(calls[0][0]).toContain('Elements($select=Name)');
         });
 
+        test('getAll throws when @odata.type discriminator is missing (tm1py parity)', async () => {
+            // tm1py does view_as_dict["@odata.type"] which raises KeyError if absent.
+            // tm1npm must throw too rather than silently falling back to NativeView.
+            mockRestService.get
+                .mockResolvedValueOnce(createMockResponse({ value: [] }))
+                .mockResolvedValueOnce(createMockResponse({
+                    value: [{ Name: 'NoDiscriminator', MDX: 'SELECT FROM [TestCube]' }]
+                }));
+
+            await expect(viewService.getAll('TestCube')).rejects.toThrow("'@odata.type'");
+        });
+
         test('getAll handles mixed MDX/Native in both buckets and preserves order', async () => {
             mockRestService.get
                 .mockResolvedValueOnce(createMockResponse({

--- a/src/tests/viewService.test.ts
+++ b/src/tests/viewService.test.ts
@@ -106,10 +106,10 @@ describe('ViewService Tests', () => {
 
             await viewService.getAll('TestCube', false);
 
-            // formatUrl percent-encodes substituted values, so ";$top=0" becomes "%3B%24top%3D0".
+            // formatUrl preserves ";$top=0" literally (matching tm1py's format_url escape set).
             const calls = mockRestService.get.mock.calls;
-            expect(calls[0][0]).toContain('Elements($select=Name%3B%24top%3D0)');
-            expect(calls[1][0]).toContain('Elements($select=Name%3B%24top%3D0)');
+            expect(calls[0][0]).toContain('Elements($select=Name;$top=0)');
+            expect(calls[1][0]).toContain('Elements($select=Name;$top=0)');
         });
 
         test('getAll with includeElements=true does NOT inject $top=0', async () => {


### PR DESCRIPTION
## Summary

Closes #87.

Aligns `ViewService.getAll` and `ViewService.getAllNames` with tm1py for byte-for-byte parity:

- **`getAll(cubeName, includeElements = true)`** — iterates `PrivateViews` then `Views`, returns `[View[], View[]] = [private, public]`. Uses tm1py's single rich `$expand` URL and the `@odata.type === '#ibm.tm1.api.v1.MDXView'` discriminator. Drops the per-Native extra `getNativeView` round-trip (tm1py builds straight from the expanded dict). Adds `includeElements` parameter matching tm1py's `include_elements`.
- **`getAllNames(cubeName)`** — iterates `PrivateViews` then `Views`, returns `[string[], string[]] = [private, public]`. Drops the non-tm1py `isPrivate?` overload.

## Breaking changes

This is an intentional breaking-signature change, authorized by `CLAUDE.md`'s strict tm1py parity rule (parity overrides backwards compatibility):

- `getAll(cubeName)` return: `[NativeView[], MDXView[]]` → `[View[], View[]]` (split is now private/public, not type).
- `getAll` adds `includeElements?: boolean = true`.
- `getAllNames(cubeName, isPrivate?)` → `getAllNames(cubeName)` (parameter dropped). Return: `string[]` → `[string[], string[]]`.

All in-repo callers (4 test files) are updated.

## tm1py parity notes

Verified against `https://github.com/cubewise-code/tm1py/blob/master/TM1py/Services/ViewService.py`:

- Iteration order `("PrivateViews", "Views")` matches `get_all` and `get_all_names`.
- Rich `$expand` URL matches `get_all` line-for-line (including the double-space inside `"Alias),  "` and the `Elements($select=Name{filter})` placeholder).
- `@odata.type` discriminator string matches.
- Tuple return order `(private, public)` matches.

One subtle wire-format issue surfaced and was fixed in this PR: tm1npm's `formatUrl` uses `encodeURIComponent` (which encodes `;` and `$`), while tm1py's `format_url` only escapes `'%#?&`. Passing `";$top=0"` through `formatUrl` would yield `%3B%24top%3D0` — wrong on the wire. Fix: `elementFilter` is inlined into the URL template literally rather than passed as a `{}` substitution. The broader `formatUrl` parity gap exists project-wide and is left for a separate scoped PR (touching it here would unmask a 15+ call-site `escapeODataValue` pre-escape pattern in `CellService`/`ElementService`).

## Test plan

- [x] `tsc --noEmit` clean.
- [x] Focused jest: `viewService.test.ts` (21/21), `comprehensive.service.test.ts` (24/24), `enhancedViewService.test.ts` (all pass).
- [x] Full jest: 1670 passed / 7 failed, all 7 in pre-existing credential-dependent suites (`cellServiceExtract`, `security.advanced`) unrelated to ViewService — same failure set as `origin/main`.
- [x] New unit tests cover: tuple shape, `@odata.type` discriminator routing (mixed MDX+Native), call-order assertion, rich-`$expand` URL assertion, `includeElements=false` literal `;$top=0` injection, asymmetric empty buckets, concurrent operations, large datasets.
- [x] Internal reviewer agent (manual + multi-perspective): APPROVED. 0 P0 / 0 P1.
- [x] External cold review: APPROVED on round 2 after applying the wire-format fix. Security 10/10, Performance 9/10, Code Quality 9/10, Test Coverage 9/10.

## Performance note

The new `getAll` makes **2 GETs** total (one per `viewType`). The previous implementation made `1 + N` GETs (1 list call + N per-native-view round-trips via `getNativeView`). Net improvement for cubes with many native views.